### PR TITLE
feat(#35): admin generates a reusable team invite link

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -1,0 +1,49 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+@Service
+class InvitationService(
+    private val invitationRepository: InvitationRepository,
+    private val clock: Clock,
+) {
+    companion object {
+        // Invite links don't expire on a timer by default in v1 — an admin rotates/expires
+        // them explicitly (#38). This TTL is a long-lived backstop, not the invalidation mechanism.
+        val INVITE_TTL: Duration = Duration.ofDays(365)
+        private const val TOKEN_BYTE_LENGTH = 32
+        private val secureRandom = SecureRandom()
+    }
+
+    /** Returns the team's existing active invite link, or generates a new one if none exists. */
+    fun generateInviteLink(teamId: UUID, createdBy: UUID): Invitation {
+        val now = Instant.now(clock)
+        val existing = invitationRepository.findLatestByTeamId(teamId)?.takeIf { it.expiresAt.isAfter(now) }
+        if (existing != null) return existing
+
+        return invitationRepository.save(
+            Invitation(
+                id = UUID.randomUUID(),
+                teamId = teamId,
+                token = generateToken(),
+                createdBy = createdBy,
+                expiresAt = now.plus(INVITE_TTL),
+                createdAt = now,
+            ),
+        )
+    }
+
+    private fun generateToken(): String {
+        val bytes = ByteArray(TOKEN_BYTE_LENGTH)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -2,7 +2,9 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Clock
 import java.time.Duration
@@ -10,10 +12,16 @@ import java.time.Instant
 import java.util.Base64
 import java.util.UUID
 
+/** The plaintext invite token (shown to the admin once) plus its expiry. Never persisted. */
+data class GeneratedInvitation(val token: String, val expiresAt: Instant)
+
 @Service
 class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val clock: Clock,
+    // App-wide secret mixed into the token hash. Supplied via INVITATION_TOKEN_SALT in live
+    // environments (see application.yml); dev and test use a hardcoded value.
+    @Value("\${teambalance.invitation.token-salt}") private val tokenSalt: String,
 ) {
     companion object {
         // Invite links don't expire on a timer by default in v1 — an admin rotates/expires
@@ -23,22 +31,27 @@ class InvitationService(
         private val secureRandom = SecureRandom()
     }
 
-    /** Returns the team's existing active invite link, or generates a new one if none exists. */
-    fun generateInviteLink(teamId: UUID, createdBy: UUID): Invitation {
+    /**
+     * Mints a fresh invite link for the team: a random token returned to the caller once, with only
+     * its salted hash persisted. The plaintext is never stored, so a DB-read adversary cannot recover
+     * a usable link. Because the hash is one-way, a repeat call can't re-show a previous link — each
+     * call mints a new one; links already shared keep working until they expire. #38 adds explicit
+     * rotate/expire to invalidate them.
+     */
+    fun generateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
         val now = Instant.now(clock)
-        val existing = invitationRepository.findLatestByTeamId(teamId)?.takeIf { it.expiresAt.isAfter(now) }
-        if (existing != null) return existing
-
-        return invitationRepository.save(
+        val token = generateToken()
+        invitationRepository.save(
             Invitation(
                 id = UUID.randomUUID(),
                 teamId = teamId,
-                token = generateToken(),
+                tokenHash = hashToken(token),
                 createdBy = createdBy,
                 expiresAt = now.plus(INVITE_TTL),
                 createdAt = now,
             ),
         )
+        return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
     }
 
     private fun generateToken(): String {
@@ -46,4 +59,14 @@ class InvitationService(
         secureRandom.nextBytes(bytes)
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
+
+    /**
+     * Salted SHA-256, hex-encoded. The salt is an app-wide secret (not per-record), so a leaked DB
+     * alone can't be brute-forced without it. The accept path (#37) will hash the presented token the
+     * same way and match on the stored hash.
+     */
+    private fun hashToken(token: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest((tokenSalt + token).toByteArray())
+            .joinToString("") { "%02x".format(it) }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
@@ -1,0 +1,13 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+data class Invitation(
+    val id: UUID,
+    val teamId: UUID,
+    val token: String,
+    val createdBy: UUID,
+    val expiresAt: Instant,
+    val createdAt: Instant,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
@@ -6,7 +6,8 @@ import java.util.UUID
 data class Invitation(
     val id: UUID,
     val teamId: UUID,
-    val token: String,
+    /** Salted SHA-256 of the invite token — never the plaintext (which is shown to the admin once). */
+    val tokenHash: String,
     val createdBy: UUID,
     val expiresAt: Instant,
     val createdAt: Instant,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -1,0 +1,11 @@
+package com.github.zzave.teambalance.api.domain.port
+
+import com.github.zzave.teambalance.api.domain.model.Invitation
+import java.util.UUID
+
+interface InvitationRepository {
+    fun save(invitation: Invitation): Invitation
+
+    /** The team's most recently created invitation, or null if none exists yet. */
+    fun findLatestByTeamId(teamId: UUID): Invitation?
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -1,11 +1,7 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
-import java.util.UUID
 
 interface InvitationRepository {
     fun save(invitation: Invitation): Invitation
-
-    /** The team's most recently created invitation, or null if none exists yet. */
-    fun findLatestByTeamId(teamId: UUID): Invitation?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -5,7 +5,6 @@ import com.github.zzave.teambalance.api.domain.port.InvitationRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import org.springframework.stereotype.Repository
-import java.util.UUID
 
 @Repository
 class JpaInvitationRepositoryAdapter(
@@ -14,7 +13,4 @@ class JpaInvitationRepositoryAdapter(
 
     override fun save(invitation: Invitation): Invitation =
         jpaRepository.save(invitation.externalize()).internalize()
-
-    override fun findLatestByTeamId(teamId: UUID): Invitation? =
-        jpaRepository.findFirstByTeamIdOrderByCreatedAtDesc(teamId)?.internalize()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -1,0 +1,20 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
+import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class JpaInvitationRepositoryAdapter(
+    private val jpaRepository: SpringDataInvitationRepository,
+) : InvitationRepository {
+
+    override fun save(invitation: Invitation): Invitation =
+        jpaRepository.save(invitation.externalize()).internalize()
+
+    override fun findLatestByTeamId(teamId: UUID): Invitation? =
+        jpaRepository.findFirstByTeamIdOrderByCreatedAtDesc(teamId)?.internalize()
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -1,0 +1,9 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.InvitationJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
+    fun findFirstByTeamIdOrderByCreatedAtDesc(teamId: UUID): InvitationJpaEntity?
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -4,6 +4,4 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.entity.Invita
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
-    fun findFirstByTeamIdOrderByCreatedAtDesc(teamId: UUID): InvitationJpaEntity?
-}
+interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
@@ -14,8 +14,8 @@ class InvitationJpaEntity(
     val id: UUID = UUID.randomUUID(),
     @Column(name = "team_id", nullable = false)
     val teamId: UUID = UUID.randomUUID(),
-    @Column(nullable = false, unique = true)
-    val token: String = "",
+    @Column(name = "token", nullable = false, unique = true)
+    val tokenHash: String = "",
     @Column(name = "created_by", nullable = false)
     val createdBy: UUID = UUID.randomUUID(),
     @Column(name = "expires_at", nullable = false)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
@@ -1,0 +1,25 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "invitations", schema = "public")
+class InvitationJpaEntity(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    @Column(name = "team_id", nullable = false)
+    val teamId: UUID = UUID.randomUUID(),
+    @Column(nullable = false, unique = true)
+    val token: String = "",
+    @Column(name = "created_by", nullable = false)
+    val createdBy: UUID = UUID.randomUUID(),
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant = Instant.EPOCH,
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant = Instant.EPOCH,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
@@ -1,0 +1,22 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence.mapper
+
+import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.InvitationJpaEntity
+
+fun InvitationJpaEntity.internalize() = Invitation(
+    id = id,
+    teamId = teamId,
+    token = token,
+    createdBy = createdBy,
+    expiresAt = expiresAt,
+    createdAt = createdAt,
+)
+
+fun Invitation.externalize() = InvitationJpaEntity(
+    id = id,
+    teamId = teamId,
+    token = token,
+    createdBy = createdBy,
+    expiresAt = expiresAt,
+    createdAt = createdAt,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
@@ -6,7 +6,7 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.entity.Invita
 fun InvitationJpaEntity.internalize() = Invitation(
     id = id,
     teamId = teamId,
-    token = token,
+    tokenHash = tokenHash,
     createdBy = createdBy,
     expiresAt = expiresAt,
     createdAt = createdAt,
@@ -15,7 +15,7 @@ fun InvitationJpaEntity.internalize() = Invitation(
 fun Invitation.externalize() = InvitationJpaEntity(
     id = id,
     teamId = teamId,
-    token = token,
+    tokenHash = tokenHash,
     createdBy = createdBy,
     expiresAt = expiresAt,
     createdAt = createdAt,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -1,0 +1,32 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.application.CurrentTeamProvider
+import com.github.zzave.teambalance.api.application.CurrentUserProvider
+import com.github.zzave.teambalance.api.application.InvitationService
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.model.Invitation
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class InvitationController(
+    private val invitationService: InvitationService,
+    private val currentUserProvider: CurrentUserProvider,
+    private val currentTeamProvider: CurrentTeamProvider,
+    private val authorizationService: AuthorizationService,
+) : CreateInvitation.Handler {
+
+    override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
+        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamProvider.requireCurrentTeamId()
+        authorizationService.requireAdmin(userId, teamId)
+
+        val invitation = invitationService.generateInviteLink(teamId = teamId, createdBy = userId)
+        return CreateInvitation.Response201(
+            Invitation(
+                token = invitation.token,
+                expiresAt = invitation.expiresAt.toString(),
+            ),
+        )
+    }
+}

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -11,6 +11,11 @@ spring:
       host: localhost
       port: 6379
 
+teambalance:
+  invitation:
+    # Dev-only salt (not a live environment) so bootRun works without INVITATION_TOKEN_SALT set.
+    token-salt: dev-invitation-salt
+
 logging:
   level:
     com.github.zzave.teambalance.api: DEBUG

--- a/api/src/main/resources/application-e2e.yml
+++ b/api/src/main/resources/application-e2e.yml
@@ -14,3 +14,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+teambalance:
+  invitation:
+    # Hardcoded salt for e2e runs (not a live environment); live supplies INVITATION_TOKEN_SALT.
+    token-salt: e2e-invitation-salt

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -26,3 +26,10 @@ management:
       base-path: /internal/actuator
       exposure:
         include: health,info,metrics
+
+teambalance:
+  invitation:
+    # App-wide secret salt applied to stored invite-token hashes. Live environments MUST provide it
+    # via INVITATION_TOKEN_SALT (no default here → the app fails fast if it is unset). Dev and test
+    # override it with a hardcoded value in their profile config.
+    token-salt: ${INVITATION_TOKEN_SALT}

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -1,0 +1,8 @@
+type Invitation {
+    token: String,
+    expiresAt: String
+}
+
+endpoint CreateInvitation POST /api/invitations -> {
+    201 -> Invitation
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -1,0 +1,156 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+private const val JAN_USER_ID = "c0000000-0000-0000-0000-000000000001"
+private const val LISA_USER_ID = "c0000000-0000-0000-0000-000000000002"
+private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+
+@AutoConfigureMockMvc
+class InvitationControllerTest : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        test("POST /api/invitations by an admin returns a reusable invite token") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan-invite@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.expiresAt").isNotEmpty)
+        }
+
+        test("POST /api/invitations twice by the same admin returns the same reusable token") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan-invite@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            fun createInvitation(): String {
+                val mvcResult = mockMvc.perform(
+                    MockMvcRequestBuilders.post("/api/invitations")
+                        .header("X-Team-Id", "public")
+                        .header("X-User-Id", JAN_USER_ID),
+                )
+                    .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                    .andReturn()
+
+                return mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                    .andExpect(MockMvcResultMatchers.status().isCreated)
+                    .andReturn()
+                    .response
+                    .contentAsString
+            }
+
+            val first = createInvitation()
+            val second = createInvitation()
+
+            first shouldBe second
+        }
+
+        test("POST /api/invitations by a non-admin team member is rejected with 403") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$LISA_USER_ID'::uuid, 'lisa-invite@test.com', 'Lisa Bakker')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero')
+                ON CONFLICT DO NOTHING
+            """
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", LISA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -1,18 +1,27 @@
 package com.github.zzave.teambalance.api.interfaces
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.security.MessageDigest
 
 private const val JAN_USER_ID = "c0000000-0000-0000-0000-000000000001"
 private const val LISA_USER_ID = "c0000000-0000-0000-0000-000000000002"
 private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+
+// Must match application-test.yml (teambalance.invitation.token-salt).
+private const val TEST_SALT = "test-invitation-salt"
+
+private fun sha256Hex(salt: String, token: String): String =
+    MessageDigest.getInstance("SHA-256").digest((salt + token).toByteArray()).joinToString("") { "%02x".format(it) }
 
 @AutoConfigureMockMvc
 class InvitationControllerTest : TeamBalanceIT() {
@@ -26,93 +35,68 @@ class InvitationControllerTest : TeamBalanceIT() {
     @Autowired
     lateinit var tenantSchemaManager: TenantSchemaManager
 
+    private val objectMapper = ObjectMapper()
+
+    private fun seedAdmin() {
+        tenantSchemaManager.provisionPlatformSchema()
+        tenantSchemaManager.provisionTenantSchema("public")
+        jdbcTemplate.execute(
+            "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
+                "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public') ON CONFLICT DO NOTHING",
+        )
+        jdbcTemplate.execute(
+            "INSERT INTO public.users (id, email, display_name) " +
+                "VALUES ('$JAN_USER_ID'::uuid, 'jan-invite@test.com', 'Jan de Vries') ON CONFLICT DO NOTHING",
+        )
+        jdbcTemplate.execute(
+            "INSERT INTO public.team_members (team_id, user_id, role, team_role) " +
+                "VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter') ON CONFLICT DO NOTHING",
+        )
+    }
+
+    private fun createInvitationAs(userId: String): String {
+        val mvcResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/invitations")
+                .header("X-Team-Id", "public")
+                .header("X-User-Id", userId),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+
+        return mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+            .andExpect(MockMvcResultMatchers.status().isCreated)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.expiresAt").isNotEmpty)
+            .andReturn()
+            .response
+            .contentAsString
+    }
+
     init {
-        test("POST /api/invitations by an admin returns a reusable invite token") {
-            tenantSchemaManager.provisionPlatformSchema()
-            tenantSchemaManager.provisionTenantSchema("public")
+        test("POST /api/invitations by an admin returns a token whose SALTED HASH is what gets stored") {
+            seedAdmin()
 
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
-                ON CONFLICT DO NOTHING
-            """
-            )
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.users (id, email, display_name)
-                VALUES ('$JAN_USER_ID'::uuid, 'jan-invite@test.com', 'Jan de Vries')
-                ON CONFLICT DO NOTHING
-            """
-            )
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.team_members (team_id, user_id, role, team_role)
-                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
-                ON CONFLICT DO NOTHING
-            """
-            )
+            val token = objectMapper.readTree(createInvitationAs(JAN_USER_ID)).get("token").asText()
 
-            val mvcResult = mockMvc.perform(
-                MockMvcRequestBuilders.post("/api/invitations")
-                    .header("X-Team-Id", "public")
-                    .header("X-User-Id", JAN_USER_ID),
+            // The plaintext token is never persisted; only its salted SHA-256 hash is.
+            val plaintextRows = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations WHERE token = ?", Long::class.java, token,
             )
-                .andExpect(MockMvcResultMatchers.request().asyncStarted())
-                .andReturn()
+            plaintextRows shouldBe 0L
 
-            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
-                .andExpect(MockMvcResultMatchers.status().isCreated)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.expiresAt").isNotEmpty)
+            val hashRows = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations WHERE token = ?", Long::class.java, sha256Hex(TEST_SALT, token),
+            )
+            hashRows shouldBe 1L
         }
 
-        test("POST /api/invitations twice by the same admin returns the same reusable token") {
-            tenantSchemaManager.provisionPlatformSchema()
-            tenantSchemaManager.provisionTenantSchema("public")
+        test("POST /api/invitations twice mints distinct tokens (fresh each call, no plaintext to reuse)") {
+            seedAdmin()
 
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
-                ON CONFLICT DO NOTHING
-            """
-            )
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.users (id, email, display_name)
-                VALUES ('$JAN_USER_ID'::uuid, 'jan-invite@test.com', 'Jan de Vries')
-                ON CONFLICT DO NOTHING
-            """
-            )
-            jdbcTemplate.execute(
-                """
-                INSERT INTO public.team_members (team_id, user_id, role, team_role)
-                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
-                ON CONFLICT DO NOTHING
-            """
-            )
+            val first = objectMapper.readTree(createInvitationAs(JAN_USER_ID)).get("token").asText()
+            val second = objectMapper.readTree(createInvitationAs(JAN_USER_ID)).get("token").asText()
 
-            fun createInvitation(): String {
-                val mvcResult = mockMvc.perform(
-                    MockMvcRequestBuilders.post("/api/invitations")
-                        .header("X-Team-Id", "public")
-                        .header("X-User-Id", JAN_USER_ID),
-                )
-                    .andExpect(MockMvcResultMatchers.request().asyncStarted())
-                    .andReturn()
-
-                return mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
-                    .andExpect(MockMvcResultMatchers.status().isCreated)
-                    .andReturn()
-                    .response
-                    .contentAsString
-            }
-
-            val first = createInvitation()
-            val second = createInvitation()
-
-            first shouldBe second
+            first shouldNotBe second
         }
 
         test("POST /api/invitations by a non-admin team member is rejected with 403") {
@@ -120,25 +104,16 @@ class InvitationControllerTest : TeamBalanceIT() {
             tenantSchemaManager.provisionTenantSchema("public")
 
             jdbcTemplate.execute(
-                """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
-                ON CONFLICT DO NOTHING
-            """
+                "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
+                    "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public') ON CONFLICT DO NOTHING",
             )
             jdbcTemplate.execute(
-                """
-                INSERT INTO public.users (id, email, display_name)
-                VALUES ('$LISA_USER_ID'::uuid, 'lisa-invite@test.com', 'Lisa Bakker')
-                ON CONFLICT DO NOTHING
-            """
+                "INSERT INTO public.users (id, email, display_name) " +
+                    "VALUES ('$LISA_USER_ID'::uuid, 'lisa-invite@test.com', 'Lisa Bakker') ON CONFLICT DO NOTHING",
             )
             jdbcTemplate.execute(
-                """
-                INSERT INTO public.team_members (team_id, user_id, role, team_role)
-                VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero')
-                ON CONFLICT DO NOTHING
-            """
+                "INSERT INTO public.team_members (team_id, user_id, role, team_role) " +
+                    "VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero') ON CONFLICT DO NOTHING",
             )
 
             val mvcResult = mockMvc.perform(

--- a/api/src/test/resources/application-test.yml
+++ b/api/src/test/resources/application-test.yml
@@ -1,0 +1,4 @@
+teambalance:
+  invitation:
+    # Hardcoded salt for the test profile — live environments supply INVITATION_TOKEN_SALT via env.
+    token-salt: test-invitation-salt

--- a/app/src/features/generate-invite/ui/GenerateInviteDialog.test.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteDialog.test.tsx
@@ -1,0 +1,50 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { GenerateInviteDialog } from './GenerateInviteDialog'
+
+const server = setupServer(
+  http.post('/api/invitations', () =>
+    HttpResponse.json({ token: 'abc123', expiresAt: '2027-01-01T00:00:00Z' }, { status: 201 }),
+  ),
+)
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+function renderWithClient() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GenerateInviteDialog />
+    </QueryClientProvider>,
+  )
+}
+
+describe('GenerateInviteDialog', () => {
+  it('generates and displays an invite link when opened', async () => {
+    renderWithClient()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Invite Link' }))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(/\/invite\/abc123$/)).toBeInTheDocument()
+    })
+  })
+
+  it('copies the invite link to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    renderWithClient()
+    await userEvent.click(screen.getByRole('button', { name: 'Invite Link' }))
+    await waitFor(() => screen.getByDisplayValue(/\/invite\/abc123$/))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringMatching(/\/invite\/abc123$/))
+    expect(await screen.findByRole('button', { name: 'Copied!' })).toBeInTheDocument()
+  })
+})

--- a/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@shared/ui/dialog'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { useCreateInvitation } from '@shared/api/invitations'
+
+export function GenerateInviteDialog() {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const createInvitation = useCreateInvitation()
+
+  const inviteUrl = createInvitation.data
+    ? `${window.location.origin}/invite/${createInvitation.data.token}`
+    : ''
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (next && !createInvitation.data) {
+      createInvitation.mutate()
+    }
+    if (!next) {
+      setCopied(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(inviteUrl)
+    setCopied(true)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Invite Link</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Team invite link</DialogTitle>
+        </DialogHeader>
+        {createInvitation.isPending && <p className="text-muted-foreground">Generating...</p>}
+        {createInvitation.isError && <p className="text-destructive">Failed to generate invite link.</p>}
+        {createInvitation.data && (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-muted-foreground">
+              Share this link with your team. Anyone with the link can join.
+            </p>
+            <div className="flex gap-2">
+              <Input readOnly value={inviteUrl} onFocus={(e) => e.currentTarget.select()} />
+              <Button type="button" onClick={handleCopy}>
+                {copied ? 'Copied!' : 'Copy'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -5,6 +5,7 @@ import {useEventTypes} from '@shared/api/event-types'
 import {useUserStore} from '@shared/stores/user-store'
 import {EventCard} from '@entities/event/ui/EventCard'
 import {CreateEventDialog} from '@features/create-event/ui/CreateEventDialog'
+import {GenerateInviteDialog} from '@features/generate-invite/ui/GenerateInviteDialog'
 import {toggleTypeSelection} from '@features/filter-event-types/model/toggleTypeSelection'
 
 export const Route = createFileRoute('/')({
@@ -60,7 +61,12 @@ function EventListPage() {
         <div>
             <div className="flex items-center justify-between">
                 <h2 className="font-display text-2xl font-bold">Events</h2>
-                {isAdmin && <CreateEventDialog/>}
+                {isAdmin && (
+                    <div className="flex items-center gap-2">
+                        <GenerateInviteDialog/>
+                        <CreateEventDialog/>
+                    </div>
+                )}
             </div>
 
             {/* Segmented pill toggle */}

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query'
+import { api } from './wirespec-client'
+
+export type { Invitation } from './generated/model/Invitation'
+
+export function useCreateInvitation() {
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.CreateInvitation()
+      return res.body
+    },
+  })
+}

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -157,4 +157,16 @@ export const handlers = [
     await delay(100)
     return new HttpResponse(null, { status: 204 })
   }),
+
+  // POST /api/invitations
+  http.post('/api/invitations', async () => {
+    await delay(300)
+    return HttpResponse.json(
+      {
+        token: 'mock-invite-token',
+        expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      { status: 201 },
+    )
+  }),
 ]


### PR DESCRIPTION
Closes #35. Part of #9 (auth & onboarding). Third of the three stacked MRs (#49 → #34 → **#35**); #49 and #34 are merged, so this targets `main` directly.

## Why

An admin needs a single shareable link to invite teammates ("drop it in the group chat"). This adds the generation half; consumption (accepting the link) is #37.

## What

- **`POST /api/invitations`** (Wirespec `invitations.ws`), admin-gated via `authorizationService.requireAdmin` on the resolved team (same pattern as #34's `EventController`).
- **Token:** 32 bytes from `SecureRandom`, URL-safe base64 (256 bits — unguessable).
- **Stored as a salted hash, never plaintext** (see below).
- **Domain/persistence:** `Invitation` model + `InvitationRepository` port + JPA entity/mapper/adapter (mirrors the `MagicLinkToken` shape). No new migration — the `invitations` table already exists in `V001` (`token VARCHAR(100)` fits the 64-char hash).
- **Admin UI:** `GenerateInviteDialog` (`features/generate-invite`) — an "Invite Link" button next to "New Event" on `EventListPage`, admin-gated (`role === 'ADMIN'`); opens a dialog, calls the endpoint, shows `origin + /invite/{token}` in a readonly field with a Copy button.

## Token hashing (security)

The invite token is persisted as a **salted SHA-256 hash**; the plaintext is returned to the admin once and never stored, so a DB-read adversary cannot recover a usable link.

- The salt is an **app-wide secret** from `teambalance.invitation.token-salt`. Live environments supply it via the **`INVITATION_TOKEN_SALT`** env var — `application.yml` has **no default**, so the app fails fast if it is unset. Dev (`application-dev.yml`) and test (`application-test.yml`) use a hardcoded profile value.
- Domain field renamed `token` → `tokenHash` (mirrors `MagicLinkToken`); the DB column stays `token`.
- Because the hash is one-way, get-or-create (which re-returned the stored plaintext) is replaced by **generate-fresh**: each call mints a new link, and links already shared keep working until they expire. Explicit rotate/expire is **#38**.

`/invite/{token}` is a placeholder path; #37 creates the actual landing route and will hash the presented token the same way to match.

## Tests

- Backend `:api:test`: **47 tests, 0 failures**; detekt clean. `InvitationControllerTest`: admin → 201; the **stored value equals `sha256(salt+token)`, not the returned plaintext**; two calls mint distinct tokens; non-admin → 403.
- Frontend: build clean, **14/14** (`GenerateInviteDialog.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
