### PR TITLE
ci(deploy): codify 2 vCPU + gVisor sandbox v2 on the Serverless Container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,19 @@ env:
   SCW_REGION: fr-par
   REGISTRY: rg.fr-par.scw.cloud/teambalance
   CONTAINER_ID: ec9dfda3-65ca-4901-a640-895fd2f9f5f3
+  # Serverless Container resource + sandbox config, asserted on every real deploy (config-as-code,
+  # so prod never drifts to a console-only value). Cold-start levers per Scaleway's guidance
+  # (docs/plans/2026-07-24-startup-time-optimization.md, Phase 4):
+  #   - CPU_LIMIT is mvCPU (2000 = 2 vCPU). Raised from 1 vCPU because the boot is CPU-bound and the
+  #     deferred Hibernate metamodel build (jpaMappingContext, ~7.5s) runs on a background thread —
+  #     it only overlaps main-thread boot work with >=2 cores. Bump to A/B (e.g. 4000) and re-read
+  #     the `Started … in X seconds` line; take the knee of the curve.
+  #   - MEMORY_LIMIT is MB. CPU/memory MUST be a valid Scaleway combination (see the Containers
+  #     limitations docs) or `scw container container update` rejects the call and the deploy fails.
+  #   - SANDBOX=v2 is the gVisor sandbox, which Scaleway recommends for faster cold starts.
+  CONTAINER_CPU_LIMIT: '2000'
+  CONTAINER_MEMORY_LIMIT: '2048'
+  CONTAINER_SANDBOX: v2
   # Object Storage buckets (fr-par) + Edge Services pipeline ids.
   S3_ENDPOINT: https://s3.fr-par.scw.cloud
   SPA_BUCKET: teambalance-spa
@@ -48,8 +61,8 @@ env:
 jobs:
   # ---------------------------------------------------------------------------
   # API: build linux/amd64 image -> push to Container Registry -> update the
-  # Serverless Container to the new tag (image-only update leaves env/secret
-  # maps untouched — see docs/ops/deploy.md).
+  # Serverless Container to the new tag AND assert its cpu/memory/sandbox config
+  # (see below). Env/secret maps are still left untouched — see docs/ops/deploy.md.
   # ---------------------------------------------------------------------------
   deploy-api:
     if: ${{ inputs.target == 'both' || inputs.target == 'api' }}
@@ -89,16 +102,27 @@ jobs:
           echo "${{ secrets.SCW_SECRET_KEY }}" | docker login "${REGISTRY%%/*}" -u nologin --password-stdin
           docker push "${{ steps.tag.outputs.image }}"
 
+      # One atomic update: new image + the codified resource/sandbox config. cpu-limit/memory-limit
+      # accelerate the CPU-bound cold start; sandbox=v2 (gVisor) cuts it further. Env/secret maps are
+      # not passed, so they stay as-is. If the cpu/memory pair is not a valid Scaleway tier, this
+      # call fails loudly (the image is already pushed, so just fix the values and re-run).
       - name: Update Serverless Container
         if: ${{ !inputs.dry_run }}
-        run: scw container container update "$CONTAINER_ID" image="${{ steps.tag.outputs.image }}" region="$SCW_REGION"
+        run: |
+          scw container container update "$CONTAINER_ID" \
+            image="${{ steps.tag.outputs.image }}" \
+            cpu-limit="$CONTAINER_CPU_LIMIT" \
+            memory-limit="$CONTAINER_MEMORY_LIMIT" \
+            sandbox="$CONTAINER_SANDBOX" \
+            region="$SCW_REGION"
 
       - name: Dry-run summary
         if: ${{ inputs.dry_run }}
         run: |
           echo "DRY RUN — image built but not pushed/deployed."
           echo "Would push:   ${{ steps.tag.outputs.image }}"
-          echo "Would update: container $CONTAINER_ID -> that image"
+          echo "Would update: container $CONTAINER_ID -> image ${{ steps.tag.outputs.image }}"
+          echo "              cpu-limit=$CONTAINER_CPU_LIMIT memory-limit=$CONTAINER_MEMORY_LIMIT sandbox=$CONTAINER_SANDBOX"
 
   # ---------------------------------------------------------------------------
   # Frontend: build the SPA (prod mode reads app/.env.production -> VITE_API_URL)


### PR DESCRIPTION
## Why

Cold start is CPU-bound on the current **1 vCPU** container. Scaleway has no Cloud-Run-style "startup boost"; its recommended cold-start levers are **more vCPU/RAM** and the **gVisor sandbox (v2)**. This codifies both into the deploy so prod config is version-controlled, not console-only drift.

This is expected to help *our* boot specifically: the dominant remaining cost — `jpaMappingContext` (~7.5s, Hibernate metamodel) — runs on a **background thread** (`task-1`), so it only overlaps main-thread boot work with **≥2 cores**.

## What changed (`.github/workflows/deploy.yml`)

- New codified env vars: `CONTAINER_CPU_LIMIT=2000` (2 vCPU), `CONTAINER_MEMORY_LIMIT=2048`, `CONTAINER_SANDBOX=v2`.
- The **Update Serverless Container** step now applies image **+** cpu/memory/sandbox in one atomic `scw container container update`. Env/secret maps are still untouched.
- Dry-run summary prints the resource/sandbox values.

## Notes & caveats

- **CPU/memory must be a valid Scaleway tier** (I couldn't fetch the limitations table — it 403'd through the sandbox proxy). If `2000/2048` isn't a valid pair, the update call fails **loudly** (the image is already pushed, so just fix the values and re-run — no half-deploy).
- Values are env vars at the top for easy **A/B tuning**: bump to `4000`, redeploy, re-read the `Started … in X seconds` line, take the knee of the curve. (Amdahl: expect 1→2 vCPU to give the biggest jump, 2→4 diminishing.)
- **gVisor caveat:** it implements only a subset of Linux syscalls. JVMs generally run fine under gVisor, but confirm the first v2 boot is healthy; revert `CONTAINER_SANDBOX` to `v1` if anything misbehaves.
- Cost stays low: scale-to-zero + low traffic means the higher allocation is billed only during brief active windows.

## Verification

`yaml.safe_load` parses clean; the rendered `scw` command is correct. Real effect is measured on the next Deploy — compare the `Started … in X seconds` line against the current **23.4s** at 1 vCPU.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_