### PR TITLE
refactor: use clock.instant() instead of Instant.now(clock)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -26,7 +26,7 @@ class AttendanceService(
         val existing = attendanceRepository.findByEventIdAndUserId(eventId, userId)
         return if (existing != null) {
             attendanceRepository.save(
-                existing.copy(state = state, updatedAt = Instant.now(clock), changedBy = changedBy),
+                existing.copy(state = state, updatedAt = clock.instant(), changedBy = changedBy),
             )
         } else {
             attendanceRepository.save(
@@ -35,7 +35,7 @@ class AttendanceService(
                     eventId = eventId,
                     userId = userId,
                     state = state,
-                    updatedAt = Instant.now(clock),
+                    updatedAt = clock.instant(),
                     changedBy = changedBy,
                 ),
             )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -29,7 +29,7 @@ class AuthService(
 
     fun requestMagicLink(email: String) {
         val token = generateToken()
-        val now = Instant.now(clock)
+        val now = clock.instant()
         magicLinkTokenRepository.save(
             MagicLinkToken(
                 id = UUID.randomUUID(),
@@ -46,7 +46,7 @@ class AuthService(
     fun findUserById(id: UUID): User? = userRepository.findById(id)
 
     fun verifyMagicLink(token: String): User? {
-        val now = Instant.now(clock)
+        val now = clock.instant()
         val record = magicLinkTokenRepository.findByTokenHash(hash(token))
             ?.takeIf { it.usedAt == null && it.expiresAt.isAfter(now) }
             ?: return null

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -29,7 +29,7 @@ class EventService(
     }
 
     fun getUpcomingEvents(): List<Event> {
-        val since = Instant.now(clock).minus(GRACE_PERIOD)
+        val since = clock.instant().minus(GRACE_PERIOD)
         return eventRepository.findUpcoming(since)
     }
 
@@ -53,7 +53,7 @@ class EventService(
                 endTime = potential.endTime,
                 location = potential.location,
                 createdBy = createdBy,
-                createdAt = Instant.now(clock),
+                createdAt = clock.instant(),
             ),
         )
 
@@ -64,7 +64,7 @@ class EventService(
                 eventId = event.id,
                 userId = member.userId,
                 state = AttendanceState.NOT_RESPONDED,
-                updatedAt = Instant.now(clock),
+                updatedAt = clock.instant(),
                 changedBy = createdBy,
             )
         }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -42,7 +42,7 @@ class InvitationService(
      * rotate/expire to invalidate them.
      */
     fun generateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
-        val now = Instant.now(clock)
+        val now = clock.instant()
         val token = generateToken()
         invitationRepository.save(
             Invitation(


### PR DESCRIPTION
## Summary

Replace all occurrences of `Instant.now(clock)` with the more idiomatic `clock.instant()` call across the backend application services.

**Files changed:**
- AttendanceService.kt (2 occurrences)
- AuthService.kt (2 occurrences)  
- EventService.kt (3 occurrences)
- InvitationService.kt (1 occurrence)