### PR TITLE
feat(infra): containerize API for Scaleway Serverless Containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Keep the build context lean — the API image only needs the Gradle build + api/design-tokens modules.
+.git
+.github
+.claude
+node_modules
+**/node_modules
+**/build
+**/dist
+**/.gradle
+app
+www
+docs
+test-results
+*.mp4
+*.log

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,36 @@
+# TeamBalance API — container image for Scaleway Serverless Containers.
+# Multi-stage: build the Spring Boot fat jar with the Gradle wrapper, then run it on a slim JRE.
+# JDK/JRE 25 to match the build toolchain (gradle.properties: javaVersion=25).
+# Build from the repo root: docker build -f api/Dockerfile -t teambalance-api .
+
+# ---- build stage -------------------------------------------------------------
+# Build on the native builder arch (the bootJar is platform-independent JVM bytecode),
+# so a cross-arch build (e.g. --platform=linux/amd64 on an arm host) stays fast.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk AS build
+WORKDIR /workspace
+
+# Wrapper + build scripts first so dependency resolution can cache across source-only changes.
+# buildSrc supplies the Wirespec SpringKotlinEmitter to the build-script classpath — required
+# to configure the codegen tasks in api/build.gradle.kts.
+COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY gradle ./gradle
+COPY buildSrc ./buildSrc
+COPY design-tokens ./design-tokens
+COPY api ./api
+
+# Daemonless, no config-cache: a one-shot container build never reuses either.
+RUN ./gradlew --no-daemon --no-configuration-cache :api:bootJar
+
+# ---- runtime stage -----------------------------------------------------------
+FROM eclipse-temurin:25-jre AS runtime
+WORKDIR /app
+
+# Run as an unprivileged user.
+RUN useradd --system --uid 1001 --home-dir /app --shell /usr/sbin/nologin app
+USER app
+
+# The Spring Boot plugin emits exactly one executable jar (the *-plain.jar is non-executable).
+COPY --from=build --chown=app:app /workspace/api/build/libs/*-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## What

First move of the V1 Scaleway launch — the **tracer-bullet infra slice**. Adds the only new code the deploy path needs:

- `api/Dockerfile` — multi-stage: build the Spring Boot bootJar with the Gradle wrapper, run it on a slim **JRE 25** (matches `gradle.properties: javaVersion=25`). The build stage pins `--platform=$BUILDPLATFORM` so a cross-arch build stays fast — Scaleway Serverless Containers require **linux/amd64**, and the bootJar is arch-independent, so only the runtime layer crosses.
- `.dockerignore` — keeps the build context lean (api + design-tokens + buildSrc only).

No application code changes. Session-store/Flyway/redis concerns are handled at **deploy time via env overrides** (`SPRING_SESSION_STORE_TYPE=none`, `MANAGEMENT_HEALTH_REDIS_ENABLED=false`) — the real session-store change remains a separate launch blocker.

## Proven end-to-end on real Scaleway (fr-par, EU)

image → Container Registry → Serverless Container (min-scale=0, :8080) → Serverless SQL DB (Flyway migrated at boot) → custom domain **`api.teambalance.nl`** with auto Let's Encrypt TLS:

```
curl https://api.teambalance.nl/internal/actuator/health
→ HTTP 200  {"groups":["liveness","readiness"],"status":"UP"}
→ TLS 1.3 · HTTP/2 · cert CN=api.teambalance.nl · issuer=Let's Encrypt
```

## Test plan

Build locally and cross-build for deploy:

```bash
docker build --platform=linux/amd64 -f api/Dockerfile -t teambalance-api .
```

Not a new app seam, so no new automated test layer per the PR gate — this is infra plumbing verified by the live HTTPS health check above.

## Notes / follow-ups (out of scope here)

- Serverless SQL DB is **fr-par-only** (not nl-ams) — drove the region choice.
- DB currently authenticates with the account API key; dedicated IAM app-key is a hardening follow-up.
- Deploy is still **manual** (`scw`); wiring CI `workflow_dispatch` is a later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf5Awddcztx5haoKdru64Z