### PR TITLE
feat(#36): auth guard on app routes (beforeLoad true gate)

### DIFF
--- a/.claude/preflight.md
+++ b/.claude/preflight.md
@@ -12,7 +12,10 @@ setup: npm --prefix app install && ./gradlew :api:wirespec-typescript  # generat
 - Stale gen across branches: switching to a branch with a different `.ws` set leaves orphaned files in `app/src/shared/api/generated/` → `tsc`/build fails on a missing export (e.g. CreateInvitation → removed Invitation model). `rm -rf app/src/shared/api/generated api/build/generated` then re-run `:api:wirespec-typescript` before frontend build.
 - mutationFns must unwrap res.body (return `res.body`, not the raw `api.*()` call) — caller mutation.data is the body, not the Wirespec envelope
 - Generated from() throws `Cannot internalize response with status: N` for undeclared status codes → React Query error state; no extra guard needed in queryFn for non-declared codes
-- MSW mocks intentionally carry role ahead of generated types (progress.txt notes which issue re-adds it to the contract)
+
+## auth / session (frontend)
+- MSW mock session state (shared/mocks/handlers.ts) must type against the generated `AuthenticatedUser` (from shared/api/auth.ts), not a hand-rolled inline literal — avoids silent drift if wirespec regenerates the contract.
+- Session-clearing mutations (logout) must write the `['auth','me']` query cache synchronously via `queryClient.setQueryData(['auth','me'], null)`, not `invalidateQueries` — invalidate triggers an async background refetch, leaving a window where AuthGuard reads stale cached (still-authenticated) data. verify.tsx's login path already uses the synchronous `setQueryData` pattern; mirror it for logout too.
 
 ## config / profiles
 - A new required `@Value` with no default (fail-fast) must be supplied in EVERY non-prod profile: application-dev.yml, test (application-test.yml), AND application-e2e.yml. CI's `scripts/e2e.sh` boots bootRun under the `e2e` profile, so a missing key there fails CI even when `:api:test` (test profile) is green. Prod relies solely on the env var.
@@ -20,7 +23,7 @@ setup: npm --prefix app install && ./gradlew :api:wirespec-typescript  # generat
 ## multitenancy / hexagonal
 - SessionTenantContextFilter must NOT inject TeamMemberRepository (domain port) — schema name is infra; inject SpringDataTeamMemberRepository directly — SessionTenantContextFilter.kt
 - Filter reads UserContext.get() (set by SessionUserContextFilter at order +2); no session re-read needed — avoids duplicate UUID parse + impossible IllegalArgumentException catch
-- TenantContext is resolved but NOT consumed (no Hibernate multi-tenant wiring; hibernate.default_schema=public) — the ThreadLocal is a placeholder until a CurrentTenantIdentifierResolver or guard filter is wired (blocker for real tenant isolation)
+- Tenant schema routing IS wired (Hibernate CurrentTenantIdentifierResolver + MultiTenantConnectionProvider, since #49) and fails closed to a non-existent schema if TenantContext is unresolved — no silent `public` fallback.
 
 ## html
 - EventCard renders location as `<a>` nested inside the outer `<Link>` `<a>` — invalid HTML; console error in Playwright run; pre-existing, tracked separately

--- a/app/e2e/auth-guard.spec.ts
+++ b/app/e2e/auth-guard.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+// Exercises the auth guard (app/src/app/providers/index.tsx) against the now-stateful MSW
+// /api/auth/me mock: logging out must clear the session and bounce protected routes back to
+// login, even on a subsequent visit — not just as a one-off redirect.
+test('logout blocks protected routes under the auth guard', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Log out' }).click()
+  await expect(page).toHaveURL('/login')
+  await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()
+
+  // Revisiting the protected route while logged out is redirected back to login, not rendered.
+  await page.goBack()
+  await expect(page).toHaveURL('/login')
+})

--- a/app/e2e/auth-guard.spec.ts
+++ b/app/e2e/auth-guard.spec.ts
@@ -1,17 +1,30 @@
 import { test, expect } from '@playwright/test'
+import { login } from './helpers'
 
-// Exercises the auth guard (app/src/app/providers/index.tsx) against the now-stateful MSW
-// /api/auth/me mock: logging out must clear the session and bounce protected routes back to
-// login, even on a subsequent visit — not just as a one-off redirect.
-test('logout blocks protected routes under the auth guard', async ({ page }) => {
+// The app boots unauthenticated (the MSW session starts empty), so the root beforeLoad guard must
+// send a cold visitor to login before any protected route renders. After magic-link sign-in the
+// member lands on events; logout returns to login and protected routes stay unreachable.
+
+test('a cold unauthenticated visit is redirected to login before events render', async ({ page }) => {
   await page.goto('/')
+
+  await expect(page).toHaveURL('/login')
+  await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()
+  // Gated: the protected events screen never rendered.
+  await expect(page.getByRole('heading', { name: 'Events' })).toHaveCount(0)
+})
+
+test('magic-link login lands on events; logout returns to login and blocks protected routes', async ({ page }) => {
+  await login(page)
+  await expect(page).toHaveURL('/')
   await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
 
   await page.getByRole('button', { name: 'Log out' }).click()
   await expect(page).toHaveURL('/login')
   await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()
 
-  // Revisiting the protected route while logged out is redirected back to login, not rendered.
-  await page.goBack()
+  // Revisiting a protected route while logged out is redirected back to login, not rendered.
+  await page.goto('/')
   await expect(page).toHaveURL('/login')
+  await expect(page.getByRole('heading', { name: 'Events' })).toHaveCount(0)
 })

--- a/app/e2e/event-type-filter.spec.ts
+++ b/app/e2e/event-type-filter.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test'
+import { login } from './helpers'
 
 // Isolate-first filter chips: from the all-active state a tap isolates that
 // type; from a subset a tap toggles it; deselecting the last chip restores all.
 test('event type chips isolate first, then toggle subsets, then restore all', async ({ page }) => {
-  await page.goto('/')
+  await login(page)
 
   const trainingChip = page.getByRole('button', { name: 'Training', exact: true })
   const matchChip = page.getByRole('button', { name: 'Match', exact: true })

--- a/app/e2e/events.spec.ts
+++ b/app/e2e/events.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test'
+import { login } from './helpers'
 
 // Drives the event list and event detail pages through real user interaction,
 // exercising the generated Wirespec client end-to-end against the MSW mocks.
 test('user can browse the event list and open an event detail', async ({ page }) => {
-  await page.goto('/')
+  await login(page)
 
   // The list page renders its heading and an upcoming event from the mocks.
   await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()

--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -1,0 +1,9 @@
+import { type Page, expect } from '@playwright/test'
+
+// Signs in through the magic-link verify flow against the MSW mock (token 'valid-token'). The mock
+// persists the session in sessionStorage, so it survives the hard navigations the specs perform
+// after logging in. Lands on the events list.
+export async function login(page: Page): Promise<void> {
+  await page.goto('/auth/verify?token=valid-token')
+  await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
+}

--- a/app/e2e/role-breakdown.spec.ts
+++ b/app/e2e/role-breakdown.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { login } from './helpers'
 
 // Renders the EventCard (list) and event-detail role-breakdown chips through the
 // real generated Wirespec client against the MSW mocks, asserting both the
@@ -10,7 +11,7 @@ const POPULATED_CHIPS = ['2 Outside Hitter', '1 Libero', '1 Opposite', '1 Setter
 const ROLE_TEXT = /\d+\s+(Setter|Libero|Outside Hitter|Middle Blocker|Opposite)/
 
 test('event list card renders attending-by-role chips for an event with responses', async ({ page }) => {
-  await page.goto('/')
+  await login(page)
 
   const matchCard = page.locator('a[href$="/events/evt-002"]')
   await expect(matchCard).toBeVisible()
@@ -21,7 +22,7 @@ test('event list card renders attending-by-role chips for an event with response
 })
 
 test('event list card shows no role chips when nobody has responded yet', async ({ page }) => {
-  await page.goto('/')
+  await login(page)
 
   const emptyCard = page.locator('a[href$="/events/evt-006"]')
   await expect(emptyCard).toBeVisible()
@@ -32,6 +33,7 @@ test('event list card shows no role chips when nobody has responded yet', async 
 })
 
 test('event detail renders the grouped role breakdown for an event with responses', async ({ page }) => {
+  await login(page)
   await page.goto('/events/evt-002')
   await expect(
     page.getByRole('heading', { name: 'League Match vs Smash United', level: 1 }),
@@ -48,6 +50,7 @@ test('event detail renders the grouped role breakdown for an event with response
 })
 
 test('event detail shows an empty breakdown when nobody has responded yet', async ({ page }) => {
+  await login(page)
   await page.goto('/events/evt-006')
   await expect(
     page.getByRole('heading', { name: 'Friendly (date TBC)', level: 1 }),

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -4,7 +4,19 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../routeTree.gen'
 import './styles/global.css'
 
-const router = createRouter({ routeTree })
+// While the root guard probes the session (and on any route load), show a brand splash rather
+// than a blank frame.
+function Splash() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <span className="font-display text-xl font-bold text-blue">
+        Team<span className="text-green">Balance</span>
+      </span>
+    </div>
+  )
+}
+
+const router = createRouter({ routeTree, defaultPendingComponent: Splash })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -1,0 +1,62 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
+import { routeTree } from '../../routeTree.gen'
+import type { AuthenticatedUser } from '@shared/api/auth'
+
+// The guard is a true render gate: a protected route must not mount (and therefore must not
+// fetch protected data) until the session is confirmed. An unconfirmed session — a 401 probe OR
+// any /me error — fails closed to the login screen.
+
+const USER: AuthenticatedUser = { id: 'user-1', email: 'jan@example.com', displayName: 'Jan', role: 'USER' }
+
+let meStatus = 401
+let eventsFetched = false
+
+const server = setupServer(
+  http.get('/api/auth/me', () =>
+    meStatus === 200 ? HttpResponse.json(USER) : new HttpResponse(null, { status: meStatus }),
+  ),
+  http.get('/api/events', () => {
+    eventsFetched = true
+    return HttpResponse.json({ events: [] })
+  }),
+  http.get('/api/event-types', () => HttpResponse.json({ eventTypes: [] })),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  meStatus = 401
+  eventsFetched = false
+})
+afterAll(() => server.close())
+
+function renderAppAt(path: string) {
+  const router = createRouter({ routeTree, history: createMemoryHistory({ initialEntries: [path] }) })
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe('auth gate', () => {
+  it('redirects an unauthenticated visitor to login without mounting the protected route', async () => {
+    meStatus = 401
+    const router = renderAppAt('/')
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/login'))
+    await waitFor(() => expect(screen.getByText(/no password/i)).toBeInTheDocument())
+    // Gated: the events route never mounted, so its protected data fetch never fired.
+    expect(eventsFetched).toBe(false)
+    expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
+  })
+
+  it('fails closed: a non-401 /me error also redirects to login and never mounts the route', async () => {
+    meStatus = 500
+    const router = renderAppAt('/')
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/login'))
+    expect(eventsFetched).toBe(false)
+    expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
+  })
+})

--- a/app/src/app/providers/index.tsx
+++ b/app/src/app/providers/index.tsx
@@ -1,19 +1,12 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useNavigate, useRouterState } from '@tanstack/react-router'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, type ReactNode } from 'react'
+import { queryClient } from '@shared/api/query-client'
 import { useAuthMe } from '@shared/api/auth'
 import { useUserStore } from '@shared/stores/user-store'
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30_000,
-      retry: 1,
-    },
-  },
-})
-
-// Keeps the user store in sync with the session — the single source of identity.
+// Keeps the user store in sync with the session — the single source of identity. Route protection
+// itself lives in the root route's beforeLoad guard (see routes/__root.tsx), which gates rendering
+// before a protected route ever mounts.
 function UserHydrator() {
   const { data } = useAuthMe()
   const setCurrentUser = useUserStore((s) => s.setCurrentUser)
@@ -25,29 +18,10 @@ function UserHydrator() {
   return null
 }
 
-// Sends unauthenticated visitors to the login screen. useAuthMe returns null on a 401 session probe;
-// the login and magic-link routes are exempt so the sign-in flow itself isn't bounced.
-function AuthGuard() {
-  const { data, isLoading, isError } = useAuthMe()
-  const navigate = useNavigate()
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
-
-  useEffect(() => {
-    if (isLoading || isError) return
-    const onAuthRoute = pathname === '/login' || pathname.startsWith('/auth')
-    if (data === null && !onAuthRoute) {
-      navigate({ to: '/login', replace: true })
-    }
-  }, [data, isLoading, isError, pathname, navigate])
-
-  return null
-}
-
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <UserHydrator />
-      <AuthGuard />
       {children}
     </QueryClientProvider>
   )

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -1,0 +1,63 @@
+import { http, HttpResponse, delay } from 'msw'
+import { setupServer } from 'msw/node'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
+import { routeTree } from '../../routeTree.gen'
+import type { AuthenticatedUser } from '@shared/api/auth'
+
+// A stateful session, mirroring the browser MSW mock (shared/mocks/handlers.ts): verify
+// establishes it, /me reflects it. The verify response is deliberately delayed relative to
+// /me's so the guard's own mount-time /me fetch (started at the same time, on the un-verified
+// session) resolves first — matching real latency, where verify does token/session work and
+// /me is a cheap read. This proves the redirect guard trusts the direct cache write from
+// verify rather than racing it with a slower background fetch.
+let session: AuthenticatedUser | null = null
+
+const USER: AuthenticatedUser = {
+  id: 'user-1',
+  email: 'jan@example.com',
+  displayName: 'Jan',
+  role: 'USER',
+}
+
+const server = setupServer(
+  http.post('/api/auth/magic-link/verify', async ({ request }) => {
+    const body = (await request.json()) as { token: string }
+    if (body.token !== 'valid-token') return new HttpResponse(null, { status: 401 })
+    await delay(10)
+    session = USER
+    return HttpResponse.json(USER)
+  }),
+  http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
+  http.get('/api/events', () => HttpResponse.json({ events: [] })),
+  http.get('/api/event-types', () => HttpResponse.json({ eventTypes: [] })),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  session = null
+})
+afterAll(() => server.close())
+
+function renderAppAt(path: string) {
+  const router = createRouter({ routeTree, history: createMemoryHistory({ initialEntries: [path] }) })
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe('magic-link verification', () => {
+  it('establishes the session and lands on events, without the guard bouncing back to login', async () => {
+    const router = renderAppAt('/auth/verify?token=valid-token')
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/'))
+    expect(await screen.findByRole('heading', { name: 'Events' })).toBeInTheDocument()
+    expect(screen.queryByText(/link expired/i)).not.toBeInTheDocument()
+  })
+
+  it('rejects an invalid token and keeps the guard from ever granting access', async () => {
+    renderAppAt('/auth/verify?token=bogus-token')
+
+    expect(await screen.findByText(/link has expired or already been used/i)).toBeInTheDocument()
+  })
+})

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -56,8 +56,11 @@ describe('magic-link verification', () => {
   })
 
   it('rejects an invalid token and keeps the guard from ever granting access', async () => {
-    renderAppAt('/auth/verify?token=bogus-token')
+    const router = renderAppAt('/auth/verify?token=bogus-token')
 
     expect(await screen.findByText(/link has expired or already been used/i)).toBeInTheDocument()
+    // Access was never granted: never navigated to the protected landing, events never rendered.
+    expect(router.state.location.pathname).toBe('/auth/verify')
+    expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })
 })

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -1,13 +1,33 @@
-import { createRootRoute, Outlet, Link, useNavigate, useRouterState } from '@tanstack/react-router'
+import { createRootRoute, redirect, Outlet, Link, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
 import { Providers } from '@app/providers'
 import { BottomNav } from '@shared/ui/BottomNav'
-import { useLogout } from '@shared/api/auth'
+import { authMeQueryOptions, useLogout } from '@shared/api/auth'
+import { queryClient } from '@shared/api/query-client'
 import { useUserStore } from '@shared/stores/user-store'
+
+// Only the sign-in routes render without a confirmed session. Exact `/auth/` prefix — not
+// startsWith('/auth') — so a future route like `/authored` can't slip past the guard.
+function isAuthRoute(pathname: string): boolean {
+  return pathname === '/login' || pathname.startsWith('/auth/')
+}
 
 export const Route = createRootRoute({
   component: RootLayout,
+  // A true gate: the session is probed before a protected route loads, so its component never
+  // mounts (and never fetches protected data) unless the session is confirmed. An unauthenticated
+  // 401 — or any /me error (fail closed) — redirects to login before render.
+  beforeLoad: async ({ location }) => {
+    if (isAuthRoute(location.pathname)) return
+    let user = null
+    try {
+      user = await queryClient.ensureQueryData(authMeQueryOptions)
+    } catch {
+      // Session could not be confirmed (network / 5xx) — fail closed.
+    }
+    if (!user) throw redirect({ to: '/login' })
+  },
 })
 
 function useViewTransitions() {

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -44,7 +44,7 @@ function LogoutButton() {
     logout.mutate(undefined, {
       onSuccess: () => {
         setCurrentUser(null)
-        queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
+        queryClient.setQueryData(['auth', 'me'], null)
         navigate({ to: '/login' })
       },
     })

--- a/app/src/shared/api/auth.ts
+++ b/app/src/shared/api/auth.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { queryOptions, useMutation, useQuery } from '@tanstack/react-query'
 import { api } from './wirespec-client'
 
 export type { AuthenticatedUser } from './generated/model/AuthenticatedUser'
@@ -29,13 +29,18 @@ export function useLogout() {
   })
 }
 
+// Shared so the root route's beforeLoad guard can prime this exact query (ensureQueryData) and
+// useAuthMe reads it back from cache — no duplicate fetch, no drifting query key. A 401 probe
+// resolves to null (unauthenticated); a non-401 error rejects and is treated as unconfirmed.
+export const authMeQueryOptions = queryOptions({
+  queryKey: ['auth', 'me'],
+  queryFn: async () => {
+    const res = await api.GetAuthMe()
+    if (res.status === 401) return null
+    return res.body
+  },
+})
+
 export function useAuthMe() {
-  return useQuery({
-    queryKey: ['auth', 'me'],
-    queryFn: async () => {
-      const res = await api.GetAuthMe()
-      if (res.status === 401) return null
-      return res.body
-    },
-  })
+  return useQuery(authMeQueryOptions)
 }

--- a/app/src/shared/api/query-client.ts
+++ b/app/src/shared/api/query-client.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query'
+
+// One shared client so the router's auth guard (root beforeLoad) and the React tree read and
+// write the same cache — the guard's session probe hydrates the very query useAuthMe subscribes to.
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+    },
+  },
+})

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -5,17 +5,28 @@ import type { AuthenticatedUser } from '../api/auth'
 // Mutable copy so mutations persist during the session
 const events = structuredClone(EVENTS)
 
-// Mock session state — a distinct identity (not a roster member) so it doesn't get pulled out
-// of any event's attendee list as the "current user". Starts authenticated so existing dev/e2e
-// flows that skip the login screen keep working; logout/verify flip it, letting the auth guard
-// actually be exercised under MSW.
-const DEFAULT_SESSION_USER: AuthenticatedUser = {
+// The one mock identity a login establishes — a distinct identity (not a roster member) so it
+// doesn't get pulled out of any event's attendee list as the "current user"; ADMIN so admin-gated
+// UI is exercisable. Used by both verify and /me, so there's a single source of truth.
+const MOCK_USER: AuthenticatedUser = {
   id: '11111111-1111-1111-1111-111111111111',
   email: 'you@example.com',
   displayName: 'You',
-  role: undefined,
+  role: 'ADMIN',
 }
-let session: AuthenticatedUser | null = DEFAULT_SESSION_USER
+
+// Session is persisted in sessionStorage so it survives page reloads (like a real session cookie),
+// letting e2e navigate with hard loads after logging in. It boots UNAUTHENTICATED — a fresh visit
+// hits the login screen, mirroring the real app — until verify establishes it. logout clears it.
+const SESSION_KEY = 'tb-mock-session'
+function readSession(): AuthenticatedUser | null {
+  const raw = sessionStorage.getItem(SESSION_KEY)
+  return raw ? (JSON.parse(raw) as AuthenticatedUser) : null
+}
+function writeSession(user: AuthenticatedUser | null): void {
+  if (user) sessionStorage.setItem(SESSION_KEY, JSON.stringify(user))
+  else sessionStorage.removeItem(SESSION_KEY)
+}
 
 function toSummary(event: MockEvent) {
   return {
@@ -147,21 +158,17 @@ export const handlers = [
     await delay(300)
     const body = (await request.json()) as { token: string }
     if (body.token === 'valid-token') {
-      session = {
-        id: MEMBERS[0].userId,
-        email: 'you@example.com',
-        displayName: MEMBERS[0].displayName,
-        role: 'ADMIN',
-      }
-      return HttpResponse.json(session)
+      writeSession(MOCK_USER)
+      return HttpResponse.json(MOCK_USER)
     }
     return new HttpResponse(null, { status: 401 })
   }),
 
-  // GET /api/auth/me — reflects mock session state so the auth guard (redirect when logged out,
-  // hydrate when logged in) can actually be exercised under MSW, not just against the real backend.
+  // GET /api/auth/me — reflects the persisted mock session so the auth guard (redirect when logged
+  // out, hydrate when logged in) is exercised under MSW, not just against the real backend.
   http.get('/api/auth/me', async () => {
     await delay(100)
+    const session = readSession()
     if (!session) return new HttpResponse(null, { status: 401 })
     return HttpResponse.json(session)
   }),
@@ -169,7 +176,7 @@ export const handlers = [
   // POST /api/auth/logout
   http.post('/api/auth/logout', async () => {
     await delay(100)
-    session = null
+    writeSession(null)
     return new HttpResponse(null, { status: 204 })
   }),
 

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse, delay } from 'msw'
 import { EVENTS, EVENT_TYPES, MEMBERS, computeRoleBreakdown, type MockEvent } from './data'
+import type { AuthenticatedUser } from '../api/auth'
 
 // Mutable copy so mutations persist during the session
 const events = structuredClone(EVENTS)
@@ -8,12 +9,13 @@ const events = structuredClone(EVENTS)
 // of any event's attendee list as the "current user". Starts authenticated so existing dev/e2e
 // flows that skip the login screen keep working; logout/verify flip it, letting the auth guard
 // actually be exercised under MSW.
-const DEFAULT_SESSION_USER = {
+const DEFAULT_SESSION_USER: AuthenticatedUser = {
   id: '11111111-1111-1111-1111-111111111111',
   email: 'you@example.com',
   displayName: 'You',
+  role: undefined,
 }
-let session: { id: string; email: string; displayName: string; role?: string } | null = DEFAULT_SESSION_USER
+let session: AuthenticatedUser | null = DEFAULT_SESSION_USER
 
 function toSummary(event: MockEvent) {
   return {

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -4,6 +4,17 @@ import { EVENTS, EVENT_TYPES, MEMBERS, computeRoleBreakdown, type MockEvent } fr
 // Mutable copy so mutations persist during the session
 const events = structuredClone(EVENTS)
 
+// Mock session state — a distinct identity (not a roster member) so it doesn't get pulled out
+// of any event's attendee list as the "current user". Starts authenticated so existing dev/e2e
+// flows that skip the login screen keep working; logout/verify flip it, letting the auth guard
+// actually be exercised under MSW.
+const DEFAULT_SESSION_USER = {
+  id: '11111111-1111-1111-1111-111111111111',
+  email: 'you@example.com',
+  displayName: 'You',
+}
+let session: { id: string; email: string; displayName: string; role?: string } | null = DEFAULT_SESSION_USER
+
 function toSummary(event: MockEvent) {
   return {
     id: event.id,
@@ -134,27 +145,29 @@ export const handlers = [
     await delay(300)
     const body = (await request.json()) as { token: string }
     if (body.token === 'valid-token') {
-      return HttpResponse.json({
+      session = {
         id: MEMBERS[0].userId,
         email: 'you@example.com',
         displayName: MEMBERS[0].displayName,
         role: 'ADMIN',
-      })
+      }
+      return HttpResponse.json(session)
     }
     return new HttpResponse(null, { status: 401 })
   }),
 
-  // GET /api/auth/me — mock an authenticated session so the app's main screens render under MSW.
-  // A distinct identity (not a roster member) so it doesn't get pulled out of any event's
-  // attendee list as the "current user".
+  // GET /api/auth/me — reflects mock session state so the auth guard (redirect when logged out,
+  // hydrate when logged in) can actually be exercised under MSW, not just against the real backend.
   http.get('/api/auth/me', async () => {
     await delay(100)
-    return HttpResponse.json({ id: '11111111-1111-1111-1111-111111111111', email: 'you@example.com', displayName: 'You' })
+    if (!session) return new HttpResponse(null, { status: 401 })
+    return HttpResponse.json(session)
   }),
 
   // POST /api/auth/logout
   http.post('/api/auth/logout', async () => {
     await delay(100)
+    session = null
     return new HttpResponse(null, { status: 204 })
   }),
 


### PR DESCRIPTION
## What

Protects the app's routes so an unauthenticated visitor is sent to login and an authenticated member lands in their team's events — implemented as a **true gate** in the root route's `beforeLoad`, not a post-render redirect.

Closes #36.

## How

- **True gate (`beforeLoad`)** — the session is probed via `ensureQueryData(authMeQueryOptions)` *before* a protected route loads, so its component never mounts (and never fetches protected data) until the session is confirmed. A component-render guard was measurably leaky: toggling `<Outlet/>` re-mounts the stale route match mid-redirect and fires its data fetch.
- **Fail closed** — a 401 (→ `null`) *or* any `/me` error redirects to `/login`.
- **Exact `/auth/` prefix** for the sign-in exemption (no `/authored`-style bypass).
- **MSW boots unauthenticated** and persists the session in `sessionStorage` (like a real cookie, surviving reloads), so a cold visit hits login as in the real app. One non-roster ADMIN `MOCK_USER` backs both `verify` and `/me`.
- **Shared `queryClient`** so the guard primes the exact cache `useAuthMe` reads; brand `Splash` as the router pending component.

## Acceptance criteria

- [x] Visiting a protected route while unauthenticated redirects to login
- [x] On load, current-user hydrates from `GET /api/auth/me`; a valid session skips login
- [x] After login, the member lands in their team's events
- [x] Logout returns to login and protected routes are no longer reachable

## Test plan

- `auth-gate.test` — proves the gate blocks the protected fetch and fails closed on a `/me` error
- `auth-guard.spec` (e2e) — cold-unauth → login, plus the full login → logout → still-gated loop
- e2e specs log in via a new `login()` helper first
- Full suite green: **vitest 20/20**, typecheck, lint, **e2e 8/8**

## Demo

A recorded walkthrough (cold visit → gated to login → magic-link sign-in → events → logout → still gated) is attached in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM7RECSwngWsW2sb375vSG
