### PR TITLE
fix(test): de-flake invite-flow render-gate test under concurrent load

### DIFF
--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -1,3 +1,12 @@
 // Registers @testing-library/jest-dom matchers (toBeInTheDocument, etc.) on Vitest's
 // expect, and augments its types. Loaded via vitest.config.ts (unit project setupFiles).
 import '@testing-library/jest-dom/vitest'
+import { configure } from '@testing-library/react'
+
+// The unit (jsdom) project runs concurrently with the headless-browser Storybook project under
+// `make test-app`. That contention starves the jsdom tests of CPU, so async assertions in the
+// render-gate tests (waitFor/findBy on a navigation that chains an MSW mock → react-query mutation
+// → cache invalidation+refetch → router navigate) intermittently blow past Testing Library's
+// default 1000ms deadline — a flake that only surfaces under load (e.g. CI). Give them real
+// headroom; a genuinely-broken assertion still fails, just after a longer wait.
+configure({ asyncUtilTimeout: 5000 })


### PR DESCRIPTION
## Problem

`invite-flow.test.tsx` fails intermittently in CI — this is what's currently blocking `main` (the #74/#79 merge CI runs were `cancelled`, so it slipped in unguarded):

```
AssertionError: expected '/invite/valid-invite-token' to be '/'
❯ src/app/providers/invite-flow.test.tsx:65:64
```

It passes in isolation and in the unit project alone, but fails under the full `make test-app`.

## Root cause (investigated, not guessed)

- Ran the file alone → **passes**. Ran the unit project alone → **passes**. Ran the full suite (unit + Storybook) → **fails**, then passed 3× in a row → **flaky**, load-dependent.
- Under `make test-app`, the jsdom **unit** project runs concurrently with the headless-browser **Storybook** project. The CPU contention starves the jsdom tests, so the async navigation chain (MSW mock → react-query mutation → cache invalidate+refetch → router `navigate`) intermittently exceeds Testing Library's default **1000ms** `waitFor`/`findBy` deadline. In the failing CI run the file took **2645ms** vs ~280ms in isolation.
- Backend (`./gradlew :api:test`) was **BUILD SUCCESSFUL** in the same CI run — not a Spring/profile/datasource issue. The app logic is correct (redirect works); the test's deadline is just too tight under load.

**Deterministic proof:** forcing `asyncUtilTimeout: 1` fails all three tests with the *exact* CI error; `5000` makes them pass.

## Fix

Raise Testing Library's global `asyncUtilTimeout` to 5000ms in the unit setup (`src/test/setup.ts`) — well above the observed load-time. One line, no logic/coverage change; a genuinely-broken assertion still fails, just after a longer wait. This also gives the two sanctioned render-gate tests (`auth-gate`, `verify-flow`) the same headroom.

## Note / follow-up (out of scope)

Per `CLAUDE.md`, `invite-flow.test.tsx` is a *third* MSW/RTL render test, beyond the two sanctioned exceptions (`auth-gate`, `verify-flow`). Worth a separate decision on whether to keep it as-is or move that coverage lower; this PR only de-flakes what's already there so `main` goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf5Awddcztx5haoKdru64Z