### PR TITLE
fix(app): stop EventCard nesting the maps link inside the card link

### DIFF
--- a/app/e2e/role-breakdown.spec.ts
+++ b/app/e2e/role-breakdown.spec.ts
@@ -12,7 +12,11 @@ const ROLE_TEXT = /\d+\s+(Setter|Libero|Outside Hitter|Middle Blocker|Opposite)/
 test('event list card renders attending-by-role chips for an event with responses', async ({ page }) => {
   await page.goto('/')
 
-  const matchCard = page.locator('a[href$="/events/evt-002"]')
+  // The card is no longer a single anchor (a nested maps <a> would be invalid HTML): the title is
+  // the link, so scope to the whole card by the container that holds that link.
+  const matchCard = page.locator('.card-enter').filter({
+    has: page.locator('a[href$="/events/evt-002"]'),
+  })
   await expect(matchCard).toBeVisible()
 
   for (const chip of POPULATED_CHIPS) {
@@ -23,7 +27,9 @@ test('event list card renders attending-by-role chips for an event with response
 test('event list card shows no role chips when nobody has responded yet', async ({ page }) => {
   await page.goto('/')
 
-  const emptyCard = page.locator('a[href$="/events/evt-006"]')
+  const emptyCard = page.locator('.card-enter').filter({
+    has: page.locator('a[href$="/events/evt-006"]'),
+  })
   await expect(emptyCard).toBeVisible()
 
   // Summary still renders, but with zero going and no role chips.

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -40,3 +40,17 @@ export const NoResponses: Story = {
     ).not.toBeInTheDocument()
   },
 }
+
+export const WithLocation: Story = {
+  args: { event: makeEvent({ location: 'Sporthal De Boog' }) },
+  play: async ({ canvas, canvasElement }) => {
+    // The location renders as a real maps link that opens in a new tab...
+    const maps = canvas.getByRole('link', { name: 'Sporthal De Boog' })
+    await expect(maps).toHaveAttribute('href', expect.stringContaining('maps.google.com'))
+    await expect(maps).toHaveAttribute('target', '_blank')
+    // ...and it must NOT be nested inside the card's own <Link> anchor (invalid HTML — the
+    // "<a> cannot contain a nested <a>" warning this fix removes). The card link and the maps
+    // link are siblings; the card stays clickable via a stretched-link overlay.
+    await expect(canvasElement.querySelectorAll('a a')).toHaveLength(0)
+  },
+}

--- a/app/src/entities/event/ui/EventCard.tsx
+++ b/app/src/entities/event/ui/EventCard.tsx
@@ -12,69 +12,74 @@ export function EventCard({ event, index = 0 }: { event: Event; index?: number }
   // const relativeChip = getRelativeTimeChip(date)
 
   return (
-    <Link
-      to="/events/$eventId"
-      params={{ eventId: event.id }}
+    // Stretched-link pattern: the card itself is not an anchor. The title <Link> carries an
+    // after:inset-0 overlay that makes the whole card clickable, so the maps link can be a sibling
+    // anchor rather than a nested one (an <a> inside the card's <a> is invalid HTML).
+    <Card
       style={{ animationDelay: `${index * 60}ms` }}
-      className="card-enter block"
+      className="card-enter card-shadow relative p-4 transition-[box-shadow] hover:card-shadow-hover"
     >
-      <Card className="card-shadow p-4 transition-[box-shadow] hover:card-shadow-hover">
-        {/* Top: icon + badge/title */}
-        <div className="flex items-start gap-3.5">
-          <EventTypeIcon type={event.eventType} size="sm" />
-          <div className="min-w-0 flex-1">
-            <EventTypeBadge type={event.eventType} />
-            <p className="font-display mt-1 text-[17px] font-medium leading-tight">{event.title}</p>
-          </div>
+      {/* Top: icon + badge/title */}
+      <div className="flex items-start gap-3.5">
+        <EventTypeIcon type={event.eventType} size="sm" />
+        <div className="min-w-0 flex-1">
+          <EventTypeBadge type={event.eventType} />
+          <Link
+            to="/events/$eventId"
+            params={{ eventId: event.id }}
+            className="font-display mt-1 block text-[17px] font-medium leading-tight after:absolute after:inset-0"
+          >
+            {event.title}
+          </Link>
         </div>
+      </div>
 
-        {/* Meta: date · time · location — indented to align with title */}
-        <div className="mt-2.5 flex flex-wrap items-center gap-1 pl-[50px] text-[13px] text-muted-foreground">
-          <Calendar size={13} className="shrink-0 text-muted-foreground/60" />
-          {date.toLocaleDateString('nl-NL', { weekday: 'long', day: 'numeric', month: 'short' })}
-          {' · '}
-          {date.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit' })}
-          {event.location && (
-            <>
-              <span className="text-muted-foreground/40">·</span>
-              <MapPin size={13} className="shrink-0 text-muted-foreground/60" />
-              <a
-                href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                className="hover:text-blue hover:underline"
-              >
-                {event.location}
-              </a>
-            </>
-          )}
-        </div>
+      {/* Meta: date · time · location — indented to align with title */}
+      <div className="mt-2.5 flex flex-wrap items-center gap-1 pl-[50px] text-[13px] text-muted-foreground">
+        <Calendar size={13} className="shrink-0 text-muted-foreground/60" />
+        {date.toLocaleDateString('nl-NL', { weekday: 'long', day: 'numeric', month: 'short' })}
+        {' · '}
+        {date.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit' })}
+        {event.location && (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <MapPin size={13} className="shrink-0 text-muted-foreground/60" />
+            {/* relative z-10 lifts this above the card link's stretched overlay so it stays clickable */}
+            <a
+              href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative z-10 hover:text-blue hover:underline"
+            >
+              {event.location}
+            </a>
+          </>
+        )}
+      </div>
 
-        {/* Bottom: status + attendance summary */}
-        <div className="mt-3 border-t border-border/40 pt-3">
-          <div className="flex items-center gap-2">
-            <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
-              ✓ {s.attending} going
-            </span>
-            <span className="text-xs text-muted-foreground">
-              of {s.attending + s.maybe + s.absent + s.notResponded}
-              {s.notResponded > 0 && (
-                <> · <span className="opacity-60">{s.notResponded} pending</span></>
-              )}
-            </span>
-          </div>
-          {s.roleBreakdown.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {s.roleBreakdown.map(({ role, attending }) => (
-                <span key={role} className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                  {attending} {role}
-                </span>
-              ))}
-            </div>
-          )}
+      {/* Bottom: status + attendance summary */}
+      <div className="mt-3 border-t border-border/40 pt-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
+            ✓ {s.attending} going
+          </span>
+          <span className="text-xs text-muted-foreground">
+            of {s.attending + s.maybe + s.absent + s.notResponded}
+            {s.notResponded > 0 && (
+              <> · <span className="opacity-60">{s.notResponded} pending</span></>
+            )}
+          </span>
         </div>
-      </Card>
-    </Link>
+        {s.roleBreakdown.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {s.roleBreakdown.map(({ role, attending }) => (
+              <span key={role} className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                {attending} {role}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
   )
 }


### PR DESCRIPTION
## Problem

`EventCard` wrapped its entire body in a TanStack Router `<Link>` (an `<a>`), and the location rendered a second `<a>` to Google Maps *inside* it. Nested anchors are invalid HTML — React logged `<a> cannot contain a nested <a>` on every list render (visible throughout the e2e logs). The previous `onClick={e => e.stopPropagation()}` on the maps link masked the click behaviour but not the invalid markup.

## Fix — stretched-link pattern

- The `Card` is now a plain `relative` container, not an anchor.
- The **title** is the `<Link>`, carrying an `after:absolute after:inset-0` overlay so the whole card stays clickable.
- The **maps link** is a sibling anchor lifted above the overlay with `relative z-10`, so it remains independently clickable.

Result: two sibling anchors, no nesting, both behaviours preserved.

## Verification

- **Regression pin:** new `EventCard` `WithLocation` story asserts the maps link is a real anchor (`href`, `target=_blank`) **and** `querySelectorAll('a a')` is empty. It fails on the old markup, passes on the fix.
- `make test-app` (8 files / 29 tests), lint, typecheck, build, build-storybook — all green.
- `make e2e` — 6 passed, and the `<a> cannot contain a nested <a>` warning is **gone** (grep count 0). Card list→detail navigation still works.
- The two MSW role-breakdown specs that scoped chip assertions to the card *anchor* now scope to the card *container* (`.card-enter` filtered by the title link) — the anchor is only the title now. Test intent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)