### PR TITLE
fix(deploy): correct scw v2.58.3 arg names + split image/resource updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,16 +40,21 @@ env:
   CONTAINER_ID: ec9dfda3-65ca-4901-a640-895fd2f9f5f3
   # Serverless Container resource + sandbox config, asserted on every real deploy (config-as-code,
   # so prod never drifts to a console-only value). Cold-start levers per Scaleway's guidance
-  # (docs/plans/2026-07-24-startup-time-optimization.md, Phase 4):
-  #   - CPU_LIMIT is mvCPU (2000 = 2 vCPU). Raised from 1 vCPU because the boot is CPU-bound and the
-  #     deferred Hibernate metamodel build (jpaMappingContext, ~7.5s) runs on a background thread —
-  #     it only overlaps main-thread boot work with >=2 cores. Bump to A/B (e.g. 4000) and re-read
-  #     the `Started … in X seconds` line; take the knee of the curve.
-  #   - MEMORY_LIMIT is MB. CPU/memory MUST be a valid Scaleway combination (see the Containers
-  #     limitations docs) or `scw container container update` rejects the call and the deploy fails.
+  # (docs/plans/2026-07-24-startup-time-optimization.md, Phase 4).
+  #
+  # ARG NAMES ARE CLI-VERSION SPECIFIC: the pinned scw CLI (v2.58.3, see scaleway/action-scw below)
+  # uses `mvcpu-limit` + `memory-limit-bytes`, NOT `cpu-limit`/`memory-limit` (those are a different
+  # CLI version — the v2.58.3 run rejected them with "Unknown argument 'cpu-limit'"). If you bump the
+  # CLI version, re-check the arg names with `scw container container update -h`.
+  #   - MVCPU_LIMIT is mvCPU (1000 = 1 vCPU, so 2000 = 2 vCPU). Raised from 1 vCPU because the boot
+  #     is CPU-bound and the deferred Hibernate metamodel build (jpaMappingContext, ~7.5s) runs on a
+  #     background thread — it only overlaps main-thread boot work with >=2 cores. Bump to A/B
+  #     (e.g. 4000) and re-read the `Started … in X seconds` line; take the knee of the curve.
+  #   - MEMORY_LIMIT_BYTES is BYTES (2147483648 = 2048 MiB = 2 GiB). CPU/memory MUST be a valid
+  #     Scaleway pair (see the Containers limitations docs) or the update call is rejected.
   #   - SANDBOX=v2 is the gVisor sandbox, which Scaleway recommends for faster cold starts.
-  CONTAINER_CPU_LIMIT: '2000'
-  CONTAINER_MEMORY_LIMIT: '2048'
+  CONTAINER_MVCPU_LIMIT: '2000'
+  CONTAINER_MEMORY_LIMIT_BYTES: '2147483648'
   CONTAINER_SANDBOX: v2
   # Object Storage buckets (fr-par) + Edge Services pipeline ids.
   S3_ENDPOINT: https://s3.fr-par.scw.cloud
@@ -102,17 +107,22 @@ jobs:
           echo "${{ secrets.SCW_SECRET_KEY }}" | docker login "${REGISTRY%%/*}" -u nologin --password-stdin
           docker push "${{ steps.tag.outputs.image }}"
 
-      # One atomic update: new image + the codified resource/sandbox config. cpu-limit/memory-limit
-      # accelerate the CPU-bound cold start; sandbox=v2 (gVisor) cuts it further. Env/secret maps are
-      # not passed, so they stay as-is. If the cpu/memory pair is not a valid Scaleway tier, this
-      # call fails loudly (the image is already pushed, so just fix the values and re-run).
-      - name: Update Serverless Container
+      # Image update FIRST and on its own, so it can never be blocked by a bad resource value below.
+      # Env/secret maps are not passed, so they stay as-is.
+      - name: Update Serverless Container image
+        if: ${{ !inputs.dry_run }}
+        run: scw container container update "$CONTAINER_ID" image="${{ steps.tag.outputs.image }}" region="$SCW_REGION"
+
+      # Resource + sandbox config in a SEPARATE update. If mvcpu/memory isn't a valid Scaleway pair
+      # this step fails, but the new image is already live (previous step), so it's a one-value fix +
+      # re-run — never a half-deploy. Arg names are for scw CLI v2.58.3: `mvcpu-limit` (mvCPU) and
+      # `memory-limit-bytes` (BYTES).
+      - name: Assert Serverless Container resources + sandbox
         if: ${{ !inputs.dry_run }}
         run: |
           scw container container update "$CONTAINER_ID" \
-            image="${{ steps.tag.outputs.image }}" \
-            cpu-limit="$CONTAINER_CPU_LIMIT" \
-            memory-limit="$CONTAINER_MEMORY_LIMIT" \
+            mvcpu-limit="$CONTAINER_MVCPU_LIMIT" \
+            memory-limit-bytes="$CONTAINER_MEMORY_LIMIT_BYTES" \
             sandbox="$CONTAINER_SANDBOX" \
             region="$SCW_REGION"
 
@@ -122,7 +132,7 @@ jobs:
           echo "DRY RUN — image built but not pushed/deployed."
           echo "Would push:   ${{ steps.tag.outputs.image }}"
           echo "Would update: container $CONTAINER_ID -> image ${{ steps.tag.outputs.image }}"
-          echo "              cpu-limit=$CONTAINER_CPU_LIMIT memory-limit=$CONTAINER_MEMORY_LIMIT sandbox=$CONTAINER_SANDBOX"
+          echo "              mvcpu-limit=$CONTAINER_MVCPU_LIMIT memory-limit-bytes=$CONTAINER_MEMORY_LIMIT_BYTES sandbox=$CONTAINER_SANDBOX"
 
   # ---------------------------------------------------------------------------
   # Frontend: build the SPA (prod mode reads app/.env.production -> VITE_API_URL)


### PR DESCRIPTION
## Problem

Deploy #9 (the #98 config) failed at the container update:

```
Unknown argument 'cpu-limit'
Valid arguments are: … memory-limit-bytes, mvcpu-limit, … sandbox, … region
```

The pinned scw CLI (**v2.58.3**, via `scaleway/action-scw`) uses **`mvcpu-limit`** and **`memory-limit-bytes`**, not `cpu-limit`/`memory-limit`. (Confusingly, the CLI's *master* docs show the `cpu-limit`/`memory-limit`-in-MB form — that's a different CLI version. The runner's own error is authoritative.) The whole `update` was atomic, so this also meant the new image didn't get applied.

## Fix

1. **Correct arg names + unit:** `mvcpu-limit=2000` (2 vCPU) and `memory-limit-bytes=2147483648` (**bytes** — 2 GiB / 2048 MiB). Env vars renamed to `CONTAINER_MVCPU_LIMIT` / `CONTAINER_MEMORY_LIMIT_BYTES` to make the unit unmistakable.
2. **Split image and resource updates into two steps.** The image update runs first and alone, so a bad resource/tier value can **never block the image deploy** again — if the resource step is rejected, the new image is already live and it's a one-value fix + re-run, never a half-deploy.

## Caveats

- **CPU/memory must be a valid Scaleway pair.** 2 vCPU / 2 GiB is a standard tier, but I can't verify against the limitations table (proxy 403). If it's rejected, the image is still deployed (see split above) — adjust `CONTAINER_MEMORY_LIMIT_BYTES` and re-run. If the byte unit turns out to be decimal MB rather than MiB, the fix is just that one number.
- Still A/B-tunable: bump `CONTAINER_MVCPU_LIMIT` to `4000` and re-read `Started … in X seconds`.

## Verification

`yaml.safe_load` parses clean; rendered `scw` commands are correct with the v2.58.3 arg names. Real effect measured on the next Deploy — compare boot time against **23.4s** at 1 vCPU.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_