### PR TITLE
Migrate tests from JUnit 5 to Kotest FunSpec

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -51,15 +51,24 @@ dependencies {
     // Wirespec runtime
     implementation("community.flock.wirespec.integration:spring-jvm:$wirespecVersion")
 
-    // Testing
+    // Testing — Kotest
+    val kotestVersion: String by project
+    val kotestSpringExtensionVersion: String by project
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:$kotestSpringExtensionVersion")
+
+    // Testing — Spring + Testcontainers
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation(platform("org.testcontainers:testcontainers-bom:$testcontainersVersion"))
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+
+    // Testing — ArchUnit
     testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
-    testImplementation(kotlin("test"))
 
 }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/ArchitectureTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/ArchitectureTest.kt
@@ -3,9 +3,9 @@ package com.github.zzave.teambalance.api
 import com.tngtech.archunit.core.importer.ClassFileImporter
 import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.FunSpec
 
-class ArchitectureTest {
+class ArchitectureTest : FunSpec() {
 
     companion object {
         private val classes by lazy {
@@ -15,57 +15,53 @@ class ArchitectureTest {
         }
     }
 
-    @Test
-    fun `domain must not depend on infrastructure`() {
-        noClasses()
-            .that().resideInAPackage("..domain..")
-            .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
-            .allowEmptyShould(true)
-            .check(classes)
-    }
+    init {
+        test("domain must not depend on infrastructure") {
+            noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
 
-    @Test
-    fun `domain must not depend on interfaces`() {
-        noClasses()
-            .that().resideInAPackage("..domain..")
-            .should().dependOnClassesThat().resideInAPackage("..interfaces..")
-            .allowEmptyShould(true)
-            .check(classes)
-    }
+        test("domain must not depend on interfaces") {
+            noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..interfaces..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
 
-    @Test
-    fun `domain must not depend on Spring`() {
-        noClasses()
-            .that().resideInAPackage("..domain..")
-            .should().dependOnClassesThat().resideInAPackage("org.springframework..")
-            .allowEmptyShould(true)
-            .check(classes)
-    }
+        test("domain must not depend on Spring") {
+            noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("org.springframework..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
 
-    @Test
-    fun `application must not depend on infrastructure`() {
-        noClasses()
-            .that().resideInAPackage("..application..")
-            .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
-            .allowEmptyShould(true)
-            .check(classes)
-    }
+        test("application must not depend on infrastructure") {
+            noClasses()
+                .that().resideInAPackage("..application..")
+                .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
 
-    @Test
-    fun `application must not depend on interfaces`() {
-        noClasses()
-            .that().resideInAPackage("..application..")
-            .should().dependOnClassesThat().resideInAPackage("..interfaces..")
-            .allowEmptyShould(true)
-            .check(classes)
-    }
+        test("application must not depend on interfaces") {
+            noClasses()
+                .that().resideInAPackage("..application..")
+                .should().dependOnClassesThat().resideInAPackage("..interfaces..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
 
-    @Test
-    fun `interfaces must not depend on infrastructure`() {
-        noClasses()
-            .that().resideInAPackage("..interfaces..")
-            .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
-            .allowEmptyShould(true)
-            .check(classes)
+        test("interfaces must not depend on infrastructure") {
+            noClasses()
+                .that().resideInAPackage("..interfaces..")
+                .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
+                .allowEmptyShould(true)
+                .check(classes)
+        }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/TeamBalanceIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/TeamBalanceIT.kt
@@ -1,0 +1,39 @@
+package com.github.zzave.teambalance.api
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+@SpringBootTest
+@ContextConfiguration(initializers = [TeamBalanceIT.Initializer::class])
+abstract class TeamBalanceIT : FunSpec() {
+
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Test))
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:17-alpine")
+            .also { it.start() }
+
+        val redis: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .also { it.start() }
+    }
+
+    class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            val env = ctx.environment.systemProperties
+            env["spring.datasource.url"] = postgres.jdbcUrl
+            env["spring.datasource.username"] = postgres.username
+            env["spring.datasource.password"] = postgres.password
+            env["spring.data.redis.host"] = redis.host
+            env["spring.data.redis.port"] = redis.getMappedPort(6379).toString()
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/FlywayMigrationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/FlywayMigrationTest.kt
@@ -1,36 +1,12 @@
 package com.github.zzave.teambalance.api.infrastructure
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
+import com.github.zzave.teambalance.api.TeamBalanceIT
 
-@SpringBootTest
-@Testcontainers
-class FlywayMigrationTest {
+class FlywayMigrationTest : TeamBalanceIT() {
 
-    companion object {
-        @Container
-        @JvmStatic
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
-
-        @DynamicPropertySource
-        @JvmStatic
-        fun configureProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", postgres::getJdbcUrl)
-            registry.add("spring.datasource.username", postgres::getUsername)
-            registry.add("spring.datasource.password", postgres::getPassword)
-            registry.add("spring.data.redis.host") { "localhost" }
-            registry.add("spring.data.redis.port") { "6379" }
-            registry.add("spring.session.store-type") { "none" }
+    init {
+        test("flyway migrations run successfully") {
+            // If we get here, Spring Boot started and Flyway ran all migrations
         }
-    }
-
-    @Test
-    fun `flyway migrations run successfully`() {
-        // If we get here, Spring Boot started and Flyway ran all migrations
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManagerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManagerTest.kt
@@ -1,36 +1,11 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
+import com.github.zzave.teambalance.api.TeamBalanceIT
 import io.kotest.matchers.collections.shouldContain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
 
-@SpringBootTest
-@Testcontainers
-class TenantSchemaManagerTest {
-
-    companion object {
-        @Container
-        @JvmStatic
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
-
-        @DynamicPropertySource
-        @JvmStatic
-        fun configureProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", postgres::getJdbcUrl)
-            registry.add("spring.datasource.username", postgres::getUsername)
-            registry.add("spring.datasource.password", postgres::getPassword)
-            registry.add("spring.data.redis.host") { "localhost" }
-            registry.add("spring.data.redis.port") { "6379" }
-            registry.add("spring.session.store-type") { "none" }
-        }
-    }
+class TenantSchemaManagerTest : TeamBalanceIT() {
 
     @Autowired
     lateinit var tenantSchemaManager: TenantSchemaManager
@@ -38,22 +13,23 @@ class TenantSchemaManagerTest {
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
 
-    @Test
-    fun `provisioning a tenant creates schema with all tables`() {
-        tenantSchemaManager.provisionTenantSchema("team_test_team")
+    init {
+        test("provisioning a tenant creates schema with all tables") {
+            tenantSchemaManager.provisionTenantSchema("team_test_team")
 
-        val tables = jdbcTemplate.queryForList(
-            """
-            SELECT table_name FROM information_schema.tables
-            WHERE table_schema = 'team_test_team'
-            ORDER BY table_name
-            """,
-            String::class.java,
-        )
+            val tables = jdbcTemplate.queryForList(
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'team_test_team'
+                ORDER BY table_name
+                """,
+                String::class.java,
+            )
 
-        tables shouldContain "events"
-        tables shouldContain "attendances"
-        tables shouldContain "transactions"
-        tables shouldContain "event_types"
+            tables shouldContain "events"
+            tables shouldContain "attendances"
+            tables shouldContain "transactions"
+            tables shouldContain "event_types"
+        }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManagerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManagerTest.kt
@@ -9,7 +9,7 @@ import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import kotlin.test.assertTrue
+import io.kotest.matchers.collections.shouldContain
 
 @SpringBootTest
 @Testcontainers
@@ -51,9 +51,9 @@ class TenantSchemaManagerTest {
             String::class.java,
         )
 
-        assertTrue(tables.contains("events"), "Expected 'events' table in tenant schema")
-        assertTrue(tables.contains("attendances"), "Expected 'attendances' table in tenant schema")
-        assertTrue(tables.contains("transactions"), "Expected 'transactions' table in tenant schema")
-        assertTrue(tables.contains("event_types"), "Expected 'event_types' table in tenant schema")
+        tables shouldContain "events"
+        tables shouldContain "attendances"
+        tables shouldContain "transactions"
+        tables shouldContain "event_types"
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/HealthControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/HealthControllerTest.kt
@@ -1,48 +1,24 @@
 package com.github.zzave.teambalance.api.interfaces
 
-import org.junit.jupiter.api.Test
+import com.github.zzave.teambalance.api.TeamBalanceIT
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@SpringBootTest
 @AutoConfigureMockMvc
-@Testcontainers
-class HealthControllerTest {
-
-    companion object {
-        @Container
-        @JvmStatic
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
-
-        @DynamicPropertySource
-        @JvmStatic
-        fun configureProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", postgres::getJdbcUrl)
-            registry.add("spring.datasource.username", postgres::getUsername)
-            registry.add("spring.datasource.password", postgres::getPassword)
-            registry.add("spring.data.redis.host") { "localhost" }
-            registry.add("spring.data.redis.port") { "6379" }
-            registry.add("spring.session.store-type") { "none" }
-        }
-    }
+class HealthControllerTest : TeamBalanceIT() {
 
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    @Test
-    fun `GET api health returns 200`() {
-        mockMvc.get("/api/health")
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.status") { value("UP") }
-            }
+    init {
+        test("GET api/health returns 200") {
+            mockMvc.get("/api/health")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.status") { value("UP") }
+                }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ org.gradle.configuration-cache=true
 wirespecVersion=0.14.3
 testcontainersVersion=1.20.4
 archunitVersion=1.3.0
+kotestVersion=5.9.1
+kotestSpringExtensionVersion=1.3.0


### PR DESCRIPTION
## Summary
- Add Kotest dependencies (runner, assertions, Spring extension) and Redis Testcontainer
- Create `TeamBalanceIT` abstract base class with shared Postgres + Redis Testcontainers and Spring integration
- Migrate all 4 test files to Kotest `FunSpec`: `ArchitectureTest`, `FlywayMigrationTest`, `TenantSchemaManagerTest`, `HealthControllerTest`

## Test plan
- [x] `./gradlew :api:compileTestKotlin` — compiles clean
- [x] `./gradlew :api:test` — all tests pass
- [x] No `org.junit.jupiter.api.Test` imports remain
- [x] No `@Testcontainers` / `@Container` / `@DynamicPropertySource` annotations remain

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)