### PR TITLE
feat(#34): reusable team-admin authorization check + #31 auth-cache seed

### DIFF
--- a/.claude/preflight.md
+++ b/.claude/preflight.md
@@ -7,5 +7,10 @@ setup: npm --prefix app install && ./gradlew :api:wirespec-typescript  # generat
 - Generated from() throws `Cannot internalize response with status: N` for undeclared status codes → React Query error state; no extra guard needed in queryFn for non-declared codes
 - MSW mocks intentionally carry role ahead of generated types (progress.txt notes which issue re-adds it to the contract)
 
+## multitenancy / hexagonal
+- SessionTenantContextFilter must NOT inject TeamMemberRepository (domain port) — schema name is infra; inject SpringDataTeamMemberRepository directly — SessionTenantContextFilter.kt
+- Filter reads UserContext.get() (set by SessionUserContextFilter at order +2); no session re-read needed — avoids duplicate UUID parse + impossible IllegalArgumentException catch
+- TenantContext is resolved but NOT consumed (no Hibernate multi-tenant wiring; hibernate.default_schema=public) — the ThreadLocal is a placeholder until a CurrentTenantIdentifierResolver or guard filter is wired (blocker for real tenant isolation)
+
 ## html
 - EventCard renders location as `<a>` nested inside the outer `<Link>` `<a>` — invalid HTML; console error in Playwright run; pre-existing, tracked separately

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -1,18 +1,29 @@
 package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.stereotype.Service
 import java.util.UUID
 
-private const val ADMIN_ROLE = "ADMIN"
-
+/**
+ * Team-scoped authorization checks.
+ *
+ * SECURITY CONTRACT — this primitive is only as safe as its arguments:
+ * - [userId] MUST be the authenticated principal (from the session, e.g. `UserContext.get()`),
+ *   never a user-supplied id from a request body/path/query — otherwise this is trivially bypassed.
+ * - [teamId] MUST be the server-resolved tenant for that request, never a raw request parameter —
+ *   otherwise a user can probe or act on teams they don't belong to (IDOR).
+ *
+ * The check is fail-closed: a missing, inactive, or wrong-team membership yields no role and is
+ * therefore not admin.
+ */
 @Service
 class AuthorizationService(
     private val teamMemberRepository: TeamMemberRepository,
 ) {
     fun isAdmin(userId: UUID, teamId: UUID): Boolean =
-        teamMemberRepository.findRole(teamId, userId) == ADMIN_ROLE
+        teamMemberRepository.findRole(teamId, userId) == Role.ADMIN
 
     fun requireAdmin(userId: UUID, teamId: UUID) {
         if (!isAdmin(userId, teamId)) throw NotTeamAdminException(userId, teamId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -1,0 +1,20 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+private const val ADMIN_ROLE = "ADMIN"
+
+@Service
+class AuthorizationService(
+    private val teamMemberRepository: TeamMemberRepository,
+) {
+    fun isAdmin(userId: UUID, teamId: UUID): Boolean =
+        teamMemberRepository.findRole(teamId, userId) == ADMIN_ROLE
+
+    fun requireAdmin(userId: UUID, teamId: UUID) {
+        if (!isAdmin(userId, teamId)) throw NotTeamAdminException(userId, teamId)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -12,3 +12,8 @@ class EventTypeNotFoundException(id: UUID) : NotFoundException("EventType not fo
 
 class AttendanceNotFoundException(eventId: UUID, userId: UUID) :
     NotFoundException("Attendance not found for event $eventId and user $userId")
+
+sealed class ForbiddenException(message: String) : TeambalanceException(message)
+
+class NotTeamAdminException(userId: UUID, teamId: UUID) :
+    ForbiddenException("User $userId is not an admin of team $teamId")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Role.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Role.kt
@@ -1,0 +1,6 @@
+package com.github.zzave.teambalance.api.domain.model
+
+enum class Role {
+    USER,
+    ADMIN,
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.domain.port
 
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import java.util.UUID
 
@@ -7,5 +8,7 @@ interface TeamMemberRepository {
     fun findByTeamId(teamId: UUID): List<TeamMember>
     fun findDisplayName(userId: UUID): String?
     fun findMembersByUserIds(userIds: Set<UUID>): Map<UUID, TeamMember>
-    fun findRole(teamId: UUID, userId: UUID): String?
+
+    /** The user's role on the team, or null if they have no active membership there. */
+    fun findRole(teamId: UUID, userId: UUID): Role?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -7,4 +7,5 @@ interface TeamMemberRepository {
     fun findByTeamId(teamId: UUID): List<TeamMember>
     fun findDisplayName(userId: UUID): String?
     fun findMembersByUserIds(userIds: Set<UUID>): Map<UUID, TeamMember>
+    fun findRole(teamId: UUID, userId: UUID): String?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -35,4 +35,7 @@ class JpaTeamMemberRepositoryAdapter(
             )
         }
     }
+
+    override fun findRole(teamId: UUID, userId: UUID): String? =
+        jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId)?.role
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.stereotype.Repository
@@ -36,6 +37,8 @@ class JpaTeamMemberRepositoryAdapter(
         }
     }
 
-    override fun findRole(teamId: UUID, userId: UUID): String? =
-        jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId)?.role
+    override fun findRole(teamId: UUID, userId: UUID): Role? =
+        jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId)
+            ?.role
+            ?.let { role -> Role.entries.firstOrNull { it.name == role } }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 
 interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UUID> {
     fun findByTeamIdAndActiveTrue(teamId: UUID): List<TeamMemberJpaEntity>
+    fun findByTeamIdAndUserIdAndActiveTrue(teamId: UUID, userId: UUID): TeamMemberJpaEntity?
 
     @Query("SELECT u.display_name FROM public.users u WHERE u.id = :userId", nativeQuery = true)
     fun findDisplayNameByUserId(userId: UUID): String?

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.interfaces
 
+import com.github.zzave.teambalance.api.domain.exception.ForbiddenException
 import com.github.zzave.teambalance.api.domain.exception.NotFoundException
 import com.github.zzave.teambalance.api.domain.exception.TeambalanceException
 import org.springframework.http.HttpStatus
@@ -15,6 +16,11 @@ class GlobalExceptionHandler {
     fun handleNotFound(ex: NotFoundException): ResponseEntity<Map<String, String>> =
         ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(mapOf("error" to (ex.message ?: "Not found")))
+
+    @ExceptionHandler(ForbiddenException::class)
+    fun handleForbidden(ex: ForbiddenException): ResponseEntity<Map<String, String>> =
+        ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(mapOf("error" to (ex.message ?: "Forbidden")))
 
     @ExceptionHandler(TeambalanceException::class)
     fun handleTeambalanceException(ex: TeambalanceException): ResponseEntity<Map<String, String>> =

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -1,0 +1,56 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+private class FakeTeamMemberRepository(private val roles: Map<Pair<UUID, UUID>, String>) : TeamMemberRepository {
+    override fun findByTeamId(teamId: UUID) = emptyList<com.github.zzave.teambalance.api.domain.model.TeamMember>()
+    override fun findDisplayName(userId: UUID): String? = null
+    override fun findMembersByUserIds(userIds: Set<UUID>) = emptyMap<UUID, com.github.zzave.teambalance.api.domain.model.TeamMember>()
+    override fun findRole(teamId: UUID, userId: UUID): String? = roles[teamId to userId]
+}
+
+class AuthorizationServiceTest : FunSpec() {
+
+    init {
+        val teamId = UUID.randomUUID()
+        val adminId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+        val strangerId = UUID.randomUUID()
+
+        val service = AuthorizationService(
+            FakeTeamMemberRepository(
+                mapOf(
+                    (teamId to adminId) to "ADMIN",
+                    (teamId to memberId) to "USER",
+                ),
+            ),
+        )
+
+        test("isAdmin is true for a user with the ADMIN role on that team") {
+            service.isAdmin(adminId, teamId) shouldBe true
+        }
+
+        test("isAdmin is false for a non-admin member of that team") {
+            service.isAdmin(memberId, teamId) shouldBe false
+        }
+
+        test("isAdmin is false for a user with no team_members row for that team") {
+            service.isAdmin(strangerId, teamId) shouldBe false
+        }
+
+        test("requireAdmin passes through silently for an admin") {
+            service.requireAdmin(adminId, teamId)
+        }
+
+        test("requireAdmin throws NotTeamAdminException for a non-admin") {
+            shouldThrow<NotTeamAdminException> {
+                service.requireAdmin(memberId, teamId)
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -1,23 +1,26 @@
 package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.util.UUID
 
-private class FakeTeamMemberRepository(private val roles: Map<Pair<UUID, UUID>, String>) : TeamMemberRepository {
-    override fun findByTeamId(teamId: UUID) = emptyList<com.github.zzave.teambalance.api.domain.model.TeamMember>()
+private class FakeTeamMemberRepository(private val roles: Map<Pair<UUID, UUID>, Role>) : TeamMemberRepository {
+    override fun findByTeamId(teamId: UUID) = emptyList<TeamMember>()
     override fun findDisplayName(userId: UUID): String? = null
-    override fun findMembersByUserIds(userIds: Set<UUID>) = emptyMap<UUID, com.github.zzave.teambalance.api.domain.model.TeamMember>()
-    override fun findRole(teamId: UUID, userId: UUID): String? = roles[teamId to userId]
+    override fun findMembersByUserIds(userIds: Set<UUID>) = emptyMap<UUID, TeamMember>()
+    override fun findRole(teamId: UUID, userId: UUID): Role? = roles[teamId to userId]
 }
 
 class AuthorizationServiceTest : FunSpec() {
 
     init {
         val teamId = UUID.randomUUID()
+        val otherTeamId = UUID.randomUUID()
         val adminId = UUID.randomUUID()
         val memberId = UUID.randomUUID()
         val strangerId = UUID.randomUUID()
@@ -25,8 +28,8 @@ class AuthorizationServiceTest : FunSpec() {
         val service = AuthorizationService(
             FakeTeamMemberRepository(
                 mapOf(
-                    (teamId to adminId) to "ADMIN",
-                    (teamId to memberId) to "USER",
+                    (teamId to adminId) to Role.ADMIN,
+                    (teamId to memberId) to Role.USER,
                 ),
             ),
         )
@@ -41,6 +44,10 @@ class AuthorizationServiceTest : FunSpec() {
 
         test("isAdmin is false for a user with no team_members row for that team") {
             service.isAdmin(strangerId, teamId) shouldBe false
+        }
+
+        test("isAdmin is false for an admin of a different team (cross-team isolation)") {
+            service.isAdmin(adminId, otherTeamId) shouldBe false
         }
 
         test("requireAdmin passes through silently for an admin") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -1,0 +1,57 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.UUID
+
+class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var teamMemberRepository: TeamMemberRepository
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        test("findRole returns the mapped Role for an active member") {
+            val (teamId, userId) = seedMember(role = "ADMIN", active = true)
+            teamMemberRepository.findRole(teamId, userId) shouldBe Role.ADMIN
+        }
+
+        // The security boundary: a deactivated admin must NOT count as an admin. The active=true
+        // filter lives in the JPA query, so this can only be proven against a real database.
+        test("findRole returns null for a deactivated admin (active = false)") {
+            val (teamId, userId) = seedMember(role = "ADMIN", active = false)
+            teamMemberRepository.findRole(teamId, userId) shouldBe null
+        }
+    }
+
+    private fun seedMember(role: String, active: Boolean): Pair<UUID, UUID> {
+        tenantSchemaManager.provisionPlatformSchema()
+        val userId = UUID.randomUUID()
+        val teamId = UUID.randomUUID()
+        val schemaName = "team_${teamId.toString().replace("-", "")}"
+
+        jdbcTemplate.update(
+            "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
+            userId, "member-$userId@test.com", "Test Member",
+        )
+        jdbcTemplate.update(
+            "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
+            teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
+        )
+        jdbcTemplate.update(
+            "INSERT INTO public.team_members (team_id, user_id, role, team_role, active) VALUES (?, ?, ?, 'Setter', ?)",
+            teamId, userId, role, active,
+        )
+        return teamId to userId
+    }
+}

--- a/app/src/routes/auth/verify.tsx
+++ b/app/src/routes/auth/verify.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { useVerifyMagicLink } from '@shared/api/auth'
 
 export const Route = createFileRoute('/auth/verify')({
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/auth/verify')({
 function VerifyPage() {
   const { token } = Route.useSearch()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const verifyMagicLink = useVerifyMagicLink()
   const [error, setError] = useState<string | null>(null)
   const attempted = useRef(false)
@@ -22,7 +24,10 @@ function VerifyPage() {
 
     verifyMagicLink
       .mutateAsync(token)
-      .then(() => navigate({ to: '/', replace: true }))
+      .then((user) => {
+        queryClient.setQueryData(['auth', 'me'], user)
+        navigate({ to: '/', replace: true })
+      })
       .catch(() => setError('This link has expired or already been used. Request a new one.'))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token])

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "claude-handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/claude-handoff/SKILL.md",
+      "computedHash": "6bde27729c8a56b601b4137024a6a9e8056e214b45d2cfc64c69eec93d0b6f66"
+    },
     "demo-video": {
       "source": "flock-community/flock-skills",
       "sourceType": "github",


### PR DESCRIPTION
## What & why

This is the residual, un-merged work from the `feature/#9-34-event-admin-authz` line, rebased cleanly onto `main`. The bulk of the branch (the #31 magic-link **frontend** and the #32/#33 tenant-context work) was already merged via #40 and #46, so rebasing dropped those as *"patch already upstream"*. Two things remain:

### `feat(#34)` — reusable is-admin-of-team authorization check
A small, framework-free authorization primitive in the application layer:
- `AuthorizationService.isAdmin(userId, teamId)` / `requireAdmin(...)`, backed by `TeamMemberRepository.findRole`.
- Fail-closed by construction: a missing, **inactive**, or wrong-team membership yields no role → not admin (`findByTeamIdAndUserIdAndActiveTrue` excludes deactivated members).
- `NotTeamAdminException` (sealed `ForbiddenException`) → **HTTP 403** via `GlobalExceptionHandler`.
- No call sites yet — this is the building block for admin-gated endpoints.

### `fix(#31)` — seed auth cache from verify response
`verify.tsx` seeds the `['auth','me']` React Query cache with the magic-link verify response before redirecting home, so the app renders signed-in immediately — no auth flash, no redundant `/api/auth/me` round-trip. Key and payload shape match `useAuthMe` exactly (both endpoints return `AuthenticatedUser`).

## Review follow-ups applied
This branch was reviewed with a focus on intent, hard-to-change decisions, and security. All findings were addressed here:
- **Security contract documented** — `isAdmin`/`requireAdmin` take `userId`/`teamId` as parameters, so safety depends entirely on callers. Added a KDoc pinning the invariant (userId = authenticated principal, teamId = server-resolved tenant, never raw request params) *before* call sites exist.
- **Type-safe role** — `findRole` now returns a domain `Role` enum instead of a raw `String`; the adapter maps the persisted value fail-closed. Removes the stringly-typed `== "ADMIN"` comparison from the application layer.
- **Active-member boundary now proven** — added a Testcontainers persistence test asserting `findRole` returns `null` for an `active=false` admin (and the mapped `Role` for an active one). This is the actual security boundary and previously lived only in the JPA query.

## Testing
- API: **31 tests, 0 failures** (Testcontainers) — incl. `AuthorizationServiceTest` (happy/deny/stranger/**cross-team**/requireAdmin) and `JpaTeamMemberRepositoryAdapterTest` (active vs **deactivated** admin against real Postgres).
- Frontend: vitest **8 passed**; e2e **6 passed / 2 skipped** (real-backend specs); typecheck/build clean.
- Full pre-commit gate (`make format test e2e`) green on every commit.

A short demo of the end-to-end magic-link flow was recorded separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
