### PR TITLE
feat(test): change-attendance e2e + attendance-update bugfix (layered test strategy, phase 2)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
@@ -23,7 +23,10 @@ class JpaAttendanceRepositoryAdapter(
     override fun save(attendance: Attendance): Attendance {
         val eventEntity = eventJpaRepository.findByUuid(attendance.eventId)
             ?: throw EventNotFoundException(attendance.eventId)
-        return jpaRepository.save(attendance.externalize(eventEntity)).internalize()
+        // Carry the DB identity over when the row already exists: a fresh entity (id=0) makes
+        // Hibernate INSERT — violating the uuid unique constraint — instead of updating in place.
+        val existingDbId = jpaRepository.findByUuid(attendance.id)?.id ?: 0
+        return jpaRepository.save(attendance.externalize(eventEntity, existingDbId)).internalize()
     }
 
     override fun saveAll(attendances: List<Attendance>): List<Attendance> {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/AttendanceMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/AttendanceMapper.kt
@@ -14,7 +14,8 @@ fun AttendanceJpaEntity.internalize() = Attendance(
     changedBy = changedBy,
 )
 
-fun Attendance.externalize(event: EventJpaEntity) = AttendanceJpaEntity(
+fun Attendance.externalize(event: EventJpaEntity, dbId: Long = 0) = AttendanceJpaEntity(
+    id = dbId,
     uuid = id,
     event = event,
     userId = userId,

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -18,3 +18,34 @@ VALUES (
     'ADMIN'
 )
 ON CONFLICT DO NOTHING;
+
+-- Tenant data for the change-attendance flow (team_test is provisioned before this runs).
+-- Event types are seeded per-tenant by tenant-migration V002; resolve the FK by name.
+-- start_time is relative so the event stays on the upcoming list; the uuid conflict keeps
+-- re-runs from duplicating it (stale start_time on a long-lived local DB is acceptable —
+-- CI is always fresh, locally `docker-compose down -v` resets).
+-- end_time is required even though the column is nullable: the Event domain model is non-null.
+INSERT INTO team_test.events (uuid, event_type_id, title, description, start_time, end_time, location, created_by)
+SELECT
+    'e2e00000-0000-0000-0000-000000000004',
+    et.id,
+    'E2E Training',
+    'Seeded for the change-attendance e2e flow',
+    now() + interval '7 days',
+    now() + interval '7 days 2 hours',
+    'E2E Sporthal',
+    'e2e00000-0000-0000-0000-000000000002'
+FROM team_test.event_types et
+WHERE et.name = 'Training'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO team_test.attendances (uuid, event_id, user_id, state, changed_by)
+SELECT
+    'e2e00000-0000-0000-0000-000000000005',
+    e.id,
+    'e2e00000-0000-0000-0000-000000000002',
+    'NOT_RESPONDED',
+    'e2e00000-0000-0000-0000-000000000002'
+FROM team_test.events e
+WHERE e.uuid = 'e2e00000-0000-0000-0000-000000000004'
+ON CONFLICT DO NOTHING;

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
@@ -74,6 +74,53 @@ class AttendanceControllerTest : TeamBalanceIT() {
             queryChangedBy(eventId, JAN_USER_ID) shouldBe UUID.fromString(JAN_USER_ID)
         }
 
+        test("PUT twice updates the existing attendance row instead of duplicating it") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute("""
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team 2', 'test-team-2', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """)
+            jdbcTemplate.execute("""
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan2@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """)
+            jdbcTemplate.execute("""
+                INSERT INTO public.team_members (team_id, user_id, role, team_role)
+                VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter')
+                ON CONFLICT DO NOTHING
+            """)
+
+            val eventId = UUID.randomUUID()
+            jdbcTemplate.execute("""
+                INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                VALUES ('$eventId'::uuid,
+                    (SELECT id FROM public.event_types WHERE name = 'Training'),
+                    'Toggle Twice', '2026-07-01 20:00:00+00', '2026-07-01 22:00:00+00',
+                    '$JAN_USER_ID'::uuid, now(), now())
+            """)
+
+            putAttendance(eventId, "ATTENDING")
+            putAttendance(eventId, "MAYBE")
+
+            val rows = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.attendances a JOIN public.events e ON e.id = a.event_id " +
+                    "WHERE e.uuid = '$eventId'::uuid AND a.user_id = '$JAN_USER_ID'::uuid",
+                Int::class.java,
+            )
+            rows shouldBe 1
+
+            val state = jdbcTemplate.queryForObject(
+                "SELECT a.state FROM public.attendances a JOIN public.events e ON e.id = a.event_id " +
+                    "WHERE e.uuid = '$eventId'::uuid AND a.user_id = '$JAN_USER_ID'::uuid",
+                String::class.java,
+            )
+            state shouldBe "MAYBE"
+        }
+
         test("PUT /api/events/{id}/attendances/{userId} records the editor, not the owner, as changedBy") {
             tenantSchemaManager.provisionPlatformSchema()
             tenantSchemaManager.provisionTenantSchema("public")
@@ -125,6 +172,20 @@ class AttendanceControllerTest : TeamBalanceIT() {
 
             queryChangedBy(eventId, ownerId) shouldBe UUID.fromString(editorId)
         }
+    }
+
+    private fun putAttendance(eventId: UUID, state: String) {
+        val started = mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$JAN_USER_ID")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"state":"$state"}""")
+                .header("X-Team-Id", "public")
+                .header("X-User-Id", JAN_USER_ID),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(started))
+            .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
     private fun queryChangedBy(eventId: UUID, userId: String): UUID? =

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/E2eSupportIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/E2eSupportIT.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.mock.web.MockHttpSession
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
@@ -46,6 +47,25 @@ class E2eSupportIT : TeamBalanceIT() {
             membershipCount shouldBe 1
         }
 
+        test("e2e profile seeds a future event with an attendance row for the e2e user") {
+            val eventCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM team_test.events WHERE title = 'E2E Training' AND start_time > now()",
+                Int::class.java,
+            )
+            eventCount shouldBe 1
+
+            val attendanceCount = jdbcTemplate.queryForObject(
+                """
+                SELECT count(*) FROM team_test.attendances a
+                JOIN team_test.events e ON e.id = a.event_id
+                JOIN public.users u ON u.id = a.user_id
+                WHERE e.title = 'E2E Training' AND u.email = 'e2e@example.com'
+                """,
+                Int::class.java,
+            )
+            attendanceCount shouldBe 1
+        }
+
         test("plaintext magic-link token is retrievable via the e2e endpoint and verifies") {
             val email = "e2e@example.com"
 
@@ -71,6 +91,40 @@ class E2eSupportIT : TeamBalanceIT() {
             )
             verified.andExpect(MockMvcResultMatchers.status().isOk)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.email").value(email))
+        }
+
+        // Guards the seed ↔ domain-model contract: a fixture row the Event mapper can't
+        // internalize (e.g. NULL end_time) 500s here instead of only failing the slow e2e.
+        test("seeded tenant data is servable through the events API as the e2e user") {
+            val email = "e2e@example.com"
+
+            val (_, requested) = performAsync(
+                MockMvcRequestBuilders.post("/api/auth/magic-link/request")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email":"$email"}"""),
+            )
+            requested.andExpect(MockMvcResultMatchers.status().isAccepted)
+
+            val tokenResult = mockMvc.perform(
+                MockMvcRequestBuilders.get("/internal/e2e/magic-link-token").param("email", email),
+            ).andReturn()
+            val token = ObjectMapper().readTree(tokenResult.response.contentAsString)["token"].asText()
+
+            val (started, verified) = performAsync(
+                MockMvcRequestBuilders.post("/api/auth/magic-link/verify")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"token":"$token"}"""),
+            )
+            verified.andExpect(MockMvcResultMatchers.status().isOk)
+            val session = started.request.session as MockHttpSession
+
+            // Query params must be in the URI: the Wirespec adapter parses the raw query string,
+            // which MockMvc's .param() does not populate.
+            val (_, events) = performAsync(
+                MockMvcRequestBuilders.get("/api/events?include-past=false").session(session),
+            )
+            events.andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[?(@.title == 'E2E Training')]").exists())
         }
 
         test("e2e token endpoint returns 404 for an email without a requested token") {

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -6,3 +6,6 @@
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Real-e2e auth fixture (session cookie)
+/e2e-real/.auth/

--- a/app/e2e-real/attendance.spec.ts
+++ b/app/e2e-real/attendance.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+
+// Real e2e: change attendance — starts authenticated via the storageState fixture
+// (auth.setup.ts), so the spec stays focused on attendance.
+// Seams uniquely covered: authenticated-session reuse, a tenant-schema WRITE
+// (attendance mutation), and read-back persistence. List→detail navigation rides along.
+//
+// Mutation-tolerant: asserts a TRANSITION from whatever the current state is, never an
+// absolute state — re-runs against a warm local DB stay green.
+
+test('change attendance: toggle a response and it persists across a reload', async ({ page }) => {
+  // 1. Authenticated user lands on the events list directly (no login UI)
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
+
+  // 2. Open the seeded event (list → detail navigation)
+  await page.getByText('E2E Training').first().click()
+  // exact: the attendee-count tabs also match by prefix ("Going 0")
+  const going = page.getByRole('button', { name: 'Going', exact: true })
+  const maybe = page.getByRole('button', { name: 'Maybe', exact: true })
+  await expect(going).toBeVisible()
+
+  // 3. Toggle to a state different from the current one
+  const goingIsActive = (await going.getAttribute('aria-pressed')) === 'true'
+  const target = goingIsActive ? maybe : going
+  const targetName = goingIsActive ? 'Maybe' : 'Going'
+  await target.click()
+  await expect(target).toHaveAttribute('aria-pressed', 'true')
+
+  // 4. The transition survives a full reload — i.e. it was persisted, not just local state
+  await page.reload()
+  await expect(page.getByRole('button', { name: targetName, exact: true })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+    { timeout: 10_000 },
+  )
+})

--- a/app/e2e-real/auth.setup.ts
+++ b/app/e2e-real/auth.setup.ts
@@ -1,0 +1,29 @@
+import { test as setup, expect } from '@playwright/test'
+
+const TEST_EMAIL = 'e2e@example.com'
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+
+// Where the authenticated session is saved; the chromium project points storageState here.
+export const STORAGE_STATE = 'e2e-real/.auth/user.json'
+
+// Logs in ONCE via the API and saves the session as storageState, so authed specs skip the
+// login UI (which login.spec.ts already covers). The request/verify calls go through the
+// Vite origin (baseURL + /api proxy) so the session cookie lands on the frontend origin the
+// browser will use; only the token fetch talks to the backend directly.
+setup('authenticate as the seeded e2e user', async ({ request }) => {
+  const requested = await request.post('/api/auth/magic-link/request', {
+    data: { email: TEST_EMAIL },
+  })
+  expect(requested.status()).toBe(202)
+
+  const tokenResponse = await request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email: TEST_EMAIL },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+
+  const verified = await request.post('/api/auth/magic-link/verify', { data: { token } })
+  expect(verified.ok()).toBeTruthy()
+
+  await request.storageState({ path: STORAGE_STATE })
+})

--- a/app/e2e-real/login.spec.ts
+++ b/app/e2e-real/login.spec.ts
@@ -9,6 +9,9 @@ import { test, expect } from '@playwright/test'
 const TEST_EMAIL = 'e2e@example.com'
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
 
+// This spec IS the login flow — start unauthenticated, overriding the project-wide storageState.
+test.use({ storageState: { cookies: [], origins: [] } })
+
 test('magic-link login: request → verify → lands on events', async ({ page, request }) => {
   // 1. Request a magic link from the login page
   await page.goto('/login')

--- a/app/playwright.real.config.ts
+++ b/app/playwright.real.config.ts
@@ -17,7 +17,15 @@ export default defineConfig({
     baseURL: 'http://localhost:5173',
     trace: 'retain-on-failure',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    // Logs in once via the API and saves storageState (see auth.setup.ts).
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: 'e2e-real/.auth/user.json' },
+      dependencies: ['setup'],
+    },
+  ],
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:5173',

--- a/app/src/features/attendance-toggle/ui/AttendanceToggle.tsx
+++ b/app/src/features/attendance-toggle/ui/AttendanceToggle.tsx
@@ -1,35 +1,74 @@
-import { Button } from '@shared/ui/button'
-import { useSetAttendance } from '@shared/api/attendances'
+import type { ComponentType, MouseEvent } from 'react'
+import { Check, HelpCircle, X } from 'lucide-react'
 
-const STATES = [
-  { value: 'ATTENDING', label: 'Yes', className: 'bg-green text-white hover:bg-green/90' },
-  { value: 'MAYBE', label: 'Maybe', className: 'bg-gold text-white hover:bg-gold/90' },
-  { value: 'ABSENT', label: 'No', className: 'bg-red-500 text-white hover:bg-red-500/90' },
-] as const
+export type AttendanceState = 'ATTENDING' | 'MAYBE' | 'ABSENT' | 'NOT_RESPONDED'
 
-interface AttendanceToggleProps {
-  eventId: string
-  userId: string
-  currentState: string
+interface ResponseOption {
+  value: AttendanceState
+  label: string
+  icon: ComponentType<{ size?: number; className?: string }>
+  activeClass: string
+  inactiveClass: string
 }
 
-export function AttendanceToggle({ eventId, userId, currentState }: AttendanceToggleProps) {
-  const { mutate, isPending } = useSetAttendance()
+const RESPONSE_OPTIONS: ResponseOption[] = [
+  {
+    value: 'ATTENDING',
+    label: 'Going',
+    icon: Check,
+    activeClass: 'bg-green text-white border-green hover:bg-green/90',
+    inactiveClass: 'border-green/30 text-green hover:bg-green/10',
+  },
+  {
+    value: 'MAYBE',
+    label: 'Maybe',
+    icon: HelpCircle,
+    activeClass: 'bg-gold text-white border-gold hover:bg-gold/90',
+    inactiveClass: 'border-gold/30 text-gold hover:bg-gold/10',
+  },
+  {
+    value: 'ABSENT',
+    label: "Can't go",
+    icon: X,
+    activeClass: 'bg-red-500 text-white border-red-500 hover:bg-red-500/90',
+    inactiveClass: 'border-red-300 text-red-500 hover:bg-red-500/10',
+  },
+]
 
+interface AttendanceToggleProps {
+  value: AttendanceState
+  onToggle: (state: AttendanceState) => void
+  disabled?: boolean
+}
+
+// Presentational: current response + callback come in as props; the mutation lives in the
+// page container. Idle/pending/selected states are pure render args (Storybook-ready).
+export function AttendanceToggle({ value, onToggle, disabled = false }: AttendanceToggleProps) {
   return (
-    <div className="flex gap-1">
-      {STATES.map(({ value, label, className }) => (
-        <Button
-          key={value}
-          size="sm"
-          variant={currentState === value ? 'default' : 'outline'}
-          className={currentState === value ? className : ''}
-          disabled={isPending}
-          onClick={() => mutate({ eventId, userId, state: value })}
-        >
-          {label}
-        </Button>
-      ))}
+    <div className="flex gap-2.5">
+      {RESPONSE_OPTIONS.map(({ value: option, label, icon: Icon, activeClass, inactiveClass }) => {
+        const isActive = value === option
+        const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+          e.preventDefault()
+          onToggle(option)
+        }
+        return (
+          <button
+            key={option}
+            aria-pressed={isActive}
+            disabled={disabled}
+            onClick={handleClick}
+            className={[
+              'flex flex-1 items-center justify-center gap-2 rounded-xl border-2 py-3.5 text-sm font-semibold transition-all active:scale-95',
+              isActive ? activeClass : inactiveClass,
+              disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+            ].join(' ')}
+          >
+            <Icon size={18} />
+            {label}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -1,51 +1,17 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import type { ComponentType, MouseEvent } from 'react'
 import { useState } from 'react'
-import { ArrowLeft, Check, HelpCircle, MapPin, Pencil, Trash2, X } from 'lucide-react'
+import { ArrowLeft, MapPin, Pencil, Trash2 } from 'lucide-react'
 import { useEvent, type AttendanceEntry } from '@shared/api/events'
 import { useSetAttendance } from '@shared/api/attendances'
 import { useUserStore } from '@shared/stores/user-store'
 import { Button } from '@shared/ui/button'
 import { EventTypeBadge } from '@entities/event/ui/EventTypeBadge'
 import { EventTypeIcon } from '@entities/event/ui/EventTypeIcon'
+import { AttendanceToggle, type AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 
 export const Route = createFileRoute('/events/$eventId')({
   component: EventDetailPage,
 })
-
-type AttendanceState = 'ATTENDING' | 'MAYBE' | 'ABSENT' | 'NOT_RESPONDED'
-
-interface ResponseOption {
-  value: AttendanceState
-  label: string
-  icon: ComponentType<{ size?: number; className?: string }>
-  activeClass: string
-  inactiveClass: string
-}
-
-const RESPONSE_OPTIONS: ResponseOption[] = [
-  {
-    value: 'ATTENDING',
-    label: 'Going',
-    icon: Check,
-    activeClass: 'bg-green text-white border-green hover:bg-green/90',
-    inactiveClass: 'border-green/30 text-green hover:bg-green/10',
-  },
-  {
-    value: 'MAYBE',
-    label: 'Maybe',
-    icon: HelpCircle,
-    activeClass: 'bg-gold text-white border-gold hover:bg-gold/90',
-    inactiveClass: 'border-gold/30 text-gold hover:bg-gold/10',
-  },
-  {
-    value: 'ABSENT',
-    label: "Can't go",
-    icon: X,
-    activeClass: 'bg-red-500 text-white border-red-500 hover:bg-red-500/90',
-    inactiveClass: 'border-red-300 text-red-500 hover:bg-red-500/10',
-  },
-]
 
 const ATTENDEE_TABS: {
   state: AttendanceState
@@ -169,30 +135,11 @@ function EventDetailPage() {
       {currentUserId && (
         <div className="mt-6">
           <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">Your response</p>
-          <div className="flex gap-2.5">
-            {RESPONSE_OPTIONS.map(({ value, label, icon: Icon, activeClass, inactiveClass }) => {
-              const isActive = myState === value
-              const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
-                e.preventDefault()
-                mutate({ eventId, userId: currentUserId, state: value })
-              }
-              return (
-                <button
-                  key={value}
-                  disabled={isPending}
-                  onClick={handleClick}
-                  className={[
-                    'flex flex-1 items-center justify-center gap-2 rounded-xl border-2 py-3.5 text-sm font-semibold transition-all active:scale-95',
-                    isActive ? activeClass : inactiveClass,
-                    isPending ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
-                  ].join(' ')}
-                >
-                  <Icon size={18} />
-                  {label}
-                </button>
-              )
-            })}
-          </div>
+          <AttendanceToggle
+            value={myState}
+            disabled={isPending}
+            onToggle={(state) => mutate({ eventId, userId: currentUserId, state })}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## What

Phase 2 of the layered test strategy: the second real full-stack Playwright flow — **change attendance** — plus a production-path backend bug it flushed out.

Seams uniquely covered by the new flow: authenticated-session reuse (`storageState`), a **tenant-schema write** (attendance mutation through #49's routing), and read-back persistence. List→detail navigation rides along.

## Changes

**`fix(api)` — attendance re-response 500'd** (own commit): the domain→JPA mapper dropped the BIGSERIAL id, so saving an *existing* attendance INSERTed a duplicate uuid (`attendances_uuid_key` violation). Existing ITs only ever PUT once per (event, user); this e2e was the first thing to change an existing response. TDD'd: failing IT (PUT twice → one row, final state wins) → fix carries the DB id over on update.

**`feat(test)` — the phase-2 suite**:
- Seed: future event + `NOT_RESPONDED` attendance for the e2e user in `team_test` (pure INSERT, idempotent). `end_time` set — the column is nullable but the `Event` domain model is not (found via a 500 in the e2e; now guarded by a new IT that reads the seed **through the events API**, so seed↔domain mismatches fail at IT speed).
- `auth.setup.ts`: logs in once via the API (token from the e2e support endpoint) against the Vite origin, saves `storageState`; specs start authenticated. `login.spec.ts` opts out — it *is* the login flow.
- `AttendanceToggle` → presentational (`value`/`onToggle`/`disabled`, `aria-pressed`), per the plan's accepted scope; the mutation stays in the event-detail route. Storybook-ready for phase 3.
- `attendance.spec.ts` is mutation-tolerant: asserts a state *transition* that survives a reload, never absolute states — warm-DB re-runs stay green.

## Verified

- `make e2e-real`: **3 passed** (setup + login + attendance) against real FE + BE + Postgres/Redis with #49 routing.
- Full backend suite + detekt, Vitest (12), ESLint, typecheck, MSW suite — all green (pre-commit hook re-ran the lot).

## Notes

- Initial implementation drafted by a background agent; verified, debugged (three real findings: missing tenant routing → #49, seed NULL `end_time`, the attendance-update bug), and completed in-session.
- Phase 3 next: Storybook spine + `RoleBreakdown` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1YYEVptnskyffAwpdYzC6