### PR TITLE
fix(api): unbreak prod deploy — AOT bake stage Postgres install + resilience

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -52,19 +52,30 @@ FROM eclipse-temurin:25-jdk AS bake
 WORKDIR /app
 COPY --from=build /workspace/app.jar /app/app.jar
 
-# postgresql-16 auto-creates the Debian "main" cluster; the pg_ctlcluster wrapper drops privileges.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends postgresql-16 \
- && rm -rf /var/lib/apt/lists/*
-
 # Keep the jar path identical to the runtime stage (/app/app.jar): the AOT cache validates the
-# classpath it was recorded against. `|| true` + the touch guard keep the build green even if the
-# training run fails — the runtime then boots without a cache (fail-safe), never broken.
-RUN set -eux; \
-    pg_ctlcluster 16 main start; \
-    su postgres -c "psql -v ON_ERROR_STOP=1 -c \"CREATE USER tb WITH PASSWORD 'tb' SUPERUSER;\""; \
-    su postgres -c "createdb -O tb teambalance"; \
-    ( SPRING_PROFILES_ACTIVE=prod \
+# classpath it was recorded against.
+#
+# Package name: the base image is Ubuntu, whose default archive ships an UNVERSIONED `postgresql`
+# meta-package (whichever major that release carries — e.g. 17 on "resolute"), NOT `postgresql-16`
+# (that needs the external PGDG repo). Any recent Postgres serves a one-off training refresh fine,
+# so we install the meta-package and derive the auto-created cluster's version dynamically.
+#
+# The ENTIRE bake is BEST-EFFORT: the whole block is wrapped so ANY failure (apt, cluster start,
+# training run) degrades to an empty /app/app.aot and the image build still SUCCEEDS. At runtime
+# -XX:AOTCache fails safe on a missing/empty/mismatched cache (warns, boots normally). So a broken
+# bake costs only the cache-layer speedup — never the deploy. The Spring AOT bean-definition speedup
+# is independent: it lives in the jar and is always active via -Dspring.aot.enabled, so it survives
+# even a failed bake.
+RUN set -x; \
+    ( set -e; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends postgresql; \
+      rm -rf /var/lib/apt/lists/*; \
+      PGVER="$(pg_lsclusters -h | awk 'NR==1{print $1}')"; \
+      pg_ctlcluster "$PGVER" main start; \
+      su postgres -c "psql -v ON_ERROR_STOP=1 -c \"CREATE USER tb WITH PASSWORD 'tb' SUPERUSER;\""; \
+      su postgres -c "createdb -O tb teambalance"; \
+      SPRING_PROFILES_ACTIVE=prod \
       SPRING_DATASOURCE_URL=jdbc:postgresql://127.0.0.1:5432/teambalance \
       SPRING_DATASOURCE_USERNAME=tb \
       SPRING_DATASOURCE_PASSWORD=tb \
@@ -75,8 +86,9 @@ RUN set -eux; \
            -XX:AOTCacheOutput=/app/app.aot \
            -Dspring.aot.enabled=true \
            -Dspring.context.exit=onRefresh \
-           -jar /app/app.jar ) || echo "WARN: AOT-cache training run failed; runtime will boot without a cache"; \
-    pg_ctlcluster 16 main stop; \
+           -jar /app/app.jar; \
+      pg_ctlcluster "$PGVER" main stop; \
+    ) || echo "WARN: AOT-cache bake failed; runtime will boot without the cache (fail-safe)"; \
     touch /app/app.aot
 
 # ---- runtime stage -----------------------------------------------------------


### PR DESCRIPTION
## Problem

The **Deploy (manual)** run on `main` after #94 merged **failed** — while CI on the same SHA passed. CI only runs Gradle; the deploy builds the Docker image, which includes the Phase 2 **AOT-cache bake stage**, and that's what broke:

```
[bake 4/5] RUN apt-get install -y --no-install-recommends postgresql-16
E: Unable to locate package postgresql-16
ERROR: process "…postgresql-16…" did not complete successfully: exit code: 100
```

Root cause: the bake base image `eclipse-temurin:25-jdk` is **Ubuntu 25.10 "resolute"**, whose default archive ships an unversioned `postgresql` (major 17), with **no `postgresql-16`** package (that needs the external PGDG apt repo). The failing `apt-get` sat *outside* the existing `|| echo WARN` guard, so it hard-failed the whole image build — and therefore the deploy.

## Fix

Two changes, both in `api/Dockerfile`'s bake stage:

1. **Correct package** — install the unversioned `postgresql` meta-package and derive the auto-created cluster's version dynamically (`pg_lsclusters`), instead of hardcoding `postgresql-16` / `pg_ctlcluster 16`. Any recent Postgres serves a one-off training refresh fine.
2. **Make the bake un-break-able** — wrap the *entire* bake (apt + cluster + training run) in a best-effort block so **any** failure degrades to an empty `/app/app.aot` and the image build still succeeds. At runtime `-XX:AOTCache` fails safe on a missing/empty/mismatched cache (warns, boots normally). So a broken bake costs only the cache-layer speedup — never the deploy.

**Note:** the Spring AOT bean-definition speedup (the big one — it eliminates ~6.9s of runtime `@Configuration` parsing, per the prod `/actuator/startup` tree) lives in the jar and is always active via `-Dspring.aot.enabled`. It is independent of the cache, so it survives even a failed bake.

## Verification

- `sh -n` syntax-check of the embedded bake script — passes; env-var prefixes correctly continue onto the `java` line.
- **Cannot** build the image in the dev/CI sandbox (the proxy blocks the base-image and apt pulls), same limitation that let the original bug through. This is validated by **re-running the Deploy workflow** on this branch/after merge.

## Follow-up branch note

#93's branch merged and was auto-deleted, so per the follow-up-work flow this restarts `claude/startup-time-optimization-39nsfc` from the latest `main` (only already-merged history was discarded) and carries just this hotfix commit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_