### PR TITLE
feat(app): isolate-first event type filter chips

### DIFF
--- a/app/e2e/event-type-filter.spec.ts
+++ b/app/e2e/event-type-filter.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+
+// Isolate-first filter chips: from the all-active state a tap isolates that
+// type; from a subset a tap toggles it; deselecting the last chip restores all.
+test('event type chips isolate first, then toggle subsets, then restore all', async ({ page }) => {
+  await page.goto('/')
+
+  const trainingChip = page.getByRole('button', { name: 'Training', exact: true })
+  const matchChip = page.getByRole('button', { name: 'Match', exact: true })
+  const matchCard = page.getByText('League Match vs Smash United')
+  const tournamentCard = page.getByText('Spring Tournament')
+  const trainingCard = page.getByText('Friendly (date TBC)')
+
+  // All types active: events of every type are listed.
+  await expect(matchCard).toBeVisible()
+  await expect(tournamentCard).toBeVisible()
+
+  // Tapping Training from all-active isolates it.
+  await trainingChip.click()
+  await expect(trainingCard).toBeVisible()
+  await expect(matchCard).toBeHidden()
+  await expect(tournamentCard).toBeHidden()
+
+  // Tapping Match from a subset adds it (Training + Match).
+  await matchChip.click()
+  await expect(matchCard).toBeVisible()
+  await expect(trainingCard).toBeVisible()
+  await expect(tournamentCard).toBeHidden()
+
+  // Toggling Training off leaves only Match.
+  await trainingChip.click()
+  await expect(trainingCard).toBeHidden()
+  await expect(matchCard).toBeVisible()
+
+  // Deselecting the last active chip restores all types.
+  await matchChip.click()
+  await expect(trainingCard).toBeVisible()
+  await expect(matchCard).toBeVisible()
+  await expect(tournamentCard).toBeVisible()
+})

--- a/app/src/features/filter-event-types/model/toggleTypeSelection.test.ts
+++ b/app/src/features/filter-event-types/model/toggleTypeSelection.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest'
+import {toggleTypeSelection} from './toggleTypeSelection'
+
+const ALL = ['training', 'match', 'tournament', 'social']
+
+describe('toggleTypeSelection', () => {
+    it('isolates the tapped type when all types are active', () => {
+        const result = toggleTypeSelection(new Set(ALL), ALL, 'training')
+        expect([...result]).toEqual(['training'])
+    })
+
+    it('adds an inactive type when a subset is active', () => {
+        const result = toggleTypeSelection(new Set(['training']), ALL, 'match')
+        expect([...result].sort()).toEqual(['match', 'training'])
+    })
+
+    it('removes an active type when a subset is active', () => {
+        const result = toggleTypeSelection(new Set(['training', 'match']), ALL, 'training')
+        expect([...result]).toEqual(['match'])
+    })
+
+    it('restores all types when the last active type is deselected', () => {
+        const result = toggleTypeSelection(new Set(['training']), ALL, 'training')
+        expect([...result].sort()).toEqual([...ALL].sort())
+    })
+
+    it('reaches the all-active state by adding the final missing type', () => {
+        const result = toggleTypeSelection(new Set(['training', 'match', 'tournament']), ALL, 'social')
+        expect([...result].sort()).toEqual([...ALL].sort())
+    })
+
+    it('does not mutate the input set', () => {
+        const input = new Set(['training', 'match'])
+        toggleTypeSelection(input, ALL, 'training')
+        expect([...input].sort()).toEqual(['match', 'training'])
+    })
+})

--- a/app/src/features/filter-event-types/model/toggleTypeSelection.ts
+++ b/app/src/features/filter-event-types/model/toggleTypeSelection.ts
@@ -1,0 +1,23 @@
+/**
+ * Isolate-first selection: from the all-active state a tap isolates the tapped
+ * type; from a subset a tap toggles it; deselecting the last type restores all.
+ */
+export function toggleTypeSelection(
+    active: Set<string>,
+    allTypeIds: string[],
+    tappedId: string,
+): Set<string> {
+    if (active.size === allTypeIds.length) {
+        return new Set([tappedId])
+    }
+    const next = new Set(active)
+    if (next.has(tappedId)) {
+        next.delete(tappedId)
+        if (next.size === 0) {
+            return new Set(allTypeIds)
+        }
+    } else {
+        next.add(tappedId)
+    }
+    return next
+}

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -4,6 +4,7 @@ import {type Event, useEvents} from '@shared/api/events'
 import {useEventTypes} from '@shared/api/event-types'
 import {EventCard} from '@entities/event/ui/EventCard'
 import {CreateEventDialog} from '@features/create-event/ui/CreateEventDialog'
+import {toggleTypeSelection} from '@features/filter-event-types/model/toggleTypeSelection'
 
 export const Route = createFileRoute('/')({
     component: EventListPage,
@@ -91,16 +92,8 @@ function EventListPage() {
                             <button
                                 key={type.id}
                                 onClick={() => {
-                                    setActiveTypeIds(prev => {
-                                        const next = new Set(prev)
-                                        if (next.has(type.id)) {
-                                            if (next.size <= 1) return prev
-                                            next.delete(type.id)
-                                        } else {
-                                            next.add(type.id)
-                                        }
-                                        return next
-                                    })
+                                    setActiveTypeIds(prev =>
+                                        toggleTypeSelection(prev, eventTypes.map(t => t.id), type.id))
                                 }}
                                 style={isActive ? {
                                     backgroundColor: color,


### PR DESCRIPTION
## Summary

Changes the event-type filter chips (Training / Match / Tournament / Social) on the events list so a single type can be viewed in isolation with one tap, while any subset stays reachable — and the gesture is identical on desktop and mobile (no modifier keys).

**Behavior (isolate-first):**
- From the **all-active** state, tapping a chip **isolates** that type (only it stays on) — previously it removed that one type.
- From a **subset**, tapping toggles a type in/out, so any combination is reachable.
- Deselecting the **last active** chip **restores all** types.

| State | Tap "Training" → |
|-------|------------------|
| All on | Only Training |
| Subset (Training on) + tap Match | Training + Match |
| Only Training on + tap Training | All restored |

No persistence changes — the filter still resets to all-active on navigation/refresh (one tap re-isolates), matching prior behavior.

## Implementation

- Toggle logic extracted to a pure function `toggleTypeSelection(active, allTypeIds, tappedId)` in `app/src/features/filter-event-types/model/` (Feature-Sliced Design), replacing the inline handler in `routes/index.tsx`.
- Unit tests cover isolate-from-all, add/remove within a subset, restore-all on last-deselect, reaching all-active, and input immutability.
- E2E (`event-type-filter.spec.ts`) drives the full isolate → subset → restore-all loop against the MSW mocks.

## Test Plan

- [x] `npm test` — 8 unit tests pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run e2e` — 6/6 Playwright specs pass (incl. new filter spec)
- [ ] Manual: on mobile, tap a chip → only that type shows; tap another → subset; tap the last one off → all return

https://github.com/user-attachments/assets/8be5f531-bf14-477b-8acd-babcd9a672c8




🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGpbKe1d5qHRCTBkmbA3no