### PR TITLE
feat(#34): gate Event CRUD on team admin role

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -28,7 +28,8 @@ class JpaEventRepositoryAdapter(
     override fun save(event: Event): Event {
         val eventTypeEntity = eventTypeJpaRepository.findByUuid(event.eventType.id)
             ?: throw EventTypeNotFoundException(event.eventType.id)
-        return jpaRepository.save(event.externalize(eventTypeEntity)).internalize()
+        val technicalId = jpaRepository.findByUuid(event.id)?.id ?: 0
+        return jpaRepository.save(event.externalize(eventTypeEntity, technicalId)).internalize()
     }
 
     override fun deleteById(id: UUID) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
@@ -16,7 +16,8 @@ fun EventJpaEntity.internalize() = Event(
     createdAt = createdAt,
 )
 
-fun Event.externalize(eventTypeEntity: EventTypeJpaEntity) = EventJpaEntity(
+fun Event.externalize(eventTypeEntity: EventTypeJpaEntity, technicalId: Long = 0) = EventJpaEntity(
+    id = technicalId,
     uuid = id,
     eventType = eventTypeEntity,
     title = title,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AuthService
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetAuthMe
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.Logout
@@ -14,6 +15,7 @@ import java.util.UUID
 @RestController
 class AuthController(
     private val authService: AuthService,
+    private val teamMemberRepository: TeamMemberRepository,
     private val httpServletRequest: HttpServletRequest,
 ) : RequestMagicLink.Handler,
     VerifyMagicLink.Handler,
@@ -29,7 +31,12 @@ class AuthController(
         val user = authService.verifyMagicLink(request.body.token) ?: return VerifyMagicLink.Response401(Unit)
         httpServletRequest.session.setAttribute(SessionKeys.USER_ID, user.id.toString())
         return VerifyMagicLink.Response200(
-            AuthenticatedUser(id = user.id.toString(), email = user.email, displayName = user.displayName),
+            AuthenticatedUser(
+                id = user.id.toString(),
+                email = user.email,
+                displayName = user.displayName,
+                role = resolveRole(user.id),
+            ),
         )
     }
 
@@ -42,7 +49,17 @@ class AuthController(
         val user = (httpServletRequest.getSession(false)?.getAttribute(SessionKeys.USER_ID) as? String)
             ?.let { authService.findUserById(UUID.fromString(it)) }
         return user?.let {
-            GetAuthMe.Response200(AuthenticatedUser(id = it.id.toString(), email = it.email, displayName = it.displayName))
+            GetAuthMe.Response200(
+                AuthenticatedUser(
+                    id = it.id.toString(),
+                    email = it.email,
+                    displayName = it.displayName,
+                    role = resolveRole(it.id),
+                ),
+            )
         } ?: GetAuthMe.Response401(Unit)
     }
+
+    private fun resolveRole(userId: UUID): String? =
+        teamMemberRepository.findTeamId(userId)?.let { teamId -> teamMemberRepository.findRole(teamId, userId) }?.name
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
+import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
@@ -30,6 +31,7 @@ class EventController(
     private val attendanceService: AttendanceService,
     private val currentUserProvider: CurrentUserProvider,
     private val currentTeamProvider: CurrentTeamProvider,
+    private val authorizationService: AuthorizationService,
 ) : ListEvents.Handler,
     CreateEvent.Handler,
     GetEvent.Handler,
@@ -45,9 +47,11 @@ class EventController(
 
     override suspend fun createEvent(request: CreateEvent.Request): CreateEvent.Response<*> {
         val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserProvider.requireCurrentUserId()
+        authorizationService.requireAdmin(userId, teamId)
         val event = eventService.createEvent(
             potential = request.body.consume(),
-            createdBy = currentUserProvider.requireCurrentUserId(),
+            createdBy = userId,
             teamId = teamId,
         )
         return CreateEvent.Response201(event.produce(attendanceService))
@@ -86,6 +90,7 @@ class EventController(
     }
 
     override suspend fun updateEvent(request: UpdateEvent.Request): UpdateEvent.Response<*> {
+        authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), currentTeamProvider.requireCurrentTeamId())
         val id = UUID.fromString(request.path.id)
         val req = request.body
         val event = eventService.updateEvent(
@@ -102,6 +107,7 @@ class EventController(
     }
 
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
+        authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), currentTeamProvider.requireCurrentTeamId())
         val id = UUID.fromString(request.path.id)
         return if (eventService.deleteEvent(id)) {
             DeleteEvent.Response204(Unit)

--- a/api/src/main/wirespec/auth.ws
+++ b/api/src/main/wirespec/auth.ws
@@ -9,7 +9,8 @@ type VerifyMagicLinkRequest {
 type AuthenticatedUser {
     id: String,
     email: String,
-    displayName: String
+    displayName: String,
+    role: String?
 }
 
 endpoint RequestMagicLink POST RequestMagicLinkRequest /api/auth/magic-link/request -> {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
@@ -535,6 +536,129 @@ class EventControllerTest : TeamBalanceIT() {
 
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("PUT /api/events/{id} by an admin succeeds") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val eventTypeId = jdbcTemplate.queryForObject(
+                "SELECT uuid FROM public.event_types WHERE name = 'Training'",
+                UUID::class.java,
+            )
+
+            val eventId = UUID.randomUUID()
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                VALUES ('$eventId'::uuid,
+                    (SELECT id FROM public.event_types WHERE name = 'Training'),
+                    'Original Title', '2026-07-01 20:00:00+00', '2026-07-01 22:00:00+00',
+                    '$JAN_USER_ID'::uuid, now(), now())
+            """
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/events/$eventId")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "eventTypeId": "$eventTypeId",
+                          "title": "Updated by admin",
+                          "description": null,
+                          "startTime": "2026-08-01T20:00:00Z",
+                          "endTime": "2026-08-01T22:00:00Z",
+                          "location": null
+                        }
+                        """.trimIndent()
+                    ),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Updated by admin"))
+        }
+
+        test("DELETE /api/events/{id} by an admin succeeds") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val eventId = UUID.randomUUID()
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                VALUES ('$eventId'::uuid,
+                    (SELECT id FROM public.event_types WHERE name = 'Training'),
+                    'To Be Deleted', '2026-07-01 20:00:00+00', '2026-07-01 22:00:00+00',
+                    '$JAN_USER_ID'::uuid, now(), now())
+            """
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/events/$eventId")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            val remaining = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.events WHERE uuid = '$eventId'::uuid",
+                Long::class.java,
+            )
+            remaining shouldBe 0L
         }
     }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -478,6 +478,64 @@ class EventControllerTest : TeamBalanceIT() {
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
+
+        test("POST /api/events by a non-admin team member is rejected with 403") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            // Lisa is a plain USER (non-admin) member of the team — seeded by other tests too,
+            // but re-asserting the role here keeps this test independent of ordering.
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$LISA_USER_ID'::uuid, 'lisa@test.com', 'Lisa Bakker')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val eventTypeId = jdbcTemplate.queryForObject(
+                "SELECT uuid FROM public.event_types WHERE name = 'Training'",
+                UUID::class.java,
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", LISA_USER_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "eventTypeId": "$eventTypeId",
+                          "title": "Should not be created",
+                          "description": null,
+                          "startTime": "2026-08-01T20:00:00Z",
+                          "endTime": "2026-08-01T22:00:00Z",
+                          "location": null
+                        }
+                        """.trimIndent()
+                    ),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
     }
 
     private fun insertAttendance(eventId: UUID, userId: String, state: String = "ATTENDING") {

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -110,6 +110,7 @@ function EventDetailPage() {
   const { eventId } = Route.useParams()
   const { data: event, isLoading } = useEvent(eventId)
   const currentUserId = useUserStore((s) => s.userId)
+  const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
   const { mutate, isPending } = useSetAttendance()
   const [activeAttendeeTab, setActiveAttendeeTab] = useState<AttendanceState>('ATTENDING')
 
@@ -249,16 +250,18 @@ function EventDetailPage() {
       </div>
 
       {/* Admin Actions */}
-      <div className="mt-6 flex gap-2.5 border-t border-border/40 pt-5">
-        <button className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-border/60 bg-transparent py-3 text-sm font-medium text-muted-foreground transition-all hover:bg-muted/50 active:scale-[0.97]">
-          <Pencil size={15} />
-          Edit event
-        </button>
-        <button className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-200 bg-transparent py-3 text-sm font-medium text-red-500 transition-all hover:bg-red-500/5 active:scale-[0.97]">
-          <Trash2 size={15} />
-          Delete
-        </button>
-      </div>
+      {isAdmin && (
+        <div className="mt-6 flex gap-2.5 border-t border-border/40 pt-5">
+          <button className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-border/60 bg-transparent py-3 text-sm font-medium text-muted-foreground transition-all hover:bg-muted/50 active:scale-[0.97]">
+            <Pencil size={15} />
+            Edit event
+          </button>
+          <button className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-200 bg-transparent py-3 text-sm font-medium text-red-500 transition-all hover:bg-red-500/5 active:scale-[0.97]">
+            <Trash2 size={15} />
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -2,6 +2,7 @@ import {createFileRoute} from '@tanstack/react-router'
 import {useEffect, useMemo, useState} from 'react'
 import {type Event, useEvents} from '@shared/api/events'
 import {useEventTypes} from '@shared/api/event-types'
+import {useUserStore} from '@shared/stores/user-store'
 import {EventCard} from '@entities/event/ui/EventCard'
 import {CreateEventDialog} from '@features/create-event/ui/CreateEventDialog'
 import {toggleTypeSelection} from '@features/filter-event-types/model/toggleTypeSelection'
@@ -33,6 +34,7 @@ function EventListPage() {
     const [activeTypeIds, setActiveTypeIds] = useState<Set<string>>(new Set())
     const {data: events, isLoading} = useEvents(tab === 'past')
     const {data: eventTypes} = useEventTypes()
+    const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
 
     useEffect(() => {
         if (eventTypes && activeTypeIds.size === 0) {
@@ -58,7 +60,7 @@ function EventListPage() {
         <div>
             <div className="flex items-center justify-between">
                 <h2 className="font-display text-2xl font-bold">Events</h2>
-                <CreateEventDialog/>
+                {isAdmin && <CreateEventDialog/>}
             </div>
 
             {/* Segmented pill toggle */}

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -134,7 +134,12 @@ export const handlers = [
     await delay(300)
     const body = (await request.json()) as { token: string }
     if (body.token === 'valid-token') {
-      return HttpResponse.json({ id: MEMBERS[0].userId, email: 'you@example.com', displayName: MEMBERS[0].displayName })
+      return HttpResponse.json({
+        id: MEMBERS[0].userId,
+        email: 'you@example.com',
+        displayName: MEMBERS[0].displayName,
+        role: 'ADMIN',
+      })
     }
     return new HttpResponse(null, { status: 401 })
   }),

--- a/app/src/shared/stores/user-store.ts
+++ b/app/src/shared/stores/user-store.ts
@@ -5,6 +5,7 @@ interface UserState {
   userId: string | null
   displayName: string | null
   email: string | null
+  role: string | null
   setCurrentUser: (user: AuthenticatedUser | null) => void
 }
 
@@ -12,10 +13,12 @@ export const useUserStore = create<UserState>((set) => ({
   userId: null,
   displayName: null,
   email: null,
+  role: null,
   setCurrentUser: (user) =>
     set({
       userId: user?.id ?? null,
       displayName: user?.displayName ?? null,
       email: user?.email ?? null,
+      role: user?.role ?? null,
     }),
 }))


### PR DESCRIPTION
Closes #34. Part of #9 (auth & onboarding). Second of the three stacked MRs (#49 → **#34** → #35); #49 is merged, so this targets `main` directly.

## Why

`AuthorizationService` (admin gate) existed but was wired to no endpoint, and event mutations were ungated. With #49 now resolving the caller's real team, the gate can act on the actual team rather than a hardcoded UUID.

## What

- **Server-side gate:** `EventController.createEvent/updateEvent/deleteEvent` call `authorizationService.requireAdmin(userId, resolvedTeamId)` → `403 NOT_TEAM_ADMIN` for non-admins. Reads (`get`/`list`) stay open.
- **Role surfaced:** `AuthenticatedUser` (auth.ws) gains `role: String?`, populated from `team_members.role` via `AuthController.resolveRole()`; drives the frontend.
- **Frontend hides admin controls:** `EventListPage` hides the create dialog and `EventDetailPage` hides edit/delete unless `role === 'ADMIN'` — UX only; the real enforcement is server-side.
- **Bug fix (`852fc7e`):** `JpaEventRepositoryAdapter.save()` always re-inserted (surrogate id defaulted to 0) instead of updating, so `PUT /api/events/{id}` was completely broken (unique-constraint 500). Now looks up the existing row's technical id and merges. Uncovered by the new admin-success update test.

## Security notes

- The gate checks the **resolved** current team (server-derived, not client-supplied); frontend hiding is cosmetic. Cross-tenant event mutation is additionally blocked by #49's schema isolation (a foreign event 404s).
- `role` is nullable; a null role is treated as non-admin (safe default), and the backend `requireAdmin` enforces independently of the frontend.

## Tests

- Backend `:api:test`: **44 tests, 0 failures**; detekt clean. New in `EventControllerTest`: non-admin create → 403; admin PUT/DELETE → success (the latter exercising the fixed update path).
- Frontend: build clean, **12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
