### PR TITLE
ci: manual (workflow_dispatch) production deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,184 @@
+name: Deploy (manual)
+
+# MANUAL deploy only. This never fires on push to main — a human triggers it
+# deliberately from the Actions tab (workflow_dispatch). It codifies the proven
+# by-hand deploy of the API (image -> Scaleway Container Registry -> Serverless
+# Container) and the frontend (SPA + landing -> Object Storage -> Edge purge).
+#
+# SAFETY: `dry_run` defaults to true. A run with the defaults BUILDS the artifacts
+# (proving the build) but pushes/deploys/syncs NOTHING. Flip `dry_run` to false to
+# perform a real deploy. See docs/ops/deploy.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: What to deploy
+        type: choice
+        default: both
+        options: [both, api, frontend]
+      image_tag:
+        description: 'API image tag (default: short commit SHA)'
+        type: string
+        default: ''
+      dry_run:
+        description: Build only — skip push/deploy/sync/purge
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+# Never let two deploys race the shared prod resources.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+env:
+  SCW_REGION: fr-par
+  REGISTRY: rg.fr-par.scw.cloud/teambalance
+  CONTAINER_ID: ec9dfda3-65ca-4901-a640-895fd2f9f5f3
+  # Object Storage buckets (fr-par) + Edge Services pipeline ids.
+  S3_ENDPOINT: https://s3.fr-par.scw.cloud
+  SPA_BUCKET: teambalance-spa
+  WWW_BUCKET: teambalance-www
+  SPA_PIPELINE: f6b8a00d-9a40-4ceb-8d94-82d9383a7515
+  WWW_PIPELINE: 881dea79-6072-449a-99dd-75c019db3c79
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # API: build linux/amd64 image -> push to Container Registry -> update the
+  # Serverless Container to the new tag (image-only update leaves env/secret
+  # maps untouched — see docs/ops/deploy.md).
+  # ---------------------------------------------------------------------------
+  deploy-api:
+    if: ${{ inputs.target == 'both' || inputs.target == 'api' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          [ -z "$TAG" ] && TAG="${GITHUB_SHA::12}"
+          echo "image=${REGISTRY}/api:${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved image: ${REGISTRY}/api:${TAG}"
+
+      # ubuntu-latest is amd64, so --platform=linux/amd64 is native (no emulation).
+      # The build runs the Gradle wrapper + buildSrc + Java 25 toolchain INSIDE the
+      # multi-stage image (api/Dockerfile), so the runner needs no JDK/Gradle setup.
+      - name: Build API image (linux/amd64)
+        run: docker build --platform=linux/amd64 -f api/Dockerfile -t "${{ steps.tag.outputs.image }}" .
+
+      - name: Configure Scaleway CLI
+        if: ${{ !inputs.dry_run }}
+        uses: scaleway/action-scw@v0
+        with:
+          version: v2.58.3
+          save-config: true
+          export-config: true
+          access-key: ${{ secrets.SCW_ACCESS_KEY }}
+          secret-key: ${{ secrets.SCW_SECRET_KEY }}
+          default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+          default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
+
+      - name: Push image to Container Registry
+        if: ${{ !inputs.dry_run }}
+        run: |
+          echo "${{ secrets.SCW_SECRET_KEY }}" | docker login "${REGISTRY%%/*}" -u nologin --password-stdin
+          docker push "${{ steps.tag.outputs.image }}"
+
+      - name: Update Serverless Container
+        if: ${{ !inputs.dry_run }}
+        run: scw container container update "$CONTAINER_ID" image="${{ steps.tag.outputs.image }}" region="$SCW_REGION"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN — image built but not pushed/deployed."
+          echo "Would push:   ${{ steps.tag.outputs.image }}"
+          echo "Would update: container $CONTAINER_ID -> that image"
+
+  # ---------------------------------------------------------------------------
+  # Frontend: build the SPA (prod mode reads app/.env.production -> VITE_API_URL)
+  # and the landing page -> sync to Object Storage -> purge the Edge cache.
+  # S3 sync uses the DEDICATED Object Storage IAM key (SCW_S3_*), not the main key.
+  # ---------------------------------------------------------------------------
+  deploy-frontend:
+    if: ${{ inputs.target == 'both' || inputs.target == 'frontend' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # The SPA imports the Wirespec-generated TS client, which is gitignored and
+      # emitted by Gradle into app/src/shared/api/generated. Generate it before the
+      # SPA build or the vite build fails on missing ./generated/* modules.
+      - name: Generate Wirespec TypeScript client
+        run: ./gradlew :api:wirespec-typescript
+
+      # `vite build` runs in production mode and loads app/.env.production
+      # (VITE_API_URL=https://api.teambalance.nl) automatically — no env needed here.
+      - name: Build SPA
+        run: |
+          npm ci
+          npm run build
+        working-directory: app
+
+      - name: Configure Scaleway CLI
+        if: ${{ !inputs.dry_run }}
+        uses: scaleway/action-scw@v0
+        with:
+          version: v2.58.3
+          save-config: true
+          export-config: true
+          access-key: ${{ secrets.SCW_ACCESS_KEY }}
+          secret-key: ${{ secrets.SCW_SECRET_KEY }}
+          default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+          default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
+
+      - name: Sync SPA + landing to Object Storage
+        if: ${{ !inputs.dry_run }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SCW_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SCW_S3_SECRET_KEY }}
+          AWS_DEFAULT_REGION: fr-par
+        run: |
+          set -euo pipefail
+          # SPA: content-hashed assets are immutable + pruned; index.html must never cache.
+          aws --endpoint-url "$S3_ENDPOINT" s3 sync app/dist/assets "s3://${SPA_BUCKET}/assets" \
+            --cache-control "public,max-age=31536000,immutable" --delete
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp app/dist/index.html "s3://${SPA_BUCKET}/index.html" \
+            --cache-control no-cache
+          # Landing page: index.html + style.css at root, tokens.css under /design-tokens/
+          # (www/index.html references ../design-tokens/tokens.css).
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp www/index.html "s3://${WWW_BUCKET}/index.html" \
+            --cache-control no-cache
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp www/style.css "s3://${WWW_BUCKET}/style.css"
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp design-tokens/tokens.css "s3://${WWW_BUCKET}/design-tokens/tokens.css"
+
+      - name: Purge Edge Services cache
+        if: ${{ !inputs.dry_run }}
+        run: |
+          scw edge-services purge-request create pipeline-id="$SPA_PIPELINE" all=true
+          scw edge-services purge-request create pipeline-id="$WWW_PIPELINE" all=true
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN — SPA + landing built but not synced/purged."
+          echo "Would sync app/dist -> s3://${SPA_BUCKET}, www/ + tokens.css -> s3://${WWW_BUCKET}"
+          echo "Would purge Edge pipelines: $SPA_PIPELINE, $WWW_PIPELINE"

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -1,0 +1,62 @@
+# Deploy runbook (manual)
+
+Production deploys are **manual and deliberate**. There is no auto-deploy on push to
+`main`. The `.github/workflows/deploy.yml` workflow codifies the proven by-hand steps
+so a human can trigger them reproducibly from the Actions tab.
+
+## Trigger
+
+Actions → **Deploy (manual)** → *Run workflow*. Inputs:
+
+| Input | Default | Meaning |
+|-------|---------|---------|
+| `target` | `both` | `api`, `frontend`, or `both` — the two jobs are independent. |
+| `image_tag` | *(empty)* | API image tag. Empty → the 12-char commit SHA. Use a semantic tag (e.g. `v3`) for release deploys you want to roll back to. |
+| `dry_run` | **`true`** | Safety gate. `true` **builds** the artifacts (proving the build) but pushes/deploys/syncs **nothing**. Set to `false` for a real deploy. |
+
+> A default run (dry_run=true) is a no-op deploy: it verifies both builds and prints
+> what *would* happen. **A real deploy requires explicitly setting `dry_run: false`.**
+
+## What it does (mirrors the manual process)
+
+**`deploy-api`** — builds `api/Dockerfile` for **linux/amd64** (the Serverless Container
+rejects other arches), pushes to `rg.fr-par.scw.cloud/teambalance/api:<tag>`, then updates
+Serverless Container `ec9dfda3-65ca-4901-a640-895fd2f9f5f3` (fr-par) to that image. The
+Gradle build (buildSrc + Java 25 toolchain) runs *inside* the multi-stage image, so the
+runner needs no JDK/Gradle. An **image-only** container update leaves the container's
+environment and secret maps untouched — only the map you pass is replaced.
+
+**`deploy-frontend`** — builds the SPA (`vite build` auto-loads `app/.env.production` →
+`VITE_API_URL=https://api.teambalance.nl`), syncs `app/dist` → `s3://teambalance-spa`
+(hashed assets `immutable`, `index.html` `no-cache`) and the landing page + design tokens
+→ `s3://teambalance-www`, then purges both Edge Services pipelines. S3 uses the **dedicated
+Object Storage IAM key** (`SCW_S3_*`), because buckets live in the API key's own default
+project and only that key's project is `teambalance`.
+
+## Required GitHub Actions secrets
+
+Set these in **Settings → Secrets and variables → Actions** (names only — never commit values):
+
+| Secret | Used for |
+|--------|----------|
+| `SCW_ACCESS_KEY` | scw CLI auth (container update, Edge purge). |
+| `SCW_SECRET_KEY` | scw CLI auth **and** Container Registry `docker login` (user `nologin`). |
+| `SCW_DEFAULT_PROJECT_ID` | scw CLI default project (`teambalance`, `5eb5484d-…`). |
+| `SCW_DEFAULT_ORGANIZATION_ID` | scw CLI default organization. |
+| `SCW_S3_ACCESS_KEY` | Object Storage sync — dedicated `teambalance-object-storage` IAM key. |
+| `SCW_S3_SECRET_KEY` | Object Storage sync — its secret. |
+
+The first four may be a general Scaleway key with Registry + Serverless Containers +
+Edge Services rights. The `SCW_S3_*` pair must be the dedicated Object-Storage key whose
+default project is `teambalance` (see the frontend-deploy notes).
+
+## Rollback
+
+Re-run with `target: api`, `image_tag:` set to a previously deployed tag (e.g. `v1`),
+`dry_run: false`. Old image tags are retained in the registry for exactly this.
+
+## Notes / hardening ideas
+
+- The `v*` git-tag trigger was intentionally **omitted** to keep deploy strictly a
+  deliberate `workflow_dispatch` action. Add it later if release-tag = deploy is wanted.
+- For an extra approval gate, attach the jobs to a protected GitHub `environment`.


### PR DESCRIPTION
## What

V1 launch task #10 — codify the proven by-hand Scaleway deploy into a **manual** GitHub Actions workflow (`.github/workflows/deploy.yml`) + an ops runbook (`docs/ops/deploy.md`).

**Deploy stays manual.** Trigger is `workflow_dispatch` only — it **never** auto-deploys on push to `main`. A `dry_run` input (**default `true`**) builds the artifacts (proving the build) but pushes/deploys/syncs nothing; a real deploy requires explicitly setting `dry_run: false`.

## Jobs (independent, selectable via `target` input)

- **`deploy-api`** — build `api/Dockerfile` for **linux/amd64** → push to Container Registry (`rg.fr-par.scw.cloud/teambalance/api:<tag>`) → update Serverless Container `ec9dfda3-…` (fr-par) to the new tag (image-only update leaves env/secret maps untouched). Gradle/buildSrc/Java-25 build runs inside the image, so the runner needs no JDK.
- **`deploy-frontend`** — generate the Wirespec TS client → build SPA (prod mode reads `app/.env.production` → `VITE_API_URL=https://api.teambalance.nl`) + landing page → sync to Object Storage (`teambalance-spa` / `teambalance-www`) → purge both Edge Services pipelines. S3 uses the dedicated Object-Storage IAM key.

## Required GitHub Actions secrets (add before first real run)

Set in **Settings → Secrets and variables → Actions** (names only; values never committed or printed):

- `SCW_ACCESS_KEY`
- `SCW_SECRET_KEY` — also used for Container Registry `docker login` (user `nologin`)
- `SCW_DEFAULT_PROJECT_ID`
- `SCW_DEFAULT_ORGANIZATION_ID`
- `SCW_S3_ACCESS_KEY` — dedicated Object-Storage IAM key (buckets live in its default project)
- `SCW_S3_SECRET_KEY`

## Verification (no real deploy performed)

- `actionlint` (incl. shellcheck on `run:` blocks): **clean**, exit 0.
- SPA build proven locally: caught & fixed a missing step — the frontend job now generates the Wirespec TS client before `vite build` (else it fails on missing `./generated/*`). Confirmed `dist/` = `assets/` + `index.html` (matches the sync) and `https://api.teambalance.nl` is baked into the bundle.
- API image build is the identical `docker build --platform=linux/amd64 -f api/Dockerfile .` command that produced the live `:v1`/`:v2` images (not re-run here to avoid load).
- **No production deploy was run from this task** — deliverable is workflow + docs only.

## Notes

- `v*` git-tag trigger intentionally omitted to keep deploy strictly deliberate; documented as a future option in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdgbwQ7mM9fzX7AHjcMbwx