### PR TITLE
test: govern invite-flow.test.tsx as 3rd sanctioned MSW/RTL exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,12 @@ Four honest layers — place each new test at the **lowest layer that proves it*
 
 ### Sanctioned MSW/RTL exception
 
-The two auth render-gate Vitest tests (`app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx`) use `msw/node` to render the auth provider under controlled network conditions. They are the **single sanctioned exception** to the "Vitest owns only pure non-rendering logic" rule: the auth routing seam (fail-closed on error, verify-vs-/me race) cannot be forced into a meaningful failure state against a real backend, and it is not story-able. Do not remove them or use them as precedent for new RTL render tests.
+Three render-gate Vitest tests (`app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx`, `invite-flow.test.tsx`) use `msw/node` to render under controlled network conditions. They are the **only sanctioned exceptions** to the "Vitest owns only pure non-rendering logic" rule. Each guards a routing/network seam that cannot be forced into a meaningful failure state against a real backend and is not story-able:
+
+- **`auth-gate.test.tsx` / `verify-flow.test.tsx`** — the auth routing seam (fail-closed on error, verify-vs-/me race).
+- **`invite-flow.test.tsx`** — the invite-acceptance routing seam. The invite token is carried across **two separate router mounts** (`/invite/:token`, then `/auth/verify` when the emailed link is clicked — a real page reload) via `localStorage`, and the verify page's **fail-closed accept ordering** ("a failed accept must not leave the user authenticated but teamless") requires a valid magic-link token paired with a simultaneously-expired invite — a state a real backend won't produce on demand. A single Storybook story can't mount two routes and assert the redirect. The *pure* email-match gate under the carry (don't inherit someone else's invite) is pushed down to a Vitest unit (`shared/api/invitations.test.ts`); only the irreducible cross-mount seam stays here.
+
+Do not remove these or use them as precedent for new RTL render tests. A fourth would need the same bar: a genuine cross-mount/network seam with no story or real-backend path — not merely "it was easier to render."
 
 See [`docs/testing.md`](docs/testing.md) for command mechanics, the Vitest/Storybook bright line, and real-e2e gotchas.
 

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -7,8 +7,15 @@ import { routeTree } from '../../routeTree.gen'
 import type { AuthenticatedUser } from '@shared/api/auth'
 import { queryClient } from '@shared/api/query-client'
 
-// Mirrors verify-flow.test.tsx's stateful-session approach, plus a stateful invitation so accept
-// can be proven idempotent/rejecting without touching the real backend.
+// SANCTIONED MSW/RTL exception #3 (see CLAUDE.md "Sanctioned MSW/RTL exception"). Mirrors
+// verify-flow.test.tsx's stateful-session approach, plus a stateful invitation so accept can be
+// proven rejecting without touching the real backend. What makes this irreducible to a
+// story/unit: the invite token is carried across TWO separate router mounts (/invite/:token then
+// /auth/verify — a real page reload when the emailed link is clicked) via localStorage, and the
+// verify page's fail-closed accept ordering ("a failed accept must not leave the user
+// authenticated but teamless") cannot be forced against a real backend, which won't hand you a
+// valid magic-link token paired with a simultaneously-expired invite. The pure email-match gate
+// underneath this carry is unit-tested separately in shared/api/invitations.test.ts.
 let session: AuthenticatedUser | null = null
 let accepted = false
 

--- a/app/src/shared/api/invitations.test.ts
+++ b/app/src/shared/api/invitations.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { savePendingInviteToken, takePendingInviteTokenForEmail } from './invitations'
+
+// Pure client-side gate for the pending-invite-token carry (no network, no rendering). The RTL
+// invite-flow test proves the cross-page-load round trip end to end; this covers the security
+// branch it can't cheaply force — a verified user whose email does NOT match the one the invite
+// was requested with must not silently inherit someone else's invite.
+afterEach(() => localStorage.clear())
+
+describe('pending invite token gate', () => {
+  it('hands the token back when the verified email matches the one it was saved for', () => {
+    savePendingInviteToken('invite-abc', 'newbie@example.com')
+    expect(takePendingInviteTokenForEmail('newbie@example.com')).toBe('invite-abc')
+  })
+
+  it('withholds the token when a different email verifies (no silently accepting someone else\'s invite)', () => {
+    savePendingInviteToken('invite-abc', 'newbie@example.com')
+    expect(takePendingInviteTokenForEmail('someone-else@example.com')).toBeNull()
+  })
+
+  it('returns null when no invite token was pending', () => {
+    expect(takePendingInviteTokenForEmail('newbie@example.com')).toBeNull()
+  })
+
+  it('always clears both keys, even on an email mismatch, so a stale token can never leak into a later sign-in', () => {
+    savePendingInviteToken('invite-abc', 'newbie@example.com')
+
+    takePendingInviteTokenForEmail('someone-else@example.com')
+
+    expect(localStorage.getItem('tb-pending-invite-token')).toBeNull()
+    expect(localStorage.getItem('tb-pending-invite-email')).toBeNull()
+  })
+})

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,7 +21,12 @@ This is the enforced split: if it renders, it belongs in a story, not a Vitest u
 
 ### Sanctioned exception
 
-The two auth render-gate tests (`app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx`) use `msw/node` to render the auth provider under controlled 500/204 network conditions. The auth routing seam — fail-closed on network error, race between verify and /me — cannot be forced into a meaningful failure state against a real backend, and it is not story-able (depends on React Router state and network interception beyond a story's reach). These are the **single sanctioned exception** to the no-RTL rule. Do not treat them as precedent.
+Three render-gate tests use `msw/node` to render under controlled network conditions. They are the **only sanctioned exceptions** to the no-RTL rule; do not treat them as precedent.
+
+- `app/src/app/providers/auth-gate.test.tsx`, `verify-flow.test.tsx` — the auth routing seam (fail-closed on network error, race between verify and /me) cannot be forced into a meaningful failure state against a real backend, and is not story-able (depends on React Router state and network interception beyond a story's reach).
+- `app/src/app/providers/invite-flow.test.tsx` — the invite-acceptance seam: the invite token is carried across two separate router mounts (`/invite/:token`, then `/auth/verify` on link-click) via `localStorage`, and the fail-closed accept ordering needs a valid magic-link token paired with a simultaneously-expired invite — unforceable against a real backend, and a single story can't mount two routes to assert the redirect. The pure email-match gate under the carry lives at the Vitest-unit layer (`shared/api/invitations.test.ts`); only the cross-mount seam stays as RTL.
+
+See CLAUDE.md for the full justification and the bar a fourth exception would have to clear.
 
 ## What is deliberately not tested
 


### PR DESCRIPTION
## Task #13 (governance): decide the fate of `invite-flow.test.tsx`

`invite-flow.test.tsx` was a **third** MSW/RTL render test beyond the two CLAUDE.md-sanctioned exceptions, violating the "Vitest owns only pure non-rendering logic; component states go to Storybook" bright line.

### Decision: keep it — but push the one genuinely-pure piece down a layer

I followed CLAUDE.md's own reasoning template. The file asserts three behaviours, and its core is an **irreducible routing/network seam**:

- The invite token is carried across **two separate router mounts** (`/invite/:token`, then `/auth/verify` when the emailed link is clicked — a real page reload) via `localStorage`.
- The verify page's **fail-closed accept ordering** ("a failed accept must not leave the user authenticated but teamless") needs a valid magic-link token paired with a *simultaneously-expired* invite — a state a real backend won't produce on demand.
- A single Storybook story can't mount two routes and assert the redirect.

This is the same class as the sanctioned `auth-gate` / `verify-flow` tests, so **relocation of the seam itself isn't possible without a weaker assertion**.

### What moved down a layer

The one genuinely *pure* piece — `takePendingInviteTokenForEmail`'s email-match gate (don't silently inherit someone else's invite) — is now a **Vitest unit** (`app/src/shared/api/invitations.test.ts`). The mismatch branch was previously **untested at any layer** (the RTL test only exercised the matching-email path).

### Governance

- CLAUDE.md + `docs/testing.md` updated: exception count corrected to **three**, each with a per-test justification, plus the bar a 4th exception must clear so this doesn't become open-ended precedent.
- `invite-flow.test.tsx` header comment rewritten to state *why* it's irreducible.

### Verification

- `make test-app` green — **67 tests** (was 63; +4 new units).
- ESLint clean; pre-commit detekt hook passed.

### PR gate

No new e2e: the change introduces no new seam beyond what the login/attendance flows already exercise — it's test governance + a relocated unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)