### PR TITLE
feat(#49): enforce tenant context — real schema routing, fail-closed

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CurrentTeamProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CurrentTeamProvider.kt
@@ -1,0 +1,8 @@
+package com.github.zzave.teambalance.api.application
+
+import java.util.UUID
+
+interface CurrentTeamProvider {
+    fun getCurrentTeamId(): UUID?
+    fun requireCurrentTeamId(): UUID
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CurrentTeamProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CurrentTeamProvider.kt
@@ -3,6 +3,6 @@ package com.github.zzave.teambalance.api.application
 import java.util.UUID
 
 interface CurrentTeamProvider {
-    fun getCurrentTeamId(): UUID?
+    /** The team resolved for the current request, or throws if the caller has no active team. */
     fun requireCurrentTeamId(): UUID
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -13,10 +13,12 @@ class EventTypeNotFoundException(id: UUID) : NotFoundException("EventType not fo
 class AttendanceNotFoundException(eventId: UUID, userId: UUID) :
     NotFoundException("Attendance not found for event $eventId and user $userId")
 
-sealed class ForbiddenException(message: String) : TeambalanceException(message)
+// `code` is a stable machine-readable discriminator (the message is human prose) so clients can tell
+// the forbidden reasons apart — e.g. "no team yet" (send to login/onboarding) vs "not an admin".
+sealed class ForbiddenException(message: String, val code: String) : TeambalanceException(message)
 
 class NotTeamAdminException(userId: UUID, teamId: UUID) :
-    ForbiddenException("User $userId is not an admin of team $teamId")
+    ForbiddenException("User $userId is not an admin of team $teamId", "NOT_TEAM_ADMIN")
 
 class NoTeamMembershipException(userId: UUID) :
-    ForbiddenException("User $userId has no active team membership")
+    ForbiddenException("User $userId has no active team membership", "NO_TEAM_MEMBERSHIP")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -17,3 +17,6 @@ sealed class ForbiddenException(message: String) : TeambalanceException(message)
 
 class NotTeamAdminException(userId: UUID, teamId: UUID) :
     ForbiddenException("User $userId is not an admin of team $teamId")
+
+class NoTeamMembershipException(userId: UUID) :
+    ForbiddenException("User $userId has no active team membership")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -11,4 +11,7 @@ interface TeamMemberRepository {
 
     /** The user's role on the team, or null if they have no active membership there. */
     fun findRole(teamId: UUID, userId: UUID): Role?
+
+    /** The team the user actively belongs to, or null if they have no team (v1: one team per user). */
+    fun findTeamId(userId: UUID): UUID?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/SessionKeys.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/SessionKeys.kt
@@ -3,4 +3,5 @@ package com.github.zzave.teambalance.api.infrastructure.identity
 object SessionKeys {
     const val USER_ID = "userId"
     const val TENANT_SCHEMA = "tenantSchema"
+    const val TENANT_TEAM_ID = "tenantTeamId"
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamProvider.kt
@@ -1,0 +1,18 @@
+package com.github.zzave.teambalance.api.infrastructure.identity
+
+import com.github.zzave.teambalance.api.application.CurrentTeamProvider
+import com.github.zzave.teambalance.api.domain.exception.NoTeamMembershipException
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UserContextCurrentTeamProvider(
+    private val teamMemberRepository: TeamMemberRepository,
+) : CurrentTeamProvider {
+    override fun getCurrentTeamId(): UUID? =
+        UserContext.get()?.let { teamMemberRepository.findTeamId(it) }
+
+    override fun requireCurrentTeamId(): UUID =
+        getCurrentTeamId() ?: throw NoTeamMembershipException(UserContext.require())
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamProvider.kt
@@ -2,17 +2,17 @@ package com.github.zzave.teambalance.api.infrastructure.identity
 
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.domain.exception.NoTeamMembershipException
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext
 import org.springframework.stereotype.Component
 import java.util.UUID
 
+/**
+ * Reads the team resolved for this request by SessionTenantContextFilter (the same row that pinned
+ * the tenant schema), rather than re-querying — so the authorized team id and the write schema always
+ * agree, with no second round-trip.
+ */
 @Component
-class UserContextCurrentTeamProvider(
-    private val teamMemberRepository: TeamMemberRepository,
-) : CurrentTeamProvider {
-    override fun getCurrentTeamId(): UUID? =
-        UserContext.get()?.let { teamMemberRepository.findTeamId(it) }
-
+class UserContextCurrentTeamProvider : CurrentTeamProvider {
     override fun requireCurrentTeamId(): UUID =
-        getCurrentTeamId() ?: throw NoTeamMembershipException(UserContext.require())
+        CurrentTeamContext.get() ?: throw NoTeamMembershipException(UserContext.require())
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/CurrentTeamContext.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/CurrentTeamContext.kt
@@ -1,0 +1,16 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import java.util.UUID
+
+/**
+ * The team id resolved for the current request, set alongside [TenantContext] by
+ * SessionTenantContextFilter from the *same* team_members row — so the schema a write lands in and
+ * the team id it is attributed to can never diverge. Null when the request has no resolved team.
+ */
+object CurrentTeamContext {
+    private val current = InheritableThreadLocal<UUID>()
+
+    fun set(teamId: UUID) = current.set(teamId)
+    fun get(): UUID? = current.get()
+    fun clear() = current.remove()
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/HibernateMultiTenancyConfiguration.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/HibernateMultiTenancyConfiguration.kt
@@ -1,0 +1,24 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import org.hibernate.cfg.MultiTenancySettings
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.sql.DataSource
+
+/**
+ * Wires schema-based Hibernate multi-tenancy: every session's physical connection is switched
+ * to the tenant schema resolved by [TenantIdentifierResolver] (which reads [TenantContext]).
+ */
+@Configuration
+class HibernateMultiTenancyConfiguration(private val dataSource: DataSource) {
+
+    @Bean
+    fun multiTenancyHibernatePropertiesCustomizer(): HibernatePropertiesCustomizer =
+        HibernatePropertiesCustomizer { properties ->
+            properties[MultiTenancySettings.MULTI_TENANT_CONNECTION_PROVIDER] =
+                SchemaMultiTenantConnectionProvider(dataSource)
+            properties[MultiTenancySettings.MULTI_TENANT_IDENTIFIER_RESOLVER] =
+                TenantIdentifierResolver()
+        }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
@@ -1,0 +1,34 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * Routes every Hibernate connection to the tenant's Postgres schema via `SET search_path`
+ * (JDBC `Connection.setSchema`), rather than maintaining one physical DataSource per tenant.
+ * Public-schema entities (users, team_members, ...) are unaffected — they're mapped with an
+ * explicit `@Table(schema = "public")`, so Hibernate always qualifies them regardless of search_path.
+ */
+class SchemaMultiTenantConnectionProvider(
+    private val dataSource: DataSource,
+) : MultiTenantConnectionProvider<String> {
+
+    override fun getAnyConnection(): Connection = dataSource.connection
+
+    override fun releaseAnyConnection(connection: Connection) = connection.close()
+
+    override fun getConnection(tenantIdentifier: String): Connection =
+        dataSource.connection.also { it.schema = tenantIdentifier }
+
+    override fun releaseConnection(tenantIdentifier: String, connection: Connection) {
+        connection.schema = "public"
+        connection.close()
+    }
+
+    override fun supportsAggressiveRelease(): Boolean = false
+
+    override fun isUnwrappableAs(unwrapType: Class<*>?): Boolean = false
+
+    override fun <T : Any?> unwrap(unwrapType: Class<T>?): T? = null
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
@@ -22,8 +22,13 @@ class SchemaMultiTenantConnectionProvider(
         dataSource.connection.also { it.schema = tenantIdentifier }
 
     override fun releaseConnection(tenantIdentifier: String, connection: Connection) {
-        connection.schema = "public"
-        connection.close()
+        // Reset the search_path before returning the connection to the pool, but always close it —
+        // if the reset throws (e.g. an aborted connection) skipping close() would leak it from the pool.
+        try {
+            connection.schema = TenantContext.PUBLIC_SCHEMA
+        } finally {
+            connection.close()
+        }
     }
 
     override fun supportsAggressiveRelease(): Boolean = false

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -6,6 +6,7 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTea
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpSession
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
@@ -20,6 +21,8 @@ class SessionTenantContextFilter(
     private val teamMemberRepository: SpringDataTeamMemberRepository,
 ) : OncePerRequestFilter() {
 
+    private data class TenantRouting(val schemaName: String, val teamId: UUID)
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -27,32 +30,48 @@ class SessionTenantContextFilter(
     ) {
         // SessionUserContextFilter (order +2) already resolved and parsed the session user —
         // read it directly rather than re-parsing the session to avoid duplicating that logic.
-        if (!TenantContext.isSet()) {
-            // No team_members row means the user hasn't joined a team yet — leave TenantContext
-            // unset rather than guessing, so callers see the neutral "public" default explicitly.
-            UserContext.get()?.let { userId ->
-                resolveSchemaName(request, userId)?.let { TenantContext.set(it) }
+        // Resolve schema and team id together (one row) so they can never diverge; a user with no
+        // team resolves to nothing (no silent "public" fallback for tenant-scoped work).
+        UserContext.get()?.let { userId ->
+            resolveRouting(request, userId)?.let { routing ->
+                // Respect a tenant already pinned upstream (the test-profile X-Team-Id shim).
+                if (!TenantContext.isSet()) TenantContext.set(routing.schemaName)
+                CurrentTeamContext.set(routing.teamId)
             }
         }
         try {
             filterChain.doFilter(request, response)
         } finally {
             TenantContext.clear()
+            CurrentTeamContext.clear()
         }
     }
 
     /**
-     * The tenant schema is immutable per session in v1 (one team per user, fixed for the session),
-     * so resolve it from the DB once and memoize it on the session. Subsequent requests read the
-     * cached value, avoiding a `team_members JOIN teams` round-trip on every authenticated call.
-     * On a cache miss (first request, or a surviving session after a restart) fall back to the DB.
-     * Multi-team support (post-v1) will invalidate this attribute on team-switch.
+     * The tenant routing is immutable per session in v1 (one team per user, fixed for the session),
+     * so resolve it from the DB once and memoize schema + team id *together* on the session; later
+     * requests read the cached pair, avoiding a `team_members JOIN teams` round-trip on every
+     * authenticated call. Both are cached as a unit so a cached schema can never be paired with a
+     * freshly-queried team id — the single-row guarantee holds across the cache too. On a miss
+     * (first request, or a session surviving a restart) fall back to the DB. Multi-team support
+     * (post-v1) will invalidate these attributes on team-switch.
      */
-    private fun resolveSchemaName(request: HttpServletRequest, userId: UUID): String? {
+    private fun resolveRouting(request: HttpServletRequest, userId: UUID): TenantRouting? {
         val session = request.getSession(false)
-        (session?.getAttribute(SessionKeys.TENANT_SCHEMA) as? String)?.let { return it }
-        return teamMemberRepository.findSchemaNameByUserId(userId)?.also { schemaName ->
-            session?.setAttribute(SessionKeys.TENANT_SCHEMA, schemaName)
+        cachedRouting(session)?.let { return it }
+        return teamMemberRepository.findTeamRoutingByUserId(userId)?.let { routing ->
+            TenantRouting(routing.schemaName, routing.teamId).also { cache(session, it) }
         }
+    }
+
+    private fun cachedRouting(session: HttpSession?): TenantRouting? {
+        val schema = session?.getAttribute(SessionKeys.TENANT_SCHEMA) as? String
+        val teamId = session?.getAttribute(SessionKeys.TENANT_TEAM_ID) as? String
+        return if (schema != null && teamId != null) TenantRouting(schema, UUID.fromString(teamId)) else null
+    }
+
+    private fun cache(session: HttpSession?, routing: TenantRouting) {
+        session?.setAttribute(SessionKeys.TENANT_SCHEMA, routing.schemaName)
+        session?.setAttribute(SessionKeys.TENANT_TEAM_ID, routing.teamId.toString())
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantContext.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantContext.kt
@@ -1,17 +1,26 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
 object TenantContext {
+    /** The platform schema holding cross-team tables (users, teams, ...). */
+    const val PUBLIC_SCHEMA = "public"
+
+    /**
+     * The schema routed to when no tenant is resolved. It intentionally does not exist, so an
+     * *unqualified* (tenant) table reference fails loudly instead of silently hitting [PUBLIC_SCHEMA];
+     * platform entities are `@Table(schema = "public")` and so remain reachable regardless.
+     */
+    const val NO_TENANT_SCHEMA = "__no_tenant__"
+
     private val current = InheritableThreadLocal<String>()
 
     fun set(schemaName: String) = current.set(schemaName)
 
     /**
-     * Returns the resolved tenant schema, or the "public" platform schema if none was resolved.
-     * "public" here is a deliberate default for requests that don't need a tenant (e.g. a user
-     * with no team) — it is not a guess at the user's team. Callers that require an actual tenant
-     * must check [isSet] first rather than trusting this return value alone.
+     * Returns the resolved tenant schema, or [PUBLIC_SCHEMA] if none was resolved. This default is
+     * for callers operating on the platform schema; a caller that requires an actual tenant must
+     * check [isSet] first. Connection routing does NOT use this default — see [TenantIdentifierResolver].
      */
-    fun get(): String = current.get() ?: "public"
+    fun get(): String = current.get() ?: PUBLIC_SCHEMA
     fun isSet(): Boolean = current.get() != null
     fun clear() = current.remove()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantFilter.kt
@@ -22,7 +22,8 @@ class TenantFilter : OncePerRequestFilter() {
         val tenantHeader = request.getHeader("X-Team-Id")
         if (tenantHeader != null) {
             // Test-profile-only shim; prod resolves tenant from the session (SessionTenantContextFilter).
-            TenantContext.set("team_$tenantHeader")
+            // The header value IS the schema name (e.g. "public" or "team_test") — callers own provisioning it.
+            TenantContext.set(tenantHeader)
         }
         try {
             filterChain.doFilter(request, response)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantIdentifierResolver.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantIdentifierResolver.kt
@@ -5,9 +5,14 @@ import org.hibernate.context.spi.CurrentTenantIdentifierResolver
 /**
  * Tells Hibernate which schema the current request's connection should be switched to.
  * Delegates to [TenantContext], which SessionTenantContextFilter populates per-request.
+ *
+ * When no tenant is resolved we route to [TenantContext.NO_TENANT_SCHEMA] (fail closed) rather than
+ * `public`: platform entities are schema-qualified and stay reachable, while any tenant-scoped table
+ * access with no resolved tenant fails loudly instead of silently reading/writing the platform schema.
  */
 class TenantIdentifierResolver : CurrentTenantIdentifierResolver<String> {
-    override fun resolveCurrentTenantIdentifier(): String = TenantContext.get()
+    override fun resolveCurrentTenantIdentifier(): String =
+        if (TenantContext.isSet()) TenantContext.get() else TenantContext.NO_TENANT_SCHEMA
 
     override fun validateExistingCurrentSessions(): Boolean = true
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantIdentifierResolver.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantIdentifierResolver.kt
@@ -1,0 +1,13 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver
+
+/**
+ * Tells Hibernate which schema the current request's connection should be switched to.
+ * Delegates to [TenantContext], which SessionTenantContextFilter populates per-request.
+ */
+class TenantIdentifierResolver : CurrentTenantIdentifierResolver<String> {
+    override fun resolveCurrentTenantIdentifier(): String = TenantContext.get()
+
+    override fun validateExistingCurrentSessions(): Boolean = true
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -41,4 +41,7 @@ class JpaTeamMemberRepositoryAdapter(
         jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId)
             ?.role
             ?.let { role -> Role.entries.firstOrNull { it.name == role } }
+
+    override fun findTeamId(userId: UUID): UUID? =
+        jpaRepository.findTeamIdByUserId(userId)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -28,27 +28,32 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun findMemberSummariesByUserIds(@Param("userIds") userIds: Collection<UUID>): List<MemberSummaryProjection>
 
-    // v1 assumes one team per user; LIMIT 1 picks a single row if that assumption is ever violated.
+    // Resolves the tenant routing (team id + schema) for a user in ONE query, so the request's write
+    // schema and its authorized team id come from the same row and cannot diverge. v1 assumes one team
+    // per user; the deterministic ORDER BY makes the single picked row stable if that is ever violated.
     @Query(
         value = """
-            SELECT t.schema_name
+            SELECT tm.team_id     AS teamId,
+                   t.schema_name  AS schemaName
             FROM   public.team_members tm
             JOIN   public.teams t ON t.id = tm.team_id
             WHERE  tm.user_id = :userId
             AND    tm.active = true
+            ORDER  BY tm.team_id
             LIMIT  1
         """,
         nativeQuery = true,
     )
-    fun findSchemaNameByUserId(@Param("userId") userId: UUID): String?
+    fun findTeamRoutingByUserId(@Param("userId") userId: UUID): TeamRoutingProjection?
 
-    // v1 assumes one team per user; LIMIT 1 picks a single row if that assumption is ever violated.
+    // v1 assumes one team per user; the deterministic ORDER BY makes the single picked row stable.
     @Query(
         value = """
             SELECT tm.team_id
             FROM   public.team_members tm
             WHERE  tm.user_id = :userId
             AND    tm.active = true
+            ORDER  BY tm.team_id
             LIMIT  1
         """,
         nativeQuery = true,
@@ -61,4 +66,9 @@ interface MemberSummaryProjection {
     fun getDisplayName(): String
     fun getTeamRole(): String?
     fun getPermissionRole(): String
+}
+
+interface TeamRoutingProjection {
+    val teamId: UUID
+    val schemaName: String
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -41,6 +41,19 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
         nativeQuery = true,
     )
     fun findSchemaNameByUserId(@Param("userId") userId: UUID): String?
+
+    // v1 assumes one team per user; LIMIT 1 picks a single row if that assumption is ever violated.
+    @Query(
+        value = """
+            SELECT tm.team_id
+            FROM   public.team_members tm
+            WHERE  tm.user_id = :userId
+            AND    tm.active = true
+            LIMIT  1
+        """,
+        nativeQuery = true,
+    )
+    fun findTeamIdByUserId(@Param("userId") userId: UUID): UUID?
 }
 
 interface MemberSummaryProjection {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
+import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.application.PotentialEvent
@@ -28,6 +29,7 @@ class EventController(
     private val eventService: EventService,
     private val attendanceService: AttendanceService,
     private val currentUserProvider: CurrentUserProvider,
+    private val currentTeamProvider: CurrentTeamProvider,
 ) : ListEvents.Handler,
     CreateEvent.Handler,
     GetEvent.Handler,
@@ -42,8 +44,7 @@ class EventController(
     }
 
     override suspend fun createEvent(request: CreateEvent.Request): CreateEvent.Response<*> {
-        @Suppress("ForbiddenComment")
-        val teamId = UUID.fromString("a0000000-0000-0000-0000-000000000001") // TODO: resolve from tenant context
+        val teamId = currentTeamProvider.requireCurrentTeamId()
         val event = eventService.createEvent(
             potential = request.body.consume(),
             createdBy = currentUserProvider.requireCurrentUserId(),

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
@@ -20,7 +20,7 @@ class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenException::class)
     fun handleForbidden(ex: ForbiddenException): ResponseEntity<Map<String, String>> =
         ResponseEntity.status(HttpStatus.FORBIDDEN)
-            .body(mapOf("error" to (ex.message ?: "Forbidden")))
+            .body(mapOf("error" to (ex.message ?: "Forbidden"), "code" to ex.code))
 
     @ExceptionHandler(TeambalanceException::class)
     fun handleTeambalanceException(ex: TeambalanceException): ResponseEntity<Map<String, String>> =

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -8,9 +8,6 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: none
-    properties:
-      hibernate:
-        default_schema: public
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -14,6 +14,7 @@ private class FakeTeamMemberRepository(private val roles: Map<Pair<UUID, UUID>, 
     override fun findDisplayName(userId: UUID): String? = null
     override fun findMembersByUserIds(userIds: Set<UUID>) = emptyMap<UUID, TeamMember>()
     override fun findRole(teamId: UUID, userId: UUID): Role? = roles[teamId to userId]
+    override fun findTeamId(userId: UUID): UUID? = null
 }
 
 class AuthorizationServiceTest : FunSpec() {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -25,72 +25,52 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
     init {
         afterTest {
             TenantContext.clear()
+            CurrentTeamContext.clear()
             UserContext.clear()
         }
 
-        test("session user with a team_members row resolves to their tenant schema") {
+        test("session user with a team_members row resolves schema and team id from the same row") {
             tenantSchemaManager.provisionPlatformSchema()
             val userId = UUID.randomUUID()
             val teamId = UUID.randomUUID()
             val schemaName = "team_${teamId.toString().replace("-", "")}"
-
-            jdbcTemplate.update(
-                "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
-                userId, "member-$userId@test.com", "Test Member",
-            )
-            jdbcTemplate.update(
-                "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
-                teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
-            )
-            jdbcTemplate.update(
-                "INSERT INTO public.team_members (team_id, user_id, role, team_role) VALUES (?, ?, 'USER', 'Setter')",
-                teamId, userId,
-            )
+            seedMember(userId, teamId, schemaName)
 
             // SessionUserContextFilter (order +2) would have set UserContext before this filter runs.
             UserContext.set(userId)
-            val (schema, wasSet) = runFilter()
+            val resolved = runFilter()
 
-            wasSet shouldBe true
-            schema shouldBe schemaName
+            resolved.wasSet shouldBe true
+            resolved.schema shouldBe schemaName
+            resolved.teamId shouldBe teamId
             TenantContext.isSet() shouldBe false
         }
 
-        test("second request on the same session resolves from the cached schema without a DB lookup") {
+        test("second request on the same session resolves schema and team id from cache without a DB lookup") {
             tenantSchemaManager.provisionPlatformSchema()
             val userId = UUID.randomUUID()
             val teamId = UUID.randomUUID()
             val schemaName = "team_${teamId.toString().replace("-", "")}"
-
-            jdbcTemplate.update(
-                "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
-                userId, "member-$userId@test.com", "Test Member",
-            )
-            jdbcTemplate.update(
-                "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
-                teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
-            )
-            jdbcTemplate.update(
-                "INSERT INTO public.team_members (team_id, user_id, role, team_role) VALUES (?, ?, 'USER', 'Setter')",
-                teamId, userId,
-            )
+            seedMember(userId, teamId, schemaName)
 
             val session = MockHttpSession()
 
-            // First request resolves from the DB and memoizes the schema in the session.
+            // First request resolves from the DB and memoizes schema + team id on the session.
             UserContext.set(userId)
-            val (firstSchema, firstWasSet) = runFilter(session)
-            firstWasSet shouldBe true
-            firstSchema shouldBe schemaName
+            val first = runFilter(session)
+            first.wasSet shouldBe true
+            first.schema shouldBe schemaName
+            first.teamId shouldBe teamId
 
             // Remove the backing row so a DB lookup would now resolve to nothing.
             jdbcTemplate.update("DELETE FROM public.team_members WHERE user_id = ?", userId)
 
-            // Second request on the same session still resolves — only possible from the session cache.
+            // Second request on the same session still resolves both — only possible from the cache.
             UserContext.set(userId)
-            val (secondSchema, secondWasSet) = runFilter(session)
-            secondWasSet shouldBe true
-            secondSchema shouldBe schemaName
+            val second = runFilter(session)
+            second.wasSet shouldBe true
+            second.schema shouldBe schemaName
+            second.teamId shouldBe teamId
         }
 
         test("session user with no team_members row falls through with no silent fallback") {
@@ -103,23 +83,39 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
             )
 
             UserContext.set(userId)
-            val (schema, wasSet) = runFilter()
+            val resolved = runFilter()
 
-            wasSet shouldBe false
-            schema shouldBe "public"
+            resolved.wasSet shouldBe false
+            resolved.schema shouldBe "public"
+            resolved.teamId shouldBe null
             TenantContext.isSet() shouldBe false
         }
     }
 
-    private fun runFilter(session: MockHttpSession? = null): Pair<String?, Boolean> {
+    private fun seedMember(userId: UUID, teamId: UUID, schemaName: String) {
+        jdbcTemplate.update(
+            "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
+            userId, "member-$userId@test.com", "Test Member",
+        )
+        jdbcTemplate.update(
+            "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
+            teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
+        )
+        jdbcTemplate.update(
+            "INSERT INTO public.team_members (team_id, user_id, role, team_role) VALUES (?, ?, 'USER', 'Setter')",
+            teamId, userId,
+        )
+    }
+
+    private data class Resolved(val schema: String?, val teamId: UUID?, val wasSet: Boolean)
+
+    private fun runFilter(session: MockHttpSession? = null): Resolved {
         val filter = SessionTenantContextFilter(springDataTeamMemberRepository)
         val request = MockHttpServletRequest().apply { session?.let { setSession(it) } }
-        var schema: String? = null
-        var wasSet = false
+        var resolved = Resolved(null, null, false)
         filter.doFilter(request, MockHttpServletResponse()) { _, _ ->
-            schema = TenantContext.get()
-            wasSet = TenantContext.isSet()
+            resolved = Resolved(TenantContext.get(), CurrentTeamContext.get(), TenantContext.isSet())
         }
-        return schema to wasSet
+        return resolved
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaRoutingTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaRoutingTest.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.infrastructure.multitenancy
 import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataEventTypeRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,6 +38,17 @@ class TenantSchemaRoutingTest : TeamBalanceIT() {
             withTenant("team_alpha") {
                 eventTypeRepository.findAll().map { it.name }
             } shouldContain alphaOnlyName
+        }
+
+        test("with no tenant resolved, tenant-table access fails closed instead of silently hitting public") {
+            // public also carries the tenant tables in tests (provisioned as a schema), so a silent
+            // fallback would succeed — this proves routing does NOT fall back to public when unset.
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema(TenantContext.PUBLIC_SCHEMA)
+
+            TenantContext.clear()
+
+            shouldThrowAny { eventTypeRepository.findAll() }
         }
     }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaRoutingTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaRoutingTest.kt
@@ -1,0 +1,51 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataEventTypeRepository
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
+import java.util.UUID
+
+class TenantSchemaRoutingTest : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    @Autowired
+    lateinit var eventTypeRepository: SpringDataEventTypeRepository
+
+    init {
+        test("JPA writes land in the tenant schema resolved from TenantContext and are isolated per schema") {
+            tenantSchemaManager.provisionTenantSchema("team_alpha")
+            tenantSchemaManager.provisionTenantSchema("team_beta")
+
+            val alphaOnlyName = "Alpha-only-${UUID.randomUUID()}"
+
+            withTenant("team_alpha") {
+                eventTypeRepository.save(
+                    EventTypeJpaEntity(uuid = UUID.randomUUID(), name = alphaOnlyName, color = "#fff", createdAt = Instant.now()),
+                )
+            }
+
+            withTenant("team_beta") {
+                eventTypeRepository.findAll().map { it.name }
+            } shouldNotContain alphaOnlyName
+
+            withTenant("team_alpha") {
+                eventTypeRepository.findAll().map { it.name }
+            } shouldContain alphaOnlyName
+        }
+    }
+
+    private fun <T> withTenant(schema: String, block: () -> T): T {
+        TenantContext.set(schema)
+        try {
+            return block()
+        } finally {
+            TenantContext.clear()
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
@@ -61,7 +61,7 @@ class AttendanceControllerTest : TeamBalanceIT() {
                 MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$JAN_USER_ID")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"state":"ATTENDING"}""")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -113,7 +113,7 @@ class AttendanceControllerTest : TeamBalanceIT() {
                 MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$ownerId")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"state":"ATTENDING"}""")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", editorId),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTenantIsolationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTenantIsolationTest.kt
@@ -1,0 +1,146 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+private const val ALPHA_SCHEMA = "team_iso_alpha"
+private const val BETA_SCHEMA = "team_iso_beta"
+private const val ALPHA_TEAM_ID = "a0000000-0000-0000-0000-0000000000a1"
+private const val BETA_TEAM_ID = "a0000000-0000-0000-0000-0000000000b1"
+private const val ALPHA_USER_ID = "b0000000-0000-0000-0000-0000000000a1"
+private const val BETA_USER_ID = "b0000000-0000-0000-0000-0000000000b1"
+
+/**
+ * EventController-level (HTTP) proof of #49's tenant isolation, complementing
+ * TenantSchemaRoutingTest's repo-level proof: an event created in team A's schema must be
+ * invisible through the real REST endpoints when the request resolves to team B's schema,
+ * and visible again when it resolves back to team A's.
+ */
+@AutoConfigureMockMvc
+class EventControllerTenantIsolationTest : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        test("event created in team A's schema is invisible via HTTP under team B, visible again under team A") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema(ALPHA_SCHEMA)
+            tenantSchemaManager.provisionTenantSchema(BETA_SCHEMA)
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$ALPHA_TEAM_ID'::uuid, 'Team Alpha', 'team-alpha-iso', 'Volleyball', '$ALPHA_SCHEMA')
+                ON CONFLICT DO NOTHING
+                """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$BETA_TEAM_ID'::uuid, 'Team Beta', 'team-beta-iso', 'Volleyball', '$BETA_SCHEMA')
+                ON CONFLICT DO NOTHING
+                """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$ALPHA_USER_ID'::uuid, 'alpha@iso-test.com', 'Alpha User')
+                ON CONFLICT DO NOTHING
+                """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$ALPHA_TEAM_ID'::uuid, '$ALPHA_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+                """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$BETA_USER_ID'::uuid, 'beta@iso-test.com', 'Beta User')
+                ON CONFLICT DO NOTHING
+                """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$BETA_TEAM_ID'::uuid, '$BETA_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+                """
+            )
+
+            // Event lives ONLY in team A's tenant schema.
+            val eventId = UUID.randomUUID()
+            jdbcTemplate.execute(
+                """
+                INSERT INTO $ALPHA_SCHEMA.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                VALUES ('$eventId'::uuid,
+                    (SELECT id FROM $ALPHA_SCHEMA.event_types WHERE name = 'Training'),
+                    'Alpha-only Match', '2026-07-01 20:00:00+00', '2026-07-01 22:00:00+00',
+                    '$ALPHA_USER_ID'::uuid, now(), now())
+                """
+            )
+
+            // Team B's request resolves to BETA_SCHEMA — alpha's event must not be reachable.
+            val notFound = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events/$eventId")
+                    .header("X-Team-Id", BETA_SCHEMA)
+                    .header("X-User-Id", BETA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(notFound))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            // Same event, resolved via team A's own schema — must be visible.
+            val found = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events/$eventId")
+                    .header("X-Team-Id", ALPHA_SCHEMA)
+                    .header("X-User-Id", ALPHA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(found))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(eventId.toString()))
+
+            // The list endpoint must follow the same isolation: absent under team B, present under team A.
+            val listUnderBeta = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events?include-past=true")
+                    .header("X-Team-Id", BETA_SCHEMA)
+                    .header("X-User-Id", BETA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(listUnderBeta))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[?(@.id=='$eventId')]").isEmpty)
+
+            val listUnderAlpha = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events?include-past=true")
+                    .header("X-Team-Id", ALPHA_SCHEMA)
+                    .header("X-User-Id", ALPHA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(listUnderAlpha))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[?(@.id=='$eventId')]").isNotEmpty)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -75,7 +75,7 @@ class EventControllerTest : TeamBalanceIT() {
             // Call the API — X-Team-Id is required by TenantFilter
             val mvcResult = mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/events/$eventId")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -126,7 +126,7 @@ class EventControllerTest : TeamBalanceIT() {
 
             val mvcResult = mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/events?include-past=true")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -218,7 +218,7 @@ class EventControllerTest : TeamBalanceIT() {
 
             val mvcResult = mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/events/$eventId")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -290,7 +290,7 @@ class EventControllerTest : TeamBalanceIT() {
 
             val mvcResult = mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/events/$eventId")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", setterAId),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -346,7 +346,7 @@ class EventControllerTest : TeamBalanceIT() {
 
             val mvcResult = mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/events/$eventId")
-                    .header("X-Team-Id", "placeholder")
+                    .header("X-Team-Id", "public")
                     .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -359,6 +360,123 @@ class EventControllerTest : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attendanceSummary.maybe").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attendanceSummary.absent").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attendanceSummary.notResponded").value(0))
+        }
+
+        test("POST /api/events seeds attendance for the creator's real team, resolved from team_members") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            // teams.schema_name is UNIQUE, so this suite's tests all share the single 'public'-schema
+            // team ($TEAM_ID) — inserts are idempotent (ON CONFLICT DO NOTHING) across tests.
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$LISA_USER_ID'::uuid, 'lisa@test.com', 'Lisa Bakker')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            val memberCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members WHERE team_id = '$TEAM_ID'::uuid AND active = true",
+                Long::class.java,
+            )!!.toInt()
+
+            val eventTypeId = jdbcTemplate.queryForObject(
+                "SELECT uuid FROM public.event_types WHERE name = 'Training'",
+                UUID::class.java,
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "eventTypeId": "$eventTypeId",
+                          "title": "Created via API",
+                          "description": null,
+                          "startTime": "2026-08-01T20:00:00Z",
+                          "endTime": "2026-08-01T22:00:00Z",
+                          "location": null
+                        }
+                        """.trimIndent()
+                    ),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                // Every active member of the real team (resolved via team_members, not a hardcoded
+                // id) starts out NOT_RESPONDED on a freshly created event.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attendanceSummary.notResponded").value(memberCount))
+        }
+
+        test("POST /api/events by a user with no team membership is rejected, not silently defaulted") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            val teamlessUserId = "b0000000-0000-0000-0000-0000000000ff"
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$teamlessUserId'::uuid, 'teamless@test.com', 'Teamless User')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", teamlessUserId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "eventTypeId": "00000000-0000-0000-0000-000000000000",
+                          "title": "Should not be created",
+                          "description": null,
+                          "startTime": "2026-08-01T20:00:00Z",
+                          "endTime": "2026-08-01T22:00:00Z",
+                          "location": null
+                        }
+                        """.trimIndent()
+                    ),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
     }
 

--- a/app/src/app/providers/index.tsx
+++ b/app/src/app/providers/index.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useEffect, type ReactNode } from 'react'
 import { useAuthMe } from '@shared/api/auth'
 import { useUserStore } from '@shared/stores/user-store'
@@ -24,10 +25,29 @@ function UserHydrator() {
   return null
 }
 
+// Sends unauthenticated visitors to the login screen. useAuthMe returns null on a 401 session probe;
+// the login and magic-link routes are exempt so the sign-in flow itself isn't bounced.
+function AuthGuard() {
+  const { data, isLoading, isError } = useAuthMe()
+  const navigate = useNavigate()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+
+  useEffect(() => {
+    if (isLoading || isError) return
+    const onAuthRoute = pathname === '/login' || pathname.startsWith('/auth')
+    if (data === null && !onAuthRoute) {
+      navigate({ to: '/login', replace: true })
+    }
+  }, [data, isLoading, isError, pathname, navigate])
+
+  return null
+}
+
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <UserHydrator />
+      <AuthGuard />
       {children}
     </QueryClientProvider>
   )

--- a/app/src/shared/api/auth-redirect.test.ts
+++ b/app/src/shared/api/auth-redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { NO_TEAM_MEMBERSHIP_CODE, shouldRedirectToLogin } from './auth-redirect'
+
+describe('shouldRedirectToLogin', () => {
+  it('redirects a teamless authenticated user (403 with the no-team code)', () => {
+    expect(
+      shouldRedirectToLogin({ status: 403, code: NO_TEAM_MEMBERSHIP_CODE, currentPath: '/' }),
+    ).toBe(true)
+  })
+
+  it('does NOT redirect a genuine permission error (403 without the no-team code)', () => {
+    expect(
+      shouldRedirectToLogin({ status: 403, code: 'NOT_TEAM_ADMIN', currentPath: '/' }),
+    ).toBe(false)
+  })
+
+  it('does NOT redirect other statuses', () => {
+    expect(shouldRedirectToLogin({ status: 404, code: undefined, currentPath: '/' })).toBe(false)
+    expect(shouldRedirectToLogin({ status: 500, code: undefined, currentPath: '/' })).toBe(false)
+  })
+
+  it('does NOT redirect when already on the login page (avoids a loop)', () => {
+    expect(
+      shouldRedirectToLogin({ status: 403, code: NO_TEAM_MEMBERSHIP_CODE, currentPath: '/login' }),
+    ).toBe(false)
+  })
+})

--- a/app/src/shared/api/auth-redirect.ts
+++ b/app/src/shared/api/auth-redirect.ts
@@ -1,0 +1,31 @@
+export const LOGIN_PATH = '/login'
+
+/** Backend `code` (GlobalExceptionHandler) for an authenticated user who belongs to no team yet. */
+export const NO_TEAM_MEMBERSHIP_CODE = 'NO_TEAM_MEMBERSHIP'
+
+/**
+ * Whether an API response means we should bounce the user to the login screen. Kept pure (no
+ * window/router) so it is unit-testable; the effectful redirect lives in [redirectToLogin].
+ *
+ * A 403 with the "no team membership" code is a teamless authenticated user (send to login); other
+ * 403s (e.g. "not a team admin") are genuine permission errors and stay inline. The unauthenticated
+ * (401) case is handled by the route guard via the session probe, not here.
+ */
+export function shouldRedirectToLogin(params: {
+  status: number
+  code: string | undefined
+  currentPath: string
+}): boolean {
+  const { status, code, currentPath } = params
+  if (currentPath === LOGIN_PATH) return false
+  return status === 403 && code === NO_TEAM_MEMBERSHIP_CODE
+}
+
+let redirecting = false
+
+/** Full-page redirect to login (a session bounce, so a hard nav is fine). Guarded against loops. */
+export function redirectToLogin() {
+  if (redirecting || window.location.pathname === LOGIN_PATH) return
+  redirecting = true
+  window.location.assign(LOGIN_PATH)
+}

--- a/app/src/shared/api/wirespec-client.ts
+++ b/app/src/shared/api/wirespec-client.ts
@@ -1,5 +1,15 @@
 import { Wirespec } from './generated/Wirespec'
 import { client } from './generated/client'
+import { redirectToLogin, shouldRedirectToLogin } from './auth-redirect'
+
+// Best-effort read of the `code` discriminator from an error body (GlobalExceptionHandler).
+const errorCode = (body: string): string | undefined => {
+  try {
+    return JSON.parse(body)?.code
+  } catch {
+    return undefined
+  }
+}
 
 // Wirespec serialization: path/query primitives go through as-is, bodies as JSON.
 const serialization: Wirespec.Serialization = {
@@ -28,6 +38,13 @@ const handler = async (req: Wirespec.RawRequest): Promise<Wirespec.RawResponse> 
   })
 
   const text = res.status === 204 ? '' : await res.text()
+
+  // A teamless authenticated user (403 NO_TEAM_MEMBERSHIP) belongs on the login/onboarding path,
+  // not on a data screen — bounce them there rather than surfacing a raw error.
+  if (shouldRedirectToLogin({ status: res.status, code: errorCode(text), currentPath: window.location.pathname })) {
+    redirectToLogin()
+  }
+
   const headers: Record<string, string> = {}
   res.headers.forEach((value, key) => {
     headers[key] = value

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -139,10 +139,12 @@ export const handlers = [
     return new HttpResponse(null, { status: 401 })
   }),
 
-  // GET /api/auth/me
+  // GET /api/auth/me — mock an authenticated session so the app's main screens render under MSW.
+  // A distinct identity (not a roster member) so it doesn't get pulled out of any event's
+  // attendee list as the "current user".
   http.get('/api/auth/me', async () => {
     await delay(100)
-    return new HttpResponse(null, { status: 401 })
+    return HttpResponse.json({ id: '11111111-1111-1111-1111-111111111111', email: 'you@example.com', displayName: 'You' })
   }),
 
   // POST /api/auth/logout


### PR DESCRIPTION
Closes #49. Part of #9 (auth & onboarding). First of three stacked MRs splitting the unmerged work (#49 → #34 → #35), landing one at a time.

## Why

On `main` today, **tenant isolation is not actually enforced.** `spring.jpa.properties.hibernate.default_schema: public` forces every tenant-scoped table (events, attendances, …) to `public` regardless of the caller's team, and `EventController` still attaches new events to a hardcoded team UUID. #32 resolved the *value* of the tenant context but nothing consumed it. This MR makes the routing real.

## What

- **Hibernate schema-based multi-tenancy** (`HibernateMultiTenancyConfiguration`, `SchemaMultiTenantConnectionProvider`, `TenantIdentifierResolver`): every connection is switched to the tenant's Postgres schema via `SET search_path`, reset to `public` on release back to the pool. Removes the isolation-defeating `default_schema: public`; platform tables stay reachable via explicit `@Table(schema = "public")`.
- **Fail closed:** an unresolved tenant routes to a deliberately non-existent `__no_tenant__` schema, so tenant-scoped access errors loudly instead of silently hitting `public`.
- **Real team resolution:** `CurrentTeamProvider` replaces the hardcoded teamId in `EventController.createEvent`; a teamless authenticated user gets `403 NO_TEAM_MEMBERSHIP` (no silent fallback).
- **Single-row guarantee:** schema + teamId for a request are resolved from one `team_members ⋈ teams` row, so the write schema and the authorized team can never diverge.
- **Fail-loud UX complement:** unauthenticated visitors are routed to `/login`; a teamless `403 NO_TEAM_MEMBERSHIP` bounces to login (other 403s stay inline). `ForbiddenException` carries a stable machine-readable `code`.

## Reconciliation with #42 (already on `main`)

This branch was built before PR #53 (`refactor(#42): cache tenant schema in session`) merged. #42 memoizes the schema on the session to skip a per-request `team_members JOIN teams` query; this work resolves the same filter via a single per-request query yielding schema **and** teamId.

Resolved as a **union**: the session now caches schema **and** teamId *together* (`SessionKeys.TENANT_TEAM_ID`). This keeps #42's no-per-request-query optimization **and** this MR's single-row guarantee — a cached schema can never be paired with a freshly-queried teamId. Covered by a new test: *"second request on the same session resolves schema and team id from cache without a DB lookup."*

## Tests

- Backend `:api:test`: **41 tests, 0 failures**; detekt clean. Includes `TenantSchemaRoutingTest` (repo-layer A/B isolation), `EventControllerTenantIsolationTest` (HTTP-level: a team-A event 404s / is absent when the request resolves to team B), and the union filter tests.
- Frontend: build clean, **12/12** (incl. the pure `shouldRedirectToLogin` unit test).

## Note

The frontend `AuthGuard` (unauthenticated → login) overlaps with #36's scope but ships here as the fail-loud complement to the backend fail-closed behavior, per the `fix/49-review-findings` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
