### PR TITLE
docs: codify test taxonomy, PR gate, and make e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,10 @@ make infra          # Start all infra (Postgres + Redis)
 make api            # Run backend (port 8080)
 make app            # Run frontend dev server (port 5173)
 make run-local      # Start infra + backend + frontend
-make test           # Run all tests
+make test           # Fast inner loop: test-api + test-app (no full-stack e2e)
 make test-api       # Backend tests only
-make test-app       # Frontend tests only
+make test-app       # Frontend tests only (Vitest: units + Storybook stories)
+make e2e            # Real full-stack Playwright suite (requires infra + port 8080 free)
 make lint           # Lint everything (detekt + ESLint)
 make format         # Auto-format code
 make wirespec       # Regenerate API contracts from .wirespec files
@@ -92,6 +93,33 @@ free of regressions. Self-verification is encouraged by spinning up the applicat
 either through its endpoint, or through the UI. 
 
 Every change made must deliver proof that it delivers the intended value and does not introduce regression.
+
+## Testing
+
+Four honest layers — place each new test at the **lowest layer that proves it**:
+
+| Layer | Command | What it covers |
+|-------|---------|----------------|
+| Backend unit / IT | `make test-api` | Kotlin units + Testcontainers integration tests |
+| Frontend pure logic | `make test-app` | Vitest (jsdom): mappers, adapters, stores |
+| Component states | `make test-app` | Vitest + Storybook addon (headless): empty/loading/data/error stories |
+| Real e2e | `make e2e` | Full-stack Playwright: login flow + change-attendance flow |
+
+`make test` = `test-api` + `test-app` — the fast everyday inner loop. Full-stack e2e is excluded; run `make e2e` explicitly.
+
+### PR gate
+
+> **When adding or changing a feature, place its coverage at the lowest layer that proves it:**
+> - Component states (empty/loading/data/error) → a Storybook story.
+> - Pure logic (mappers, adapters, stores) → a Vitest unit.
+> - Backend behaviour → a Kotest unit or Testcontainers IT.
+> - **A new e2e is justified *only* if the change introduces a seam not already exercised by the login or attendance flows** (new auth path, new cross-tenant write, new external integration). If it does, add one flow. If it doesn't, say so in the PR.
+
+### Sanctioned MSW/RTL exception
+
+The two auth render-gate Vitest tests (`app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx`) use `msw/node` to render the auth provider under controlled network conditions. They are the **single sanctioned exception** to the "Vitest owns only pure non-rendering logic" rule: the auth routing seam (fail-closed on error, verify-vs-/me race) cannot be forced into a meaningful failure state against a real backend, and it is not story-able. Do not remove them or use them as precedent for new RTL render tests.
+
+See [`docs/testing.md`](docs/testing.md) for command mechanics, the Vitest/Storybook bright line, and real-e2e gotchas.
 
 ## Agent skills
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,93 @@
+# Testing
+
+Reference for the four-layer test pyramid. See `CLAUDE.md § Testing` for the PR gate and taxonomy rules.
+
+## Command surface
+
+| Target | Runs | Speed |
+|--------|------|-------|
+| `make test-api` | Kotlin units + Testcontainers ITs (real Postgres) | moderate |
+| `make test-app` | Vitest: jsdom unit project **+ Storybook** (headless-chromium, via Vitest addon) | fast |
+| `make e2e` | Real full-stack Playwright: `make infra` → `bootRun` → seed → 2 flows | slow |
+| `make test` | `test-api` + `test-app` — everyday inner loop, **no full-stack e2e** | fast |
+
+## Vitest / Storybook bright line
+
+**Vitest (jsdom) owns only pure, non-rendering logic:** mappers, adapters, stores, utility functions. No component rendering, no RTL, no DOM assertions.
+
+**Storybook owns everything that renders.** A component's states (empty/loading/data/error, disabled, variants) live as `.stories.tsx` files co-located with the component, and the Storybook Vitest addon runs them headlessly under `make test-app`.
+
+This is the enforced split: if it renders, it belongs in a story, not a Vitest unit.
+
+### Sanctioned exception
+
+The two auth render-gate tests (`app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx`) use `msw/node` to render the auth provider under controlled 500/204 network conditions. The auth routing seam — fail-closed on network error, race between verify and /me — cannot be forced into a meaningful failure state against a real backend, and it is not story-able (depends on React Router state and network interception beyond a story's reach). These are the **single sanctioned exception** to the no-RTL rule. Do not treat them as precedent.
+
+## What is deliberately not tested
+
+The following are not covered, and that is intentional:
+
+- **`shared/api/*` TanStack Query hooks** — thin wrappers over Wirespec-generated calls; the seam they exercise (HTTP → server) is covered by e2e.
+- **`shared/ui/*` shadcn primitives** — third-party components with their own test suites; wrapping them in stories adds no signal.
+- **`shared/lib/utils.cn`** — a one-liner re-export of clsx + tailwind-merge; trivial.
+
+## How to run each layer
+
+```bash
+# Backend
+make test-api                   # all backend tests (Kotlin units + Testcontainers ITs)
+
+# Frontend (fast)
+make test-app                   # Vitest unit project + Storybook stories (headless)
+
+# Real full-stack e2e
+make infra                      # ensure Postgres + Redis are up
+make e2e                        # boots backend, runs Playwright, kills backend
+
+# Fast inner loop (no e2e)
+make test                       # test-api + test-app
+```
+
+## Real e2e internals
+
+**Entry point:** `app/e2e-real/` + `playwright.real.config.ts`. `make e2e` runs `scripts/e2e.sh`, which:
+1. Reuses whatever is listening on :5432/:6379 (CI service containers) or docker-compose ups them.
+2. Boots `bootRun --spring.profiles.active=e2e` and health-gates on `/internal/actuator/health`.
+3. Runs Playwright, then kills the backend by port (the bootRun JVM is a daemon child, not the gradlew pid).
+
+**`e2e` Spring profile:** `E2eEnvironmentInitializer` (ApplicationRunner, after Flyway) provisions the `team_test` tenant schema and runs a pure-INSERT idempotent `db/e2e/seed.sql` (one user: `e2e@example.com`). The `/internal/e2e/magic-link-token` endpoint returns the plaintext token recorded by `RecordingEmailSender` (@Primary @Profile("e2e")).
+
+**Flows covered:** login (magic-link → verify → `/events`) + change-attendance (authed via `storageState` → open event → toggle → assert persisted transition). These two flows exercise browser→API→DB, auth handshake + session cookie, tenant-schema resolution, and a mutation round-trip.
+
+## Gotchas
+
+### Token race (single-seeded user)
+
+The magic-link token recorder is last-write-wins per email (`ConcurrentHashMap<email, token>`), and the seed has one user (`e2e@example.com`). Two concurrent in-test logins for that email (login spec + a logout spec on different Playwright workers) race — one consumes the other's token.
+
+**Fix:** mint session-mutating specs' sessions in the **serial setup phase** (`auth.setup.ts`) as separate `storageState` files (`user.json` shared, `logout-user.json` disposable), not via in-test fresh logins. Each setup creates an independent server-side session, so logging out the disposable one never kills the shared session the attendance spec reuses.
+
+### CI timeout on auth render-gate tests
+
+The auth render-gate jsdom tests (`verify-flow`, `auth-gate`) flake in CI at RTL's default 1000ms `findBy`/`waitFor` timeout — the "lands on events" chain (10ms verify delay → cache write → redirect → events route mount) can exceed 1000ms on a loaded runner. Pass explicit `{ timeout: 5000 }` to router/render assertions in these tests. Do not rely on the 1000ms default for any `msw/node` router-render assertion.
+
+### Colima env for Testcontainers
+
+`make test-api` runs Testcontainers (real Postgres). On this machine, Colima manages Docker. The pre-commit hook runs `make test-api` unconditionally, so the Colima env must be active:
+
+```
+DOCKER_HOST=unix:///Users/<you>/.colima/default/docker.sock
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+TESTCONTAINERS_RYUK_DISABLED=true
+```
+
+`make e2e` also needs Docker up (`docker info`) and ports 5432/6379/8080 free.
+
+### Fresh-worktree setup
+
+When working in a git worktree, two extra steps are required before the pre-commit gate will pass:
+
+```bash
+npm ci --prefix <worktree>/app                              # node_modules are not shared
+./gradlew -p <worktree> :api:wirespec-typescript            # generated TS client is gitignored
+```


### PR DESCRIPTION
## Summary

- Adds a **Testing** section to `CLAUDE.md` with the four-layer taxonomy (backend IT / Vitest pure logic / Storybook component states / real Playwright e2e), the PR gate blockquote, the new-e2e growth rule, and the sanctioned MSW/RTL exception
- Adds `make e2e` to the Common-commands block and clarifies that `make test` excludes full-stack e2e
- Creates `docs/testing.md` with the command table, the Vitest/Storybook bright line, the deliberately-untested list, and real-e2e internals + gotchas (token race, CI timeout, colima env, fresh-worktree setup)

Closes the layered test strategy initiative (phase 6 of 6 — docs-only). Depends on #68 (merged).

## Test plan

- [ ] Pre-commit gate passed: detekt + ESLint + `make test` (53 tests) + `make e2e` (6 real flows, all green)
- [ ] `CLAUDE.md` Guardrails/ArchUnit line unchanged (flock-detekt #17 not merged yet)
- [ ] No plan files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9Dy9EXW1rX71GPdmBaLsE