### PR TITLE
fix(api): bake AOT cache on the JRE base to match runtime (recovers the cache layer)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -48,7 +48,13 @@ RUN ./gradlew --no-daemon --no-configuration-cache :api:bootJar \
 # metamodel init and repository bootstrap, not just the pre-DB classload gap. Secrets are build-time
 # dummies: AOT-processed prod boot instantiates ScalewayTemEmailSender (builds a RestClient) but
 # never sends mail, and the token salt is only read when a login is served.
-FROM eclipse-temurin:25-jdk AS bake
+#
+# BASE MUST MATCH THE RUNTIME STAGE (eclipse-temurin:25-jre). The AOT cache records the exact JVM
+# image it was built against; the runtime rejects a cache whose `lib/modules` differs. The JDK and
+# JRE images ship different module sets, so baking on `:25-jdk` while running on `:25-jre` produced
+# "[aot] This file is not the one used while building the shared archive file: .../lib/modules,
+# size has changed" → "Unable to map shared spaces", and the app fell back to no cache (fail-safe).
+FROM eclipse-temurin:25-jre AS bake
 WORKDIR /app
 COPY --from=build /workspace/app.jar /app/app.jar
 


### PR DESCRIPTION
## Symptom

Prod deploy **00011** boots fine, but the very first log lines are:

```
[aot] This file is not the one used while building the shared archive file:
      '/opt/java/openjdk/lib/modules', size has changed
[aot] Unable to map shared spaces
[aot] An error has occurred while processing the AOT cache.
```

The app then falls back to booting **without** the AOT cache (the fail-safe added in #96 doing its job).

## Cause

The bake stage built the AOT cache on `eclipse-temurin:25-jdk`, but the runtime stage is `eclipse-temurin:25-jre`. An AOT cache validates the exact JVM image it was recorded against, and the **JDK and JRE ship different `lib/modules`** (different module sets → different size). So the runtime rejected the cache.

## Fix

Bake on `eclipse-temurin:25-jre` — the same base as the runtime stage — so `lib/modules` matches and the cache maps. One-line `FROM` change plus an explanatory comment. (The JRE runs `-XX:AOTCacheOutput` and boots the app fine; no JDK tooling is needed for the training run.)

## Impact / context

This only recovers the **AOT-cache classload layer**. The **big** Phase 2 win — Spring AOT bean definitions — was *already* working in 00011 and is unaffected: it cut `Root WebApplicationContext initialization` from **15.7s → 2.8s** (runtime `@Configuration` parsing eliminated). Phase 3 also confirmed working (DB warm-up overlapped; HikariPool start 5.1s → 0.16s). Net so far: ~40s → **23.4s**.

Per the prod `/actuator/startup` tree, the dominant remaining cost is now `jpaMappingContext` (**~7.5s**, Hibernate metamodel build) — the AOT cache helps its *classload* portion but not the reflective metamodel construction, so this fix narrows the gap without closing it to <10s on its own. See the plan doc for the reassessed target.

## Verification

`FROM`-only change; **cannot** build the image here (proxy blocks base-image/apt pulls). Validated by the next Deploy: the `[aot] ... Unable to map shared spaces` errors should be gone and boot should drop further. If the cache still can't map, the #96 fail-safe keeps the deploy healthy regardless.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_