### PR TITLE
feat(prod): Hikari minimum-idle=0 so the scale-to-zero SQL DB can pause

### DIFF
--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -4,6 +4,16 @@
 # environment variables via Spring relaxed binding — never committed here. This profile also
 # activates ScalewayTemEmailSender (@Profile("prod")) in place of ConsoleEmailSender.
 
+spring:
+  datasource:
+    hikari:
+      # The prod Serverless SQL DB scales to zero after ~5 min idle. Keep NO minimum idle pool so
+      # Hikari lets connections drain to zero instead of proactively reopening them to maintain a
+      # minimum — otherwise that reopening traffic keeps waking the DB and defeats scale-to-zero.
+      # Connections are opened on demand; the DB resumes in <5s, well within the default 30s
+      # connectionTimeout. See docs/plans/2026-07-17-v1-production-launch-scaleway.md.
+      minimum-idle: 0
+
 # Split-origin CORS (launch blocker #3): the SPA (app.teambalance.nl) and landing page
 # (teambalance.nl) call api.teambalance.nl cross-origin with the session cookie. See WebConfig.
 teambalance:

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
@@ -4,9 +4,11 @@ import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.domain.port.EmailSender
 import com.github.zzave.teambalance.api.infrastructure.devdata.DemoDataSeeder
 import com.github.zzave.teambalance.api.infrastructure.email.ScalewayTemEmailSender
+import com.zaxxer.hikari.HikariDataSource
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.web.server.Cookie
 import org.springframework.boot.web.server.autoconfigure.ServerProperties
@@ -52,6 +54,13 @@ class ProdProfileSmokeIT : TeamBalanceIT() {
             val cookie = serverProperties.servlet.session.cookie
             cookie.secure shouldBe true
             cookie.sameSite shouldBe Cookie.SameSite.LAX
+        }
+
+        test("prod profile keeps no minimum idle DB pool (so the scale-to-zero DB can pause)") {
+            // application-prod.yml sets spring.datasource.hikari.minimum-idle=0 so Hikari does not
+            // proactively reopen connections to the Serverless SQL DB, which would keep waking it.
+            val dataSource = applicationContext.getBean(DataSource::class.java).shouldBeInstanceOf<HikariDataSource>()
+            dataSource.minimumIdle shouldBe 0
         }
 
         test("prod profile activates the Scaleway TEM email sender") {


### PR DESCRIPTION
## What
Set `spring.datasource.hikari.minimum-idle=0` in the **prod** profile (`application-prod.yml`).

## Why
The prod **Serverless SQL Database** (Scaleway, fr-par) scales to zero after ~5 min idle. With Hikari's default `minimum-idle` (= `maximum-pool-size` = 10), the pool proactively **reopens** connections to maintain that minimum, and the reopen traffic keeps **waking the DB** — undercutting scale-to-zero and its cost saving. With `minimum-idle=0` the pool drains to zero when idle; connections open on demand and the DB resumes in **<5s** (per Scaleway docs), comfortably inside Hikari's default 30s `connectionTimeout`.

This is the tuning called out in the V1 launch plan, and the last piece of the "warm container + scale-to-zero DB" topology confirmed live this week.

## Testing
- `ProdProfileSmokeIT` (pure `prod` profile, Testcontainers Postgres) now asserts the autowired `HikariDataSource.minimumIdle == 0` — proves the prod binding, catches a future regression/typo before deploy. **PR gate:** backend config → covered by a Testcontainers IT at the lowest layer that proves it; no new e2e (no new seam).
- `:api:test --tests *ProdProfileSmokeIT*` → BUILD SUCCESSFUL. `:api:detekt` → clean.

## Deploy note
Config-only, prod profile. Takes effect on the next container image deploy; no infra change required. No behavioural change beyond connection-pool idling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpJj9QRUCzLM3axkAuwVta