### PR TITLE
docs: ADR-0011 — Google Sign-In via verified-email linking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,10 +60,17 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 - **Hall of Fame (Toppers 🏆)** / **Hall of Shame (Floppers 🐷)** — Side-by-side
   contributor rankings over a period (last 30 days or full season).
 
-### Identity & onboarding ([ADR-0008](docs/adr/0008-auth-magic-link-and-shareable-invite.md))
+### Identity & onboarding ([ADR-0008](docs/adr/0008-auth-magic-link-and-shareable-invite.md), [ADR-0011](docs/adr/0011-add-google-signin-verified-email-linking.md))
 
-- **Magic Link** — A one-time, passwordless login link sent to a member's email.
-  v1's authentication mechanism. Sessions are server-side (Spring Session + Redis).
+- **Magic Link** — A one-time, passwordless login link sent to a member's email. One of
+  two passwordless authentication methods (the other is **Google Sign-In**); both prove
+  control of an email. Sessions are server-side — in-memory `HttpSession` (`JSESSIONID`)
+  for 1.0; Redis-backed Spring Session is deferred ([ADR-0010](docs/adr/0010-defer-redis-sessions-to-post-1.0.md)).
+- **Google Sign-In** — Authenticating with a Google account. Treated as a second proof of
+  email control equivalent to a **Magic Link**: a Google login lands in the *same* account,
+  matched on verified email. There is no separate "Google account" in the model.
+  Deliberately **no passwords** — email control is the only proof v1 accepts.
+  _Avoid_: OAuth login, social login, password.
 - **Invite Link** — A single shareable link an admin generates to onboard members into
   an existing Team. Clicking it → enter email → Magic Link → joined. One link, many
   joiners; can expire/rotate.

--- a/docs/adr/0011-add-google-signin-verified-email-linking.md
+++ b/docs/adr/0011-add-google-signin-verified-email-linking.md
@@ -1,0 +1,80 @@
+# ADR-0011: Add Google Sign-In via verified-email linking; no passwords
+
+- Status: Accepted
+- Date: 2026-07-14
+- Amends: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (which chose magic-link
+  and explicitly excluded "passwords, no third-party OAuth provider")
+
+## Context
+
+ADR-0008 chose magic-link as the sole authentication method and ruled out both passwords
+and third-party OAuth. Two additions were proposed: username/password (for faster repeat
+logins) and Google sign-in. Grilling showed the password motivation was really *dev-loop
+friction* (fetching a token on every local login), not a user need — and that magic-link
+already covers the "no Google account" segment. Password auth would add permanent cost
+(hashing, reset flow — which needs email anyway, lockout, breach liability) to solve a
+problem that long-lived sessions + a dev-only login shortcut solve for free.
+
+## Decision
+
+**Cut username/password. Add Google sign-in as a second passwordless method. Reopen
+ADR-0008 only for Google — not passwords.**
+
+- **Identity model — Google is another proof of email control.** A Google login with
+  `email_verified == true` proves the same thing a magic link proves: control of an
+  email. So it lands in the *same* account, matched on verified email via the existing
+  find-or-create-by-email path. **No new schema, no identities/`google_sub` table, no
+  identity-provider abstraction.** One identity, two front doors.
+- **Email is the join key, normalized.** Introduce an `Email` value object that
+  normalizes `trim().lowercase()`, used by *both* methods so the match is reliable. This
+  fixes a pre-existing gap (magic-link stored email as-typed; `users.email` is a
+  case-sensitive `UNIQUE VARCHAR`, so `Alice@…` and `alice@…` were distinct rows). Add a
+  lowered-unique-index / `citext` guard on the column. No provider-specific rules (no
+  Gmail dot/`+tag` stripping). Cost-free now under ADR-0005 (clean start, no migration).
+- **Flow: backend-verified Google ID token (Google Identity Services), identity-only.**
+  The SPA's Google button yields an ID token; the frontend POSTs it to
+  `POST /api/auth/google/verify`; the backend verifies it and establishes the session
+  exactly like magic-link verify. Verification uses `GoogleIdTokenVerifier`
+  (`com.google.api-client:google-api-client`, 2.x) behind a domain port
+  (`GoogleIdentityVerifier`) — the same "abstract the third party behind a port" pattern
+  as Bunq, so `AuthService` stays framework-free and unit-testable with a fake. The one
+  business rule on top of the library's signature/`aud`/`iss`/`exp` checks: reject unless
+  `email_verified == true` (the account-takeover guard).
+- **No Google API access, so no client secret and no auth-code flow.** Only the public
+  client ID is needed (frontend `VITE_GOOGLE_CLIENT_ID`; backend
+  `teambalance.auth.google.client-id` feeds the verifier's audience).
+- **Google is optional, gated on config.** If the client ID is unset, the button hides
+  and the endpoint is disabled. Dev, tests, and self-hosters without a Google project run
+  magic-link-only, unchanged (supports ADR-0001's self-hostable ethos).
+- **Enrichment on create only.** A user created via Google gets `displayName` and
+  `avatar_url` from the token; an existing user logging in via Google is never mutated —
+  login only establishes the session.
+- **Onboarding unchanged and out of scope.** Google is symmetric with magic-link verify;
+  it neither builds nor changes invite-accept (#37). A new email with no team hits the
+  same `NoTeamMembershipException` dead-end magic-link produces today. **Forward
+  constraint on #37:** invite-acceptance must be login-method-agnostic (attach the
+  currently-authenticated user to the team, regardless of how they signed in), so Google
+  onboarding comes for free rather than needing a retrofit.
+
+## Considered Options
+
+- **Separate Google identities / explicit "connect Google" linking** — rejected: creates
+  the "why do I have two accounts?" problem and needs schema + UI for a threat model we
+  don't have. Verified email is a sound join key.
+- **Backend authorization-code / OIDC flow** — rejected: its only advantage is Google API
+  access + refresh tokens we don't need; it costs a client secret and redirect plumbing.
+- **Hand-rolled Nimbus JWKS verification** — rejected: easy to omit `aud`/`email_verified`
+  and open a hole; the official verifier makes those checks the library's job.
+
+## Consequences
+
+- We cannot tell *how* a user authenticated after the fact (no per-provider audit trail),
+  and a future "disconnect Google" action would require adding the identities table then.
+  Accepted for v1.
+- **Adopting Spring Security is a separate decision** (its own ADR/grilling), not part of
+  this work. Flow (B) needs no Spring Security; if adopted later, Google verification
+  becomes a filter/provider in the chain with the same verification logic.
+- **Test gap:** no automated test exercises a real Google-signed token end-to-end. Above
+  the `GoogleIdentityVerifier` port everything is tested with a fake (unit + Testcontainers
+  integration); Google is mocked in the MSW/Playwright e2e; the real adapter is covered by
+  one focused adapter test + manual verification. Logged in the layered-test-strategy plan.


### PR DESCRIPTION
Records the design decided in a `/grill-with-docs` session for **Google Sign-In** (implemented via #69).

## What's in this PR (docs only)
- **`docs/adr/0011-...md`** — amends ADR-0008. Cut username/password; add Google Sign-In as a second passwordless method that lands in the **same account**, matched on a normalized **verified email** (no new schema, no identity table, no client secret). Records the ID-token flow (Google Identity Services), the `GoogleIdentityVerifier` port, enrich-on-create, config-gating, and the onboarding/Spring-Security scope boundaries.
- **`CONTEXT.md`** — adds the **Google Sign-In** glossary term (equivalent proof of email control to a Magic Link) and reconciles the Magic Link session note with ADR-0010 (in-memory `HttpSession` for 1.0, not Redis).

## Not in this PR
- No implementation — that's tracked by **#69** (`ready-for-agent`), plan at `docs/plans/2026-07-14-google-signin.md`.
- Plan docs are not committed, per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)