### PR TITLE
feat(#launch): lock down /internal/* in prod (blocker #5)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilter.kt
@@ -1,0 +1,58 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.util.StringUtils
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.UrlPathHelper
+
+/**
+ * Launch blocker #5: in prod the API is a public origin (api.teambalance.nl) and no Spring Security
+ * is wired, so anything served under the `/internal/` prefix — a future admin/provision endpoint,
+ * plus the actuator's info/metrics — would be reachable from the internet. This filter fails those
+ * requests closed with 403, allowing through only the health probe that Scaleway's Serverless
+ * Container needs (`/internal/actuator/health`, with or without a trailing slash).
+ *
+ * The match is on the DECODED, NORMALIZED path (the same one the servlet container routes on), not
+ * the raw request URI, so equivalent spellings — `//internal`, `/./internal`, a `%2e`-encoded prefix,
+ * or `/internal/actuator/health/../metrics` — can't slip past the guard onto an internal handler.
+ * `application-prod.yml` additionally narrows actuator exposure to `health`, so info/metrics are a
+ * 404 there too — this filter is the defence-in-depth layer that also covers any future `/internal`.
+ *
+ * Prod-only (`@Profile("prod")`): dev keeps the full actuator, and e2e needs `/internal/e2e/...`.
+ * Runs first (HIGHEST_PRECEDENCE) so it gates before any context-setup filter or handler.
+ */
+@Component
+@Profile("prod")
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class InternalEndpointGuardFilter : OncePerRequestFilter() {
+
+    private val urlPathHelper = UrlPathHelper()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val path = StringUtils.cleanPath(urlPathHelper.getPathWithinApplication(request))
+        val isInternal = path == INTERNAL_PREFIX || path.startsWith("$INTERNAL_PREFIX/")
+        val isHealth = path.removeSuffix("/") == HEALTH_PATH
+        if (isInternal && !isHealth) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN)
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private companion object {
+        // The private namespace convention. `/internal/actuator` (application.yml
+        // management.endpoints.web.base-path) lives under it; a future admin surface would too.
+        const val INTERNAL_PREFIX = "/internal"
+        const val HEALTH_PATH = "/internal/actuator/health"
+    }
+}

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -21,6 +21,13 @@ server:
         same-site: lax
 
 management:
+  endpoints:
+    web:
+      exposure:
+        # Blocker #5: only expose the health probe in prod. info/metrics (exposed in the base config
+        # for local use) would otherwise be publicly reachable on api.teambalance.nl.
+        # InternalEndpointGuardFilter blocks them at the servlet layer too — this is defence in depth.
+        include: health
   health:
     redis:
       # Redis is on the classpath (Phase-5 infra) but unused in 1.0 — sessions are the servlet

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilterTest.kt
@@ -1,0 +1,56 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+/**
+ * Pure path-matching unit for the prod `/internal` guard (blocker #5). The filter must gate on the
+ * DECODED, NORMALIZED path — the same one the servlet container routes on — so equivalent spellings
+ * (`//internal`, `/./internal`, `%2e`-encoded, `/health/../metrics`) can't slip past. Exercising the
+ * filter directly is the lowest layer that proves this; the prod-profile wiring seam (filter actually
+ * registered) is covered by ProdProfileSmokeIT.
+ */
+class InternalEndpointGuardFilterTest : FunSpec({
+    val filter = InternalEndpointGuardFilter()
+
+    fun run(uri: String): Pair<Boolean, Int> {
+        val request = MockHttpServletRequest("GET", uri)
+        val response = MockHttpServletResponse()
+        var proceeded = false
+        filter.doFilter(request, response) { _, _ -> proceeded = true }
+        return proceeded to response.status
+    }
+
+    context("lets through") {
+        test("the exact health probe Scaleway uses") {
+            run("/internal/actuator/health").first shouldBe true
+        }
+        test("the health probe with a trailing slash") {
+            run("/internal/actuator/health/").first shouldBe true
+        }
+        test("a public /api path") {
+            run("/api/events").first shouldBe true
+        }
+    }
+
+    context("blocks with 403") {
+        listOf(
+            "the actuator metrics endpoint" to "/internal/actuator/metrics",
+            "the actuator info endpoint" to "/internal/actuator/info",
+            "a future admin/provision endpoint" to "/internal/admin/teams/team_setpoint_vt/provision",
+            "a leading-double-slash spelling" to "//internal/admin/teams/team_setpoint_vt/provision",
+            "a dot-segment spelling" to "/./internal/admin/teams/team_setpoint_vt/provision",
+            "a percent-encoded spelling" to "/%2e/internal/admin/teams/team_setpoint_vt/provision",
+            "a traversal out of the health path" to "/internal/actuator/health/../env",
+        ).forEach { (name, uri) ->
+            test("blocks $name") {
+                val (proceeded, status) = run(uri)
+                proceeded shouldBe false
+                status shouldBe HttpServletResponse.SC_FORBIDDEN
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
@@ -89,6 +89,19 @@ class ProdProfileSmokeIT : TeamBalanceIT() {
             preflight(origin = "https://evil.example.com")
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
+
+        // Blocker #5 — proves InternalEndpointGuardFilter is registered and active in the prod
+        // profile. The guard's path-matching logic (alternate spellings, traversal) is proven at the
+        // unit layer in InternalEndpointGuardFilterTest; these two assertions cover the wiring seam.
+        test("the health probe stays publicly reachable in prod (Scaleway health check)") {
+            mockMvc.perform(MockMvcRequestBuilders.get("/internal/actuator/health"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+        }
+
+        test("everything else under /internal is blocked in prod") {
+            mockMvc.perform(MockMvcRequestBuilders.get("/internal/actuator/metrics"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
     }
 
     private fun preflight(origin: String) = mockMvc.perform(


### PR DESCRIPTION
## What & why

Launch blocker #5. In prod the API is a public origin (`api.teambalance.nl`) with **no Spring Security wired**, so the actuator's `info`/`metrics` — and any future `/internal/admin/provision` endpoint — would be reachable from the internet. Scaleway's Serverless Container only needs `/internal/actuator/health` to stay public.

## Approach (api-only)

- **Prod-only servlet filter** (`InternalEndpointGuardFilter`, `@Profile("prod")`, `HIGHEST_PRECEDENCE`): fails closed with **403** for everything under `/internal`, allowing through only `/internal/actuator/health` (with or without a trailing slash — so a trailing-slash probe can't accidentally take the container down).
- Matches on the **decoded, normalized path** (`UrlPathHelper` + `StringUtils.cleanPath`), not the raw request URI, so alternate spellings — `//internal`, `/./internal`, `%2e`-encoded prefix, `/internal/actuator/health/../metrics` — can't slip past onto an internal handler.
- **Narrow actuator web exposure to `health`** in `application-prod.yml`, so `info`/`metrics` are a 404 in prod regardless (defence in depth).

Chosen over an edge/network restriction because it's app-layer, unit-testable, independent of Scaleway edge config, and future-proofs any `/internal/admin` endpoint.

## Tests (lowest layer that proves it)

- `InternalEndpointGuardFilterTest` — pure Kotest unit over the path-matching logic: health (+ trailing slash) and `/api` pass; metrics/info/admin and all three alternate spellings + traversal are blocked with 403.
- Two assertions folded into the existing `ProdProfileSmokeIT` (no second prod context boot) prove the filter is **registered and active in the real prod profile**: `/internal/actuator/health` → 200, `/internal/actuator/metrics` → 403.

Full `:api:test` green (83 tests, 0 failures); detekt clean.

## No new e2e

Per the repo PR gate: no new auth path, cross-tenant write, or external integration seam — this is a prod-profile wiring concern proven at the unit + prod-IT layers. No e2e added.

## Note on scope

Blocker #4 (relocate demo seed) is **already satisfied on `main`** — the demo seed lives at `db/seed/demo_data.sql` applied only by `DemoDataSeeder` (`@Profile("dev")`), prod's `flyway.locations` is just `classpath:db/migration`, and `ProdProfileSmokeIT` already asserts prod doesn't load the seeder. Tenant `V002__seed_event_types` (Training/Match/Other) is legitimate baseline reference data every team needs → kept. So this PR covers #5 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)