### PR TITLE
refactor(#42): cache tenant schema in session to skip per-request DB query

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/SessionKeys.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/SessionKeys.kt
@@ -2,4 +2,5 @@ package com.github.zzave.teambalance.api.infrastructure.identity
 
 object SessionKeys {
     const val USER_ID = "userId"
+    const val TENANT_SCHEMA = "tenantSchema"
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
+import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys
 import com.github.zzave.teambalance.api.infrastructure.identity.UserContext
 import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTeamMemberRepository
 import jakarta.servlet.FilterChain
@@ -9,6 +10,7 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
 
 private const val FILTER_ORDER = Ordered.HIGHEST_PRECEDENCE + 3
 
@@ -29,13 +31,28 @@ class SessionTenantContextFilter(
             // No team_members row means the user hasn't joined a team yet — leave TenantContext
             // unset rather than guessing, so callers see the neutral "public" default explicitly.
             UserContext.get()?.let { userId ->
-                teamMemberRepository.findSchemaNameByUserId(userId)?.let { TenantContext.set(it) }
+                resolveSchemaName(request, userId)?.let { TenantContext.set(it) }
             }
         }
         try {
             filterChain.doFilter(request, response)
         } finally {
             TenantContext.clear()
+        }
+    }
+
+    /**
+     * The tenant schema is immutable per session in v1 (one team per user, fixed for the session),
+     * so resolve it from the DB once and memoize it on the session. Subsequent requests read the
+     * cached value, avoiding a `team_members JOIN teams` round-trip on every authenticated call.
+     * On a cache miss (first request, or a surviving session after a restart) fall back to the DB.
+     * Multi-team support (post-v1) will invalidate this attribute on team-switch.
+     */
+    private fun resolveSchemaName(request: HttpServletRequest, userId: UUID): String? {
+        val session = request.getSession(false)
+        (session?.getAttribute(SessionKeys.TENANT_SCHEMA) as? String)?.let { return it }
+        return teamMemberRepository.findSchemaNameByUserId(userId)?.also { schemaName ->
+            session?.setAttribute(SessionKeys.TENANT_SCHEMA, schemaName)
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockHttpSession
 import java.util.UUID
 
 class SessionTenantContextFilterTest : TeamBalanceIT() {
@@ -55,6 +56,43 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
             TenantContext.isSet() shouldBe false
         }
 
+        test("second request on the same session resolves from the cached schema without a DB lookup") {
+            tenantSchemaManager.provisionPlatformSchema()
+            val userId = UUID.randomUUID()
+            val teamId = UUID.randomUUID()
+            val schemaName = "team_${teamId.toString().replace("-", "")}"
+
+            jdbcTemplate.update(
+                "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
+                userId, "member-$userId@test.com", "Test Member",
+            )
+            jdbcTemplate.update(
+                "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
+                teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
+            )
+            jdbcTemplate.update(
+                "INSERT INTO public.team_members (team_id, user_id, role, team_role) VALUES (?, ?, 'USER', 'Setter')",
+                teamId, userId,
+            )
+
+            val session = MockHttpSession()
+
+            // First request resolves from the DB and memoizes the schema in the session.
+            UserContext.set(userId)
+            val (firstSchema, firstWasSet) = runFilter(session)
+            firstWasSet shouldBe true
+            firstSchema shouldBe schemaName
+
+            // Remove the backing row so a DB lookup would now resolve to nothing.
+            jdbcTemplate.update("DELETE FROM public.team_members WHERE user_id = ?", userId)
+
+            // Second request on the same session still resolves — only possible from the session cache.
+            UserContext.set(userId)
+            val (secondSchema, secondWasSet) = runFilter(session)
+            secondWasSet shouldBe true
+            secondSchema shouldBe schemaName
+        }
+
         test("session user with no team_members row falls through with no silent fallback") {
             tenantSchemaManager.provisionPlatformSchema()
             val userId = UUID.randomUUID()
@@ -73,11 +111,12 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
         }
     }
 
-    private fun runFilter(): Pair<String?, Boolean> {
+    private fun runFilter(session: MockHttpSession? = null): Pair<String?, Boolean> {
         val filter = SessionTenantContextFilter(springDataTeamMemberRepository)
+        val request = MockHttpServletRequest().apply { session?.let { setSession(it) } }
         var schema: String? = null
         var wasSet = false
-        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse()) { _, _ ->
+        filter.doFilter(request, MockHttpServletResponse()) { _, _ ->
             schema = TenantContext.get()
             wasSet = TenantContext.isSet()
         }


### PR DESCRIPTION
Closes #42

## Problem

`SessionTenantContextFilter` ran a native `public.team_members JOIN public.teams`
query on **every authenticated request** to resolve the caller's tenant schema —
including lightweight endpoints like `/api/auth/me` and logout. In v1 (one team per
user, fixed for the session lifetime) that value is constant for the whole session,
so the per-request lookup is pure overhead on the connection pool.

## Change

Memoize the resolved schema on the HTTP session on first resolution, then read it
back on subsequent requests (the issue's preferred "memoize in the filter" option —
no login-time changes). On a cache miss (first request, or a session surviving a
server restart) it falls back to the DB lookup, so there's no correctness change.

- `SessionTenantContextFilter` — read/write `SessionKeys.TENANT_SCHEMA` around the DB lookup
- `SessionKeys` — new `TENANT_SCHEMA` attribute key

Multi-team support (deferred post-v1) will invalidate this attribute on team-switch;
the fallback-to-DB path handles that naturally.

## Evidence

Same flow (magic-link login, then 5 authenticated `GET /api/auth/me` on one session),
counting the `SELECT t.schema_name … team_members JOIN teams` query in the server log:

| build | tenant-schema DB queries for 5 requests |
|-------|:---------------------------------------:|
| `main` (before) | **5** — one JOIN per request |
| this branch (after) | **1** — resolved once, cached in session |

A short screen recording of the live run is attached to the PR review conversation.

## Verification

- **Test** (`SessionTenantContextFilterTest`): new case resolves the schema on a
  session, deletes the backing `team_members` row, then makes a second request on the
  same session — it still resolves, which is only possible from the session cache.
  `./gradlew :api:test` and `:api:detekt` green.
- **Live**: reproduced the before/after numbers above against a running dev backend
  (`org.hibernate.SQL: DEBUG`).

### Reproduce locally
```bash
make db && make api            # dev profile logs SQL + magic-link tokens
# request magic link → verify (session) → hit /api/auth/me a few times
# grep the api log: `SELECT t.schema_name` appears once per session, not per request
```
