### PR TITLE
feat(#38): rotate or expire the team invite link (admin-only)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -71,6 +71,11 @@ class InvitationService(
         return invitation.teamId
     }
 
+    /** Invalidates every currently-active invite link for the team; already-expired ones are untouched. */
+    fun expireActiveInvitations(teamId: UUID) {
+        invitationRepository.expireActive(teamId, Instant.now(clock))
+    }
+
     private fun generateToken(): String {
         val bytes = ByteArray(TOKEN_BYTE_LENGTH)
         secureRandom.nextBytes(bytes)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -5,6 +5,7 @@ import com.github.zzave.teambalance.api.domain.port.InvitationRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Clock
@@ -76,7 +77,12 @@ class InvitationService(
         invitationRepository.expireActive(teamId, Instant.now(clock))
     }
 
-    /** Invalidates the team's active invite link(s) and mints a fresh one in its place. */
+    /**
+     * Invalidates the team's active invite link(s) and mints a fresh one in its place. Atomic: the
+     * expire and the mint share one transaction, so a failure to mint rolls the expire back rather
+     * than leaving the team with no usable link.
+     */
+    @Transactional
     fun rotateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
         expireActiveInvitations(teamId)
         return generateInviteLink(teamId, createdBy)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -76,6 +76,12 @@ class InvitationService(
         invitationRepository.expireActive(teamId, Instant.now(clock))
     }
 
+    /** Invalidates the team's active invite link(s) and mints a fresh one in its place. */
+    fun rotateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
+        expireActiveInvitations(teamId)
+        return generateInviteLink(teamId, createdBy)
+    }
+
     private fun generateToken(): String {
         val bytes = ByteArray(TOKEN_BYTE_LENGTH)
         secureRandom.nextBytes(bytes)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -1,8 +1,13 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
+import java.time.Instant
+import java.util.UUID
 
 interface InvitationRepository {
     fun save(invitation: Invitation): Invitation
     fun findByTokenHash(tokenHash: String): Invitation?
+
+    /** Marks every currently-active (unexpired) invitation for the team as expired as of [now]. */
+    fun expireActive(teamId: UUID, now: Instant)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -5,6 +5,9 @@ import com.github.zzave.teambalance.api.domain.port.InvitationRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
 
 @Repository
 class JpaInvitationRepositoryAdapter(
@@ -16,4 +19,9 @@ class JpaInvitationRepositoryAdapter(
 
     override fun findByTokenHash(tokenHash: String): Invitation? =
         jpaRepository.findByTokenHash(tokenHash)?.internalize()
+
+    @Transactional
+    override fun expireActive(teamId: UUID, now: Instant) {
+        jpaRepository.expireActive(teamId, now)
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -2,8 +2,18 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.InvitationJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
 import java.util.UUID
 
 interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
     fun findByTokenHash(tokenHash: String): InvitationJpaEntity?
+
+    @Modifying
+    @Query(
+        "UPDATE InvitationJpaEntity i SET i.expiresAt = :now " +
+            "WHERE i.teamId = :teamId AND i.expiresAt > :now",
+    )
+    fun expireActive(teamId: UUID, now: Instant)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
     fun findByTokenHash(tokenHash: String): InvitationJpaEntity?
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query(
         "UPDATE InvitationJpaEntity i SET i.expiresAt = :now " +
             "WHERE i.teamId = :teamId AND i.expiresAt > :now",

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -7,6 +7,7 @@ import com.github.zzave.teambalance.api.application.InvitationService
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireInvitations
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RotateInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.AcceptedInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.Invitation
 import org.springframework.web.bind.annotation.RestController
@@ -19,7 +20,8 @@ class InvitationController(
     private val authorizationService: AuthorizationService,
 ) : CreateInvitation.Handler,
     AcceptInvitation.Handler,
-    ExpireInvitations.Handler {
+    ExpireInvitations.Handler,
+    RotateInvitation.Handler {
 
     override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
@@ -49,5 +51,19 @@ class InvitationController(
 
         invitationService.expireActiveInvitations(teamId)
         return ExpireInvitations.Response204(Unit)
+    }
+
+    override suspend fun rotateInvitation(request: RotateInvitation.Request): RotateInvitation.Response<*> {
+        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamProvider.requireCurrentTeamId()
+        authorizationService.requireAdmin(userId, teamId)
+
+        val invitation = invitationService.rotateInviteLink(teamId = teamId, createdBy = userId)
+        return RotateInvitation.Response201(
+            Invitation(
+                token = invitation.token,
+                expiresAt = invitation.expiresAt.toString(),
+            ),
+        )
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -6,6 +6,7 @@ import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.InvitationService
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireInvitations
 import com.github.zzave.teambalance.api.interfaces.generated.model.AcceptedInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.Invitation
 import org.springframework.web.bind.annotation.RestController
@@ -17,7 +18,8 @@ class InvitationController(
     private val currentTeamProvider: CurrentTeamProvider,
     private val authorizationService: AuthorizationService,
 ) : CreateInvitation.Handler,
-    AcceptInvitation.Handler {
+    AcceptInvitation.Handler,
+    ExpireInvitations.Handler {
 
     override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
@@ -38,5 +40,14 @@ class InvitationController(
         val teamId = invitationService.acceptInvitation(request.path.token, userId)
             ?: return AcceptInvitation.Response404(Unit)
         return AcceptInvitation.Response200(AcceptedInvitation(teamId = teamId.toString()))
+    }
+
+    override suspend fun expireInvitations(request: ExpireInvitations.Request): ExpireInvitations.Response<*> {
+        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamProvider.requireCurrentTeamId()
+        authorizationService.requireAdmin(userId, teamId)
+
+        invitationService.expireActiveInvitations(teamId)
+        return ExpireInvitations.Response204(Unit)
     }
 }

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -20,3 +20,7 @@ endpoint AcceptInvitation POST /api/invitations/{token: String}/accept -> {
 endpoint ExpireInvitations POST /api/invitations/expire -> {
     204 -> Unit
 }
+
+endpoint RotateInvitation POST /api/invitations/rotate -> {
+    201 -> Invitation
+}

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -16,3 +16,7 @@ endpoint AcceptInvitation POST /api/invitations/{token: String}/accept -> {
     401 -> Unit
     404 -> Unit
 }
+
+endpoint ExpireInvitations POST /api/invitations/expire -> {
+    204 -> Unit
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -209,5 +209,55 @@ class InvitationControllerTest : TeamBalanceIT() {
             )
             memberRows shouldBe 0L
         }
+
+        test("POST /api/invitations/expire by an admin invalidates the team's active invitation") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "joiner-expire@test.com")
+            seedInvitation("plaintext-expire-token")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/expire")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            val acceptResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-expire-token/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(acceptResult))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+        }
+
+        test("POST /api/invitations/expire by a non-admin team member is rejected with 403") {
+            seedAdmin()
+            jdbcTemplate.execute(
+                "INSERT INTO public.users (id, email, display_name) " +
+                    "VALUES ('$LISA_USER_ID'::uuid, 'lisa-expire@test.com', 'Lisa Bakker') ON CONFLICT DO NOTHING",
+            )
+            jdbcTemplate.execute(
+                "INSERT INTO public.team_members (team_id, user_id, role, team_role) " +
+                    "VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero') ON CONFLICT DO NOTHING",
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/expire")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", LISA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -237,6 +237,71 @@ class InvitationControllerTest : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isNotFound)
         }
 
+        test("POST /api/invitations/rotate by an admin rejects the old token and accepts the new one") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "joiner-rotate@test.com")
+            seedInvitation("plaintext-rotate-old-token")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/rotate")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            val newToken = objectMapper.readTree(
+                mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                    .andExpect(MockMvcResultMatchers.status().isCreated)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
+                    .andReturn()
+                    .response
+                    .contentAsString,
+            ).get("token").asText()
+
+            val oldTokenResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-rotate-old-token/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(oldTokenResult))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            val newTokenResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/$newToken/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(newTokenResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.teamId").value(TEAM_ID))
+        }
+
+        test("POST /api/invitations/rotate by a non-admin team member is rejected with 403") {
+            seedAdmin()
+            jdbcTemplate.execute(
+                "INSERT INTO public.users (id, email, display_name) " +
+                    "VALUES ('$LISA_USER_ID'::uuid, 'lisa-rotate@test.com', 'Lisa Bakker') ON CONFLICT DO NOTHING",
+            )
+            jdbcTemplate.execute(
+                "INSERT INTO public.team_members (team_id, user_id, role, team_role) " +
+                    "VALUES ('$TEAM_ID'::uuid, '$LISA_USER_ID'::uuid, 'USER', 'Libero') ON CONFLICT DO NOTHING",
+            )
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/rotate")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", LISA_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
         test("POST /api/invitations/expire by a non-admin team member is rejected with 403") {
             seedAdmin()
             jdbcTemplate.execute(

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
@@ -15,6 +15,7 @@ const meta = {
     expired: false,
     isRotating: false,
     isExpiring: false,
+    actionError: false,
     onCopy: fn(),
     onRotate: fn(),
     onExpire: fn(),
@@ -87,5 +88,15 @@ export const Expired: Story = {
     await expect(canvas.getByText(/this link has expired/i)).toBeInTheDocument()
     await userEvent.click(canvas.getByRole('button', { name: 'Generate new link' }))
     await expect(args.onGenerateNew).toHaveBeenCalled()
+  },
+}
+
+// A failed rotate/expire surfaces inline while the active link stays shown — so the admin isn't
+// left believing a dead link is still valid.
+export const ActionError: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false, actionError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/something went wrong/i)).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Rotate link' })).toBeInTheDocument()
   },
 }

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
@@ -11,7 +11,15 @@ const LINK = 'https://app.teambalance.app/invite/abc123'
 const meta = {
   title: 'features/generate-invite/GenerateInviteContent',
   component: GenerateInviteContent,
-  args: { onCopy: fn() },
+  args: {
+    expired: false,
+    isRotating: false,
+    isExpiring: false,
+    onCopy: fn(),
+    onRotate: fn(),
+    onExpire: fn(),
+    onGenerateNew: fn(),
+  },
 } satisfies Meta<typeof GenerateInviteContent>
 
 export default meta
@@ -54,5 +62,30 @@ export const Copied: Story = {
   args: { isPending: false, isError: false, link: LINK, copied: true },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
+  },
+}
+
+export const Rotating: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false, isRotating: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Rotating...' })).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Rotating...' })).toBeDisabled()
+  },
+}
+
+export const Expiring: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false, isExpiring: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Expiring...' })).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Expiring...' })).toBeDisabled()
+  },
+}
+
+export const Expired: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false, expired: true },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText(/this link has expired/i)).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Generate new link' }))
+    await expect(args.onGenerateNew).toHaveBeenCalled()
   },
 }

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.tsx
@@ -6,26 +6,51 @@ interface GenerateInviteContentProps {
   isError: boolean
   link: string | null
   copied: boolean
+  expired: boolean
+  isRotating: boolean
+  isExpiring: boolean
   onCopy: () => void
+  onRotate: () => void
+  onExpire: () => void
+  onGenerateNew: () => void
 }
 
 /**
- * Presentational body of the invite dialog. Renders exactly one of: generating / error / the
- * generated link with a copy button. The mutation, dialog open/close state, and the copied flag all
- * live in the GenerateInviteDialog container — so each state (pending, error, generated, copied) is
- * renderable in isolation as a story (see GenerateInviteContent.stories.tsx). The Dialog chrome
- * (trigger + header) stays in the container, so this stays free of Radix context.
+ * Presentational body of the invite dialog. Renders exactly one of: generating / error / expired /
+ * the active link with copy+rotate+expire actions. The mutations, dialog open/close state, and the
+ * copied flag all live in the GenerateInviteDialog container — so each state is renderable in
+ * isolation as a story (see GenerateInviteContent.stories.tsx). The Dialog chrome (trigger + header)
+ * stays in the container, so this stays free of Radix context.
  */
 export function GenerateInviteContent({
   isPending,
   isError,
   link,
   copied,
+  expired,
+  isRotating,
+  isExpiring,
   onCopy,
+  onRotate,
+  onExpire,
+  onGenerateNew,
 }: GenerateInviteContentProps) {
   if (isPending) return <p className="text-muted-foreground">Generating...</p>
   if (isError) return <p className="text-destructive">Failed to generate invite link.</p>
   if (!link) return null
+
+  if (expired) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          This link has expired. New joiners can no longer use it.
+        </p>
+        <Button type="button" onClick={onGenerateNew}>
+          Generate new link
+        </Button>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-3">
@@ -36,6 +61,14 @@ export function GenerateInviteContent({
         <Input readOnly value={link} onFocus={(e) => e.currentTarget.select()} />
         <Button type="button" onClick={onCopy}>
           {copied ? 'Copied!' : 'Copy'}
+        </Button>
+      </div>
+      <div className="flex gap-2">
+        <Button type="button" variant="outline" onClick={onRotate} disabled={isRotating}>
+          {isRotating ? 'Rotating...' : 'Rotate link'}
+        </Button>
+        <Button type="button" variant="destructive" onClick={onExpire} disabled={isExpiring}>
+          {isExpiring ? 'Expiring...' : 'Expire link'}
         </Button>
       </div>
     </div>

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.tsx
@@ -9,6 +9,7 @@ interface GenerateInviteContentProps {
   expired: boolean
   isRotating: boolean
   isExpiring: boolean
+  actionError: boolean
   onCopy: () => void
   onRotate: () => void
   onExpire: () => void
@@ -30,6 +31,7 @@ export function GenerateInviteContent({
   expired,
   isRotating,
   isExpiring,
+  actionError,
   onCopy,
   onRotate,
   onExpire,
@@ -71,6 +73,9 @@ export function GenerateInviteContent({
           {isExpiring ? 'Expiring...' : 'Expire link'}
         </Button>
       </div>
+      {actionError && (
+        <p className="text-sm text-destructive">Something went wrong. Please try again.</p>
+      )}
     </div>
   )
 }

--- a/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
@@ -1,28 +1,39 @@
 import { useState } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@shared/ui/dialog'
 import { Button } from '@shared/ui/button'
-import { useCreateInvitation } from '@shared/api/invitations'
+import { type Invitation, useCreateInvitation, useExpireInvitations, useRotateInvitation } from '@shared/api/invitations'
 import { GenerateInviteContent } from './GenerateInviteContent'
 
 /**
- * Container for the team invite link: owns the dialog open/close state, the copied flag, and the
- * create-invitation mutation, wiring them to the presentational GenerateInviteContent. Opening the
- * dialog kicks off generation once; closing resets the copied flag. The Dialog wrapper stays here —
- * Radix unmounts the content on close, so no extra reset is needed.
+ * Container for the team invite link: owns the dialog open/close state, the copied/expired flags,
+ * and the create/rotate/expire mutations, wiring them to the presentational GenerateInviteContent.
+ * Opening the dialog kicks off generation once; closing resets the copied flag. The Dialog wrapper
+ * stays here — Radix unmounts the content on close, so no extra reset is needed.
  */
 export function GenerateInviteDialog() {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [invitation, setInvitation] = useState<Invitation | null>(null)
+  const [expired, setExpired] = useState(false)
   const createInvitation = useCreateInvitation()
+  const rotateInvitation = useRotateInvitation()
+  const expireInvitation = useExpireInvitations()
 
-  const link = createInvitation.data
-    ? `${window.location.origin}/invite/${createInvitation.data.token}`
-    : null
+  const link = invitation ? `${window.location.origin}/invite/${invitation.token}` : null
+
+  const generate = () => {
+    createInvitation.mutate(undefined, {
+      onSuccess: (inv) => {
+        setInvitation(inv)
+        setExpired(false)
+      },
+    })
+  }
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next)
-    if (next && !createInvitation.data) {
-      createInvitation.mutate()
+    if (next && !invitation) {
+      generate()
     }
     if (!next) {
       setCopied(false)
@@ -33,6 +44,22 @@ export function GenerateInviteDialog() {
     if (!link) return
     await navigator.clipboard.writeText(link)
     setCopied(true)
+  }
+
+  const handleRotate = () => {
+    setCopied(false)
+    rotateInvitation.mutate(undefined, {
+      onSuccess: (inv) => {
+        setInvitation(inv)
+        setExpired(false)
+      },
+    })
+  }
+
+  const handleExpire = () => {
+    expireInvitation.mutate(undefined, {
+      onSuccess: () => setExpired(true),
+    })
   }
 
   return (
@@ -49,7 +76,13 @@ export function GenerateInviteDialog() {
           isError={createInvitation.isError}
           link={link}
           copied={copied}
+          expired={expired}
+          isRotating={rotateInvitation.isPending}
+          isExpiring={expireInvitation.isPending}
           onCopy={handleCopy}
+          onRotate={handleRotate}
+          onExpire={handleExpire}
+          onGenerateNew={generate}
         />
       </DialogContent>
     </Dialog>

--- a/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteDialog.tsx
@@ -21,13 +21,16 @@ export function GenerateInviteDialog() {
 
   const link = invitation ? `${window.location.origin}/invite/${invitation.token}` : null
 
+  // Both the initial generate and a rotate land on a fresh active link: adopt it, drop the
+  // expired/copied flags from whatever state we were in.
+  const adoptNewLink = (inv: Invitation) => {
+    setInvitation(inv)
+    setExpired(false)
+    setCopied(false)
+  }
+
   const generate = () => {
-    createInvitation.mutate(undefined, {
-      onSuccess: (inv) => {
-        setInvitation(inv)
-        setExpired(false)
-      },
-    })
+    createInvitation.mutate(undefined, { onSuccess: adoptNewLink })
   }
 
   const handleOpenChange = (next: boolean) => {
@@ -37,6 +40,12 @@ export function GenerateInviteDialog() {
     }
     if (!next) {
       setCopied(false)
+      // Drop a dead (expired) link on close so reopening mints a fresh one instead of showing the
+      // stale "expired" panel. A still-active link is kept and reused on reopen.
+      if (expired) {
+        setInvitation(null)
+        setExpired(false)
+      }
     }
   }
 
@@ -47,18 +56,15 @@ export function GenerateInviteDialog() {
   }
 
   const handleRotate = () => {
-    setCopied(false)
-    rotateInvitation.mutate(undefined, {
-      onSuccess: (inv) => {
-        setInvitation(inv)
-        setExpired(false)
-      },
-    })
+    rotateInvitation.mutate(undefined, { onSuccess: adoptNewLink })
   }
 
   const handleExpire = () => {
     expireInvitation.mutate(undefined, {
-      onSuccess: () => setExpired(true),
+      onSuccess: () => {
+        setExpired(true)
+        setCopied(false)
+      },
     })
   }
 
@@ -79,6 +85,7 @@ export function GenerateInviteDialog() {
           expired={expired}
           isRotating={rotateInvitation.isPending}
           isExpiring={expireInvitation.isPending}
+          actionError={rotateInvitation.isError || expireInvitation.isError}
           onCopy={handleCopy}
           onRotate={handleRotate}
           onExpire={handleExpire}

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -13,6 +13,23 @@ export function useCreateInvitation() {
   })
 }
 
+export function useRotateInvitation() {
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.RotateInvitation()
+      return res.body
+    },
+  })
+}
+
+export function useExpireInvitations() {
+  return useMutation({
+    mutationFn: async () => {
+      await api.ExpireInvitations()
+    },
+  })
+}
+
 export function useAcceptInvitation() {
   return useMutation({
     mutationFn: async (token: string) => {


### PR DESCRIPTION
Closes #38.

Lets an **Admin** rotate or expire their team's invite link (parent #9, story 8). Rotating mints a fresh token and invalidates the previous one; an expired/rotated link is rejected at accept time. Both endpoints reuse the admin authorization seam (#34).

## What's included
- **Backend** — `POST /api/invitations/expire` (204) and `POST /api/invitations/rotate` (201) endpoints; `InvitationService.expireActiveInvitations` / `rotateInviteLink`; a scoped `expireActive(teamId, now)` bulk update on the repository port. Both endpoints gate `requireCurrentUserId()` → `requireAdmin(userId, teamId)` with server-resolved user + team (no IDOR).
- **Frontend** — admin control in the invite dialog exposes Rotate / Expire, shows the active link, and surfaces mutation errors + expired state.

## Review hardening (in `fix(#38)`)
- `rotateInviteLink` is `@Transactional` — expire + mint commit atomically, so a failed mint can't strand a team with zero valid links.
- `@Modifying(clearAutomatically = true)` on the bulk expire — no stale persistence-context read in a shared transaction.
- UI surfaces rotate/expire errors inline (was create-only); reopen-after-expire mints a fresh link instead of showing the stale panel.

## Acceptance criteria
- [x] Admin can rotate (new token issued, previous invalidated) and/or expire.
- [x] Accepting a rotated/expired token is rejected (404).
- [x] Endpoints admin-only; non-admin → 403.
- [x] Frontend exposes rotate/expire and surfaces the current active link.
- [x] Integration test: rotate → old rejected, new accepted; expire → rejected.

## Testing
- Backend: 57 tests + detekt green — incl. new ITs (expire/rotate by admin, both non-admin → 403, expired-token accept → 404) in `InvitationControllerTest`.
- Frontend: 60 tests (incl. new `ActionError` Storybook story) + eslint green.
- E2e: existing login + attendance flows pass (pre-commit hook).


https://github.com/user-attachments/assets/c0b7d7bd-8364-44ed-9aee-7b9d3db5482c



## PR gate — no new e2e
Coverage sits at the lowest layer that proves it: backend behaviour → Testcontainers ITs; component states → Storybook stories. The change reuses the existing admin-authz seam (#34) and the accept path (#37) — it introduces no new auth path, cross-tenant write, or external integration beyond what the login/attendance flows already exercise, so no new full-stack e2e is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)