### PR TITLE
refactor: use clock.instant() instead of Instant.now(clock)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -26,7 +26,7 @@ class AttendanceService(
         val existing = attendanceRepository.findByEventIdAndUserId(eventId, userId)
         return if (existing != null) {
             attendanceRepository.save(
-                existing.copy(state = state, updatedAt = Instant.now(clock), changedBy = changedBy),
+                existing.copy(state = state, updatedAt = clock.instant(), changedBy = changedBy),
             )
         } else {
             attendanceRepository.save(
@@ -35,7 +35,7 @@ class AttendanceService(
                     eventId = eventId,
                     userId = userId,
                     state = state,
-                    updatedAt = Instant.now(clock),
+                    updatedAt = clock.instant(),
                     changedBy = changedBy,
                 ),
             )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -29,7 +29,7 @@ class AuthService(
 
     fun requestMagicLink(email: String) {
         val token = generateToken()
-        val now = Instant.now(clock)
+        val now = clock.instant()
         magicLinkTokenRepository.save(
             MagicLinkToken(
                 id = UUID.randomUUID(),
@@ -46,7 +46,7 @@ class AuthService(
     fun findUserById(id: UUID): User? = userRepository.findById(id)
 
     fun verifyMagicLink(token: String): User? {
-        val now = Instant.now(clock)
+        val now = clock.instant()
         val record = magicLinkTokenRepository.findByTokenHash(hash(token))
             ?.takeIf { it.usedAt == null && it.expiresAt.isAfter(now) }
             ?: return null

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -29,7 +29,7 @@ class EventService(
     }
 
     fun getUpcomingEvents(): List<Event> {
-        val since = Instant.now(clock).minus(GRACE_PERIOD)
+        val since = clock.instant().minus(GRACE_PERIOD)
         return eventRepository.findUpcoming(since)
     }
 
@@ -53,7 +53,7 @@ class EventService(
                 endTime = potential.endTime,
                 location = potential.location,
                 createdBy = createdBy,
-                createdAt = Instant.now(clock),
+                createdAt = clock.instant(),
             ),
         )
 
@@ -64,7 +64,7 @@ class EventService(
                 eventId = event.id,
                 userId = member.userId,
                 state = AttendanceState.NOT_RESPONDED,
-                updatedAt = Instant.now(clock),
+                updatedAt = clock.instant(),
                 changedBy = createdBy,
             )
         }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.security.MessageDigest
@@ -18,6 +19,7 @@ data class GeneratedInvitation(val token: String, val expiresAt: Instant)
 @Service
 class InvitationService(
     private val invitationRepository: InvitationRepository,
+    private val teamMemberRepository: TeamMemberRepository,
     private val clock: Clock,
     // App-wide secret mixed into the token hash. Supplied via INVITATION_TOKEN_SALT in live
     // environments (see application.yml); dev and test use a hardcoded value.
@@ -52,6 +54,21 @@ class InvitationService(
             ),
         )
         return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
+    }
+
+    /**
+     * Joins the presenting user to the invitation's team. Returns null for an unknown or expired
+     * token (rotated/revoked tokens will read the same way once #38 lands) so the controller can
+     * answer with a plain 404 — no distinction is made between "never existed" and "expired" to
+     * avoid leaking which is the case.
+     */
+    fun acceptInvitation(token: String, userId: UUID): UUID? {
+        val now = Instant.now(clock)
+        val invitation = invitationRepository.findByTokenHash(hashToken(token))
+            ?.takeIf { it.expiresAt.isAfter(now) }
+            ?: return null
+        teamMemberRepository.addMember(invitation.teamId, userId)
+        return invitation.teamId
     }
 
     private fun generateToken(): String {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -41,7 +41,7 @@ class InvitationService(
      * rotate/expire to invalidate them.
      */
     fun generateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
-        val now = Instant.now(clock)
+        val now = clock.instant()
         val token = generateToken()
         invitationRepository.save(
             Invitation(
@@ -63,7 +63,7 @@ class InvitationService(
      * avoid leaking which is the case.
      */
     fun acceptInvitation(token: String, userId: UUID): UUID? {
-        val now = Instant.now(clock)
+        val now = clock.instant()
         val invitation = invitationRepository.findByTokenHash(hashToken(token))
             ?.takeIf { it.expiresAt.isAfter(now) }
             ?: return null

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/UnauthenticatedException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/UnauthenticatedException.kt
@@ -1,0 +1,3 @@
+package com.github.zzave.teambalance.api.domain.exception
+
+class UnauthenticatedException(message: String) : RuntimeException(message)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -4,4 +4,5 @@ import com.github.zzave.teambalance.api.domain.model.Invitation
 
 interface InvitationRepository {
     fun save(invitation: Invitation): Invitation
+    fun findByTokenHash(tokenHash: String): Invitation?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -14,4 +14,7 @@ interface TeamMemberRepository {
 
     /** The team the user actively belongs to, or null if they have no team (v1: one team per user). */
     fun findTeamId(userId: UUID): UUID?
+
+    /** Joins the user to the team as a USER. No-op if already an active member of this team. */
+    fun addMember(teamId: UUID, userId: UUID)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContext.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContext.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.infrastructure.identity
 
+import com.github.zzave.teambalance.api.domain.exception.UnauthenticatedException
 import java.util.UUID
 
 object UserContext {
@@ -7,6 +8,6 @@ object UserContext {
 
     fun set(userId: UUID) = current.set(userId)
     fun get(): UUID? = current.get()
-    fun require(): UUID = current.get() ?: throw IllegalStateException("No user in context")
+    fun require(): UUID = current.get() ?: throw UnauthenticatedException("No user in context")
     fun clear() = current.remove()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -13,4 +13,7 @@ class JpaInvitationRepositoryAdapter(
 
     override fun save(invitation: Invitation): Invitation =
         jpaRepository.save(invitation.externalize()).internalize()
+
+    override fun findByTokenHash(tokenHash: String): Invitation? =
+        jpaRepository.findByTokenHash(tokenHash)?.internalize()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -4,7 +4,9 @@ import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.TeamMemberJpaEntity
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Repository
@@ -46,8 +48,14 @@ class JpaTeamMemberRepositoryAdapter(
     override fun findTeamId(userId: UUID): UUID? =
         jpaRepository.findTeamIdByUserId(userId)
 
+    @Suppress("SwallowedException") // intentional: concurrent accept or inactive-member conflict is a no-op
+    @Transactional
     override fun addMember(teamId: UUID, userId: UUID) {
         if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId) != null) return
-        jpaRepository.save(TeamMemberJpaEntity(teamId = teamId, userId = userId, role = Role.USER.name))
+        try {
+            jpaRepository.save(TeamMemberJpaEntity(teamId = teamId, userId = userId, role = Role.USER.name))
+        } catch (e: DataIntegrityViolationException) {
+            // Concurrent accept or inactive-member row conflict — already a member, no-op
+        }
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.TeamMemberJpaEntity
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -13,6 +14,7 @@ import java.util.UUID
 class JpaTeamMemberRepositoryAdapter(
     private val jpaRepository: SpringDataTeamMemberRepository,
 ) : TeamMemberRepository {
+    private val logger = LoggerFactory.getLogger(JpaTeamMemberRepositoryAdapter::class.java)
 
     override fun findByTeamId(teamId: UUID): List<TeamMember> =
         jpaRepository.findByTeamIdAndActiveTrue(teamId).map { entity ->
@@ -48,7 +50,6 @@ class JpaTeamMemberRepositoryAdapter(
     override fun findTeamId(userId: UUID): UUID? =
         jpaRepository.findTeamIdByUserId(userId)
 
-    @Suppress("SwallowedException") // intentional: concurrent accept or inactive-member conflict is a no-op
     @Transactional
     override fun addMember(teamId: UUID, userId: UUID) {
         if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId) != null) return
@@ -56,6 +57,10 @@ class JpaTeamMemberRepositoryAdapter(
             jpaRepository.save(TeamMemberJpaEntity(teamId = teamId, userId = userId, role = Role.USER.name))
         } catch (e: DataIntegrityViolationException) {
             // Concurrent accept or inactive-member row conflict — already a member, no-op
+            logger.info(
+                "Failed to add member to team because of a conflic. " +
+                        "This signals that the user is already a member, no biggy", e
+            )
         }
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.TeamMemberJpaEntity
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -44,4 +45,9 @@ class JpaTeamMemberRepositoryAdapter(
 
     override fun findTeamId(userId: UUID): UUID? =
         jpaRepository.findTeamIdByUserId(userId)
+
+    override fun addMember(teamId: UUID, userId: UUID) {
+        if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId, userId) != null) return
+        jpaRepository.save(TeamMemberJpaEntity(teamId = teamId, userId = userId, role = Role.USER.name))
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -4,4 +4,6 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.entity.Invita
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID>
+interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
+    fun findByTokenHash(tokenHash: String): InvitationJpaEntity?
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.interfaces
 import com.github.zzave.teambalance.api.domain.exception.ForbiddenException
 import com.github.zzave.teambalance.api.domain.exception.NotFoundException
 import com.github.zzave.teambalance.api.domain.exception.TeambalanceException
+import com.github.zzave.teambalance.api.domain.exception.UnauthenticatedException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -11,6 +12,11 @@ import java.time.format.DateTimeParseException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
+
+    @ExceptionHandler(UnauthenticatedException::class)
+    fun handleUnauthenticated(ex: UnauthenticatedException): ResponseEntity<Map<String, String>> =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to (ex.message ?: "Unauthorized")))
 
     @ExceptionHandler(NotFoundException::class)
     fun handleNotFound(ex: NotFoundException): ResponseEntity<Map<String, String>> =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -4,7 +4,9 @@ import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.InvitationService
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.model.AcceptedInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.Invitation
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,7 +16,8 @@ class InvitationController(
     private val currentUserProvider: CurrentUserProvider,
     private val currentTeamProvider: CurrentTeamProvider,
     private val authorizationService: AuthorizationService,
-) : CreateInvitation.Handler {
+) : CreateInvitation.Handler,
+    AcceptInvitation.Handler {
 
     override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
@@ -28,5 +31,12 @@ class InvitationController(
                 expiresAt = invitation.expiresAt.toString(),
             ),
         )
+    }
+
+    override suspend fun acceptInvitation(request: AcceptInvitation.Request): AcceptInvitation.Response<*> {
+        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = invitationService.acceptInvitation(request.path.token, userId)
+            ?: return AcceptInvitation.Response404(Unit)
+        return AcceptInvitation.Response200(AcceptedInvitation(teamId = teamId.toString()))
     }
 }

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -3,6 +3,15 @@ type Invitation {
     expiresAt: String
 }
 
+type AcceptedInvitation {
+    teamId: String
+}
+
 endpoint CreateInvitation POST /api/invitations -> {
     201 -> Invitation
+}
+
+endpoint AcceptInvitation POST /api/invitations/{token: String}/accept -> {
+    200 -> AcceptedInvitation
+    404 -> Unit
 }

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -13,5 +13,6 @@ endpoint CreateInvitation POST /api/invitations -> {
 
 endpoint AcceptInvitation POST /api/invitations/{token: String}/accept -> {
     200 -> AcceptedInvitation
+    401 -> Unit
     404 -> Unit
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -15,6 +15,7 @@ private class FakeTeamMemberRepository(private val roles: Map<Pair<UUID, UUID>, 
     override fun findMembersByUserIds(userIds: Set<UUID>) = emptyMap<UUID, TeamMember>()
     override fun findRole(teamId: UUID, userId: UUID): Role? = roles[teamId to userId]
     override fun findTeamId(userId: UUID): UUID? = null
+    override fun addMember(teamId: UUID, userId: UUID) = Unit
 }
 
 class AuthorizationServiceTest : FunSpec() {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -15,6 +15,8 @@ import java.security.MessageDigest
 
 private const val JAN_USER_ID = "c0000000-0000-0000-0000-000000000001"
 private const val LISA_USER_ID = "c0000000-0000-0000-0000-000000000002"
+private const val JOINER_USER_ID = "c0000000-0000-0000-0000-000000000003"
+private const val EXPIRED_JOINER_USER_ID = "c0000000-0000-0000-0000-000000000004"
 private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
 
 // Must match application-test.yml (teambalance.invitation.token-salt).
@@ -51,6 +53,21 @@ class InvitationControllerTest : TeamBalanceIT() {
         jdbcTemplate.execute(
             "INSERT INTO public.team_members (team_id, user_id, role, team_role) " +
                 "VALUES ('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'ADMIN', 'Setter') ON CONFLICT DO NOTHING",
+        )
+    }
+
+    /** Inserts an invitation row directly (bypassing generateInviteLink) so tests control its expiry. */
+    private fun seedInvitation(plaintextToken: String, expiresAt: String = "2099-01-01T00:00:00Z") {
+        jdbcTemplate.execute(
+            "INSERT INTO public.invitations (team_id, token, created_by, expires_at) " +
+                "VALUES ('$TEAM_ID'::uuid, '${sha256Hex(TEST_SALT, plaintextToken)}', '$JAN_USER_ID'::uuid, '$expiresAt'::timestamptz)",
+        )
+    }
+
+    private fun seedJoiner(userId: String, email: String) {
+        jdbcTemplate.execute(
+            "INSERT INTO public.users (id, email, display_name) " +
+                "VALUES ('$userId'::uuid, '$email', 'New Joiner') ON CONFLICT DO NOTHING",
         )
     }
 
@@ -126,6 +143,71 @@ class InvitationControllerTest : TeamBalanceIT() {
 
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("POST /api/invitations/{token}/accept adds the authenticated user as a team_member") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "joiner-accept@test.com")
+            seedInvitation("plaintext-accept-token")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-accept-token/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.teamId").value(TEAM_ID))
+
+            val memberRows = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members " +
+                    "WHERE team_id = ?::uuid AND user_id = ?::uuid AND role = 'USER' AND active = true",
+                Long::class.java,
+                TEAM_ID,
+                JOINER_USER_ID,
+            )
+            memberRows shouldBe 1L
+        }
+
+        test("POST /api/invitations/{token}/accept with an unknown token is rejected with 404") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "joiner-unknown@test.com")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/does-not-exist/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+        }
+
+        test("POST /api/invitations/{token}/accept with an expired token is rejected with 404") {
+            seedAdmin()
+            seedJoiner(EXPIRED_JOINER_USER_ID, "joiner-expired@test.com")
+            seedInvitation("plaintext-expired-token", expiresAt = "2000-01-01T00:00:00Z")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-expired-token/accept")
+                    .header("X-User-Id", EXPIRED_JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            val memberRows = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members WHERE team_id = ?::uuid AND user_id = ?::uuid",
+                Long::class.java,
+                TEAM_ID,
+                EXPIRED_JOINER_USER_ID,
+            )
+            memberRows shouldBe 0L
         }
     }
 }

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -1,0 +1,96 @@
+import { http, HttpResponse, delay } from 'msw'
+import { setupServer } from 'msw/node'
+import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
+import { routeTree } from '../../routeTree.gen'
+import type { AuthenticatedUser } from '@shared/api/auth'
+import { queryClient } from '@shared/api/query-client'
+
+// Mirrors verify-flow.test.tsx's stateful-session approach, plus a stateful invitation so accept
+// can be proven idempotent/rejecting without touching the real backend.
+let session: AuthenticatedUser | null = null
+let accepted = false
+
+const USER: AuthenticatedUser = {
+  id: 'user-1',
+  email: 'newbie@example.com',
+  displayName: 'newbie',
+  role: undefined,
+}
+
+const server = setupServer(
+  http.post('/api/auth/magic-link/request', () => new HttpResponse(null, { status: 202 })),
+  http.post('/api/auth/magic-link/verify', async ({ request }) => {
+    const body = (await request.json()) as { token: string }
+    if (body.token !== 'valid-token') return new HttpResponse(null, { status: 401 })
+    await delay(10)
+    session = USER
+    return HttpResponse.json(USER)
+  }),
+  http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
+  http.post('/api/invitations/:token/accept', ({ params }) => {
+    if (params.token !== 'valid-invite-token') return new HttpResponse(null, { status: 404 })
+    accepted = true
+    return HttpResponse.json({ teamId: 'team-1' })
+  }),
+  http.get('/api/events', () => HttpResponse.json({ events: [] })),
+  http.get('/api/event-types', () => HttpResponse.json({ eventTypes: [] })),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  session = null
+  accepted = false
+  localStorage.clear()
+  // The app's queryClient (30s staleTime) is a shared singleton — without clearing it, a later
+  // test's fresh render would read a previous test's cached ['auth','me'] value instead of
+  // actually hitting the mock, since the cache doesn't know the mock session was reset above.
+  queryClient.clear()
+})
+afterAll(() => server.close())
+
+function renderAppAt(path: string) {
+  const router = createRouter({ routeTree, history: createMemoryHistory({ initialEntries: [path] }) })
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe('invite acceptance', () => {
+  it('an already-authenticated visitor accepts immediately and lands on team events', async () => {
+    session = USER
+    const router = renderAppAt('/invite/valid-invite-token')
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/'))
+    expect(await screen.findByRole('heading', { name: 'Events' })).toBeInTheDocument()
+    expect(accepted).toBe(true)
+  })
+
+  it('an invalid invite token shows an error instead of joining', async () => {
+    session = USER
+    renderAppAt('/invite/bogus-token')
+
+    expect(await screen.findByText(/invalid or has expired/i)).toBeInTheDocument()
+    expect(accepted).toBe(false)
+  })
+
+  it('an unauthenticated visitor requests a magic link, then joins once verified', async () => {
+    renderAppAt('/invite/valid-invite-token')
+
+    const emailInput = await screen.findByLabelText('Email')
+    fireEvent.change(emailInput, { target: { value: 'newbie@example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /send magic link/i }))
+
+    expect(await screen.findByText(/check your email/i)).toBeInTheDocument()
+
+    // Simulate clicking the emailed link: a fresh router mount at /auth/verify, same page context
+    // (localStorage survives), so the pending invite token saved on submit is still there.
+    const verifyRouter = renderAppAt('/auth/verify?token=valid-token')
+
+    await waitFor(() => expect(verifyRouter.state.location.pathname).toBe('/'))
+    expect(await screen.findAllByRole('heading', { name: 'Events' })).not.toHaveLength(0)
+    expect(accepted).toBe(true)
+    expect(localStorage.getItem('tb-pending-invite-token')).toBeNull()
+  })
+})

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
 
@@ -22,6 +23,11 @@ const LoginRoute = LoginRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InviteTokenRoute = InviteTokenRouteImport.update({
+  id: '/invite/$token',
+  path: '/invite/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const EventsEventIdRoute = EventsEventIdRouteImport.update({
@@ -40,12 +46,14 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
+  '/invite/$token': typeof InviteTokenRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
+  '/invite/$token': typeof InviteTokenRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -53,13 +61,21 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
+  '/invite/$token': typeof InviteTokenRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/auth/verify' | '/events/$eventId'
+  fullPaths:
+    '/' | '/login' | '/auth/verify' | '/events/$eventId' | '/invite/$token'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/auth/verify' | '/events/$eventId'
-  id: '__root__' | '/' | '/login' | '/auth/verify' | '/events/$eventId'
+  to: '/' | '/login' | '/auth/verify' | '/events/$eventId' | '/invite/$token'
+  id:
+    | '__root__'
+    | '/'
+    | '/login'
+    | '/auth/verify'
+    | '/events/$eventId'
+    | '/invite/$token'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -67,6 +83,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   AuthVerifyRoute: typeof AuthVerifyRoute
   EventsEventIdRoute: typeof EventsEventIdRoute
+  InviteTokenRoute: typeof InviteTokenRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -83,6 +100,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/invite/$token': {
+      id: '/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
+      preLoaderRoute: typeof InviteTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/events/$eventId': {
@@ -107,6 +131,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   AuthVerifyRoute: AuthVerifyRoute,
   EventsEventIdRoute: EventsEventIdRoute,
+  InviteTokenRoute: InviteTokenRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -8,10 +8,11 @@ import { queryClient } from '@shared/api/query-client'
 import { useUserStore } from '@shared/stores/user-store'
 
 // Only the sign-in routes (and the invite landing page, reachable before a joiner has any
-// session) render without a confirmed session. Exact `/auth/` and `/invite/` prefixes — not
-// startsWith('/auth') — so a future route like `/authored` can't slip past the guard.
+// session) render without a confirmed session. Exact `/auth/` prefix — not startsWith('/auth') —
+// so a future route like `/authored` can't slip past the guard. The invite exemption is equally
+// precise: only `/invite/<single-token>` is public; sub-paths like `/invite/manage` are NOT exempt.
 function isAuthRoute(pathname: string): boolean {
-  return pathname === '/login' || pathname.startsWith('/auth/') || pathname.startsWith('/invite/')
+  return pathname === '/login' || pathname.startsWith('/auth/') || /^\/invite\/[^/]+$/.test(pathname)
 }
 
 export const Route = createRootRoute({

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -7,10 +7,11 @@ import { authMeQueryOptions, useLogout } from '@shared/api/auth'
 import { queryClient } from '@shared/api/query-client'
 import { useUserStore } from '@shared/stores/user-store'
 
-// Only the sign-in routes render without a confirmed session. Exact `/auth/` prefix — not
+// Only the sign-in routes (and the invite landing page, reachable before a joiner has any
+// session) render without a confirmed session. Exact `/auth/` and `/invite/` prefixes — not
 // startsWith('/auth') — so a future route like `/authored` can't slip past the guard.
 function isAuthRoute(pathname: string): boolean {
-  return pathname === '/login' || pathname.startsWith('/auth/')
+  return pathname === '/login' || pathname.startsWith('/auth/') || pathname.startsWith('/invite/')
 }
 
 export const Route = createRootRoute({

--- a/app/src/routes/auth/verify.tsx
+++ b/app/src/routes/auth/verify.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { useVerifyMagicLink } from '@shared/api/auth'
-import { takePendingInviteToken, useAcceptInvitation } from '@shared/api/invitations'
+import { takePendingInviteTokenForEmail, useAcceptInvitation } from '@shared/api/invitations'
 
 export const Route = createFileRoute('/auth/verify')({
   component: VerifyPage,
@@ -27,19 +27,25 @@ function VerifyPage() {
     verifyMagicLink
       .mutateAsync(token)
       .then(async (user) => {
-        queryClient.setQueryData(['auth', 'me'], user)
-
-        const inviteToken = takePendingInviteToken()
+        const inviteToken = takePendingInviteTokenForEmail(user.email)
         if (inviteToken) {
           try {
             await acceptInvitation.mutateAsync(inviteToken)
+            // Only populate the auth cache after the accept succeeds — a failed accept must not
+            // leave the user "authenticated" but teamless.
+            queryClient.setQueryData(['auth', 'me'], user)
             // Role/team membership changed by accepting — refetch so the guard's /me and the
             // user store both reflect the newly-joined team, not the pre-join session snapshot.
             await queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
           } catch {
-            setError('This invite link is invalid or has expired.')
+            // DO NOT set auth cache — don't leave user authenticated but teamless.
+            setError(
+              'Your sign-in worked, but the invite link has expired or is no longer valid. Ask your team admin for a new invitation.',
+            )
             return
           }
+        } else {
+          queryClient.setQueryData(['auth', 'me'], user)
         }
 
         navigate({ to: '/', replace: true })

--- a/app/src/routes/auth/verify.tsx
+++ b/app/src/routes/auth/verify.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { useVerifyMagicLink } from '@shared/api/auth'
+import { takePendingInviteToken, useAcceptInvitation } from '@shared/api/invitations'
 
 export const Route = createFileRoute('/auth/verify')({
   component: VerifyPage,
@@ -15,6 +16,7 @@ function VerifyPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const verifyMagicLink = useVerifyMagicLink()
+  const acceptInvitation = useAcceptInvitation()
   const [error, setError] = useState<string | null>(null)
   const attempted = useRef(false)
 
@@ -24,8 +26,22 @@ function VerifyPage() {
 
     verifyMagicLink
       .mutateAsync(token)
-      .then((user) => {
+      .then(async (user) => {
         queryClient.setQueryData(['auth', 'me'], user)
+
+        const inviteToken = takePendingInviteToken()
+        if (inviteToken) {
+          try {
+            await acceptInvitation.mutateAsync(inviteToken)
+            // Role/team membership changed by accepting — refetch so the guard's /me and the
+            // user store both reflect the newly-joined team, not the pre-join session snapshot.
+            await queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
+          } catch {
+            setError('This invite link is invalid or has expired.')
+            return
+          }
+        }
+
         navigate({ to: '/', replace: true })
       })
       .catch(() => setError('This link has expired or already been used. Request a new one.'))

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthMe, useRequestMagicLink } from '@shared/api/auth'
+import { savePendingInviteToken, useAcceptInvitation } from '@shared/api/invitations'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+
+export const Route = createFileRoute('/invite/$token')({
+  component: InvitePage,
+})
+
+function InvitePage() {
+  const { token } = Route.useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  // The root guard exempts /invite/*, so this route never goes through the beforeLoad session
+  // probe — fetch it here instead. An already-authenticated visitor (re-clicking their own invite
+  // link, or an existing member) accepts immediately rather than being asked to sign in again.
+  const { data: user, isLoading: isLoadingSession } = useAuthMe()
+  const requestMagicLink = useRequestMagicLink()
+  const acceptInvitation = useAcceptInvitation()
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const attempted = useRef(false)
+
+  useEffect(() => {
+    if (attempted.current || !user) return
+    attempted.current = true
+
+    acceptInvitation
+      .mutateAsync(token)
+      .then(() => queryClient.invalidateQueries({ queryKey: ['auth', 'me'] }))
+      .then(() => navigate({ to: '/', replace: true }))
+      .catch(() => setError('This invite link is invalid or has expired.'))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, token])
+
+  if (isLoadingSession || (user && !error)) {
+    return (
+      <div className="mx-auto mt-16 max-w-sm text-center">
+        <p className="text-sm text-muted-foreground">{user ? 'Joining the team...' : 'Loading...'}</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto mt-16 max-w-sm text-center">
+        <h1 className="font-display text-2xl font-bold">Invite link invalid</h1>
+        <p className="mt-3 text-sm text-muted-foreground">{error}</p>
+        <Link to="/login" className="mt-6 inline-block text-sm font-medium text-blue">
+          Back to login
+        </Link>
+      </div>
+    )
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    savePendingInviteToken(token)
+    requestMagicLink.mutate(email, { onSuccess: () => setSent(true) })
+  }
+
+  if (sent) {
+    return (
+      <div className="mx-auto mt-16 max-w-sm text-center">
+        <h1 className="font-display text-2xl font-bold">Check your email</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          If <span className="font-medium text-foreground">{email}</span> checks out, we've sent a magic link to sign
+          in. Click it to join the team.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto mt-16 max-w-sm">
+      <h1 className="font-display text-center text-2xl font-bold">You're invited</h1>
+      <p className="mt-2 text-center text-sm text-muted-foreground">
+        Enter your email to join the team — no password needed.
+      </p>
+      <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+        <div>
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+          />
+        </div>
+        <Button type="submit" disabled={requestMagicLink.isPending}>
+          {requestMagicLink.isPending ? 'Sending...' : 'Send magic link'}
+        </Button>
+        {requestMagicLink.isError && (
+          <p className="text-center text-sm text-red-500">Something went wrong. Please try again.</p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -38,7 +38,7 @@ function InvitePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, token])
 
-  if (isLoadingSession || (user && !error)) {
+  if (isLoadingSession || (user && !error && !acceptInvitation.isError)) {
     return (
       <div className="mx-auto mt-16 max-w-sm text-center">
         <p className="text-sm text-muted-foreground">{user ? 'Joining the team...' : 'Loading...'}</p>
@@ -60,7 +60,7 @@ function InvitePage() {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    savePendingInviteToken(token)
+    savePendingInviteToken(token, email)
     requestMagicLink.mutate(email, { onSuccess: () => setSent(true) })
   }
 

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { api } from './wirespec-client'
 
 export type { Invitation } from './generated/model/Invitation'
+export type { AcceptedInvitation } from './generated/model/AcceptedInvitation'
 
 export function useCreateInvitation() {
   return useMutation({
@@ -10,4 +11,30 @@ export function useCreateInvitation() {
       return res.body
     },
   })
+}
+
+export function useAcceptInvitation() {
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const res = await api.AcceptInvitation({ token })
+      if (res.status === 404) throw new Error('This invite link is invalid or has expired')
+      return res.body
+    },
+  })
+}
+
+// Carries the invite token across the magic-link round trip: the joiner requests a link from
+// /invite/:token (unauthenticated), then clicks it later on /auth/verify — a different page load,
+// so the token can't be passed as component state. Persisted client-side (same pattern as the
+// `teamId` shim in wirespec-client.ts), not sent to the server until accept.
+const PENDING_INVITE_TOKEN_KEY = 'tb-pending-invite-token'
+
+export function savePendingInviteToken(token: string): void {
+  localStorage.setItem(PENDING_INVITE_TOKEN_KEY, token)
+}
+
+export function takePendingInviteToken(): string | null {
+  const token = localStorage.getItem(PENDING_INVITE_TOKEN_KEY)
+  if (token) localStorage.removeItem(PENDING_INVITE_TOKEN_KEY)
+  return token
 }

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -17,7 +17,7 @@ export function useAcceptInvitation() {
   return useMutation({
     mutationFn: async (token: string) => {
       const res = await api.AcceptInvitation({ token })
-      if (res.status === 404) throw new Error('This invite link is invalid or has expired')
+      if (res.status === 404 || res.status === 401) throw new Error('invite link invalid or expired')
       return res.body
     },
   })
@@ -27,14 +27,21 @@ export function useAcceptInvitation() {
 // /invite/:token (unauthenticated), then clicks it later on /auth/verify — a different page load,
 // so the token can't be passed as component state. Persisted client-side (same pattern as the
 // `teamId` shim in wirespec-client.ts), not sent to the server until accept.
+// The email is stored alongside the token so we only hand it back if the verified user's email
+// matches — preventing a plain /login from silently accepting someone else's invite.
 const PENDING_INVITE_TOKEN_KEY = 'tb-pending-invite-token'
+const PENDING_INVITE_EMAIL_KEY = 'tb-pending-invite-email'
 
-export function savePendingInviteToken(token: string): void {
+export function savePendingInviteToken(token: string, email: string): void {
   localStorage.setItem(PENDING_INVITE_TOKEN_KEY, token)
+  localStorage.setItem(PENDING_INVITE_EMAIL_KEY, email)
 }
 
-export function takePendingInviteToken(): string | null {
+export function takePendingInviteTokenForEmail(email: string): string | null {
   const token = localStorage.getItem(PENDING_INVITE_TOKEN_KEY)
-  if (token) localStorage.removeItem(PENDING_INVITE_TOKEN_KEY)
-  return token
+  const savedEmail = localStorage.getItem(PENDING_INVITE_EMAIL_KEY)
+  // Always clean up, regardless of whether the email matches.
+  localStorage.removeItem(PENDING_INVITE_TOKEN_KEY)
+  localStorage.removeItem(PENDING_INVITE_EMAIL_KEY)
+  return token && savedEmail === email ? token : null
 }

--- a/app/src/shared/mocks/handlers.ts
+++ b/app/src/shared/mocks/handlers.ts
@@ -191,4 +191,11 @@ export const handlers = [
       { status: 201 },
     )
   }),
+
+  // POST /api/invitations/:token/accept
+  http.post('/api/invitations/:token/accept', async ({ params }) => {
+    await delay(300)
+    if (params.token !== 'mock-invite-token') return new HttpResponse(null, { status: 404 })
+    return HttpResponse.json({ teamId: '11111111-2222-3333-4444-555555555555' })
+  }),
 ]


### PR DESCRIPTION
## Summary

Replace all occurrences of `Instant.now(clock)` with the more idiomatic `clock.instant()` call across the backend application services.

**Files changed:**
- AttendanceService.kt (2 occurrences)
- AuthService.kt (2 occurrences)  
- EventService.kt (3 occurrences)
- InvitationService.kt (2 occurrences)