### PR TITLE
fix(deploy): memory-limit-bytes wants a whole-GB size string (2GB), not raw bytes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,11 +50,13 @@ env:
   #     is CPU-bound and the deferred Hibernate metamodel build (jpaMappingContext, ~7.5s) runs on a
   #     background thread — it only overlaps main-thread boot work with >=2 cores. Bump to A/B
   #     (e.g. 4000) and re-read the `Started … in X seconds` line; take the knee of the curve.
-  #   - MEMORY_LIMIT_BYTES is BYTES (2147483648 = 2048 MiB = 2 GiB). CPU/memory MUST be a valid
-  #     Scaleway pair (see the Containers limitations docs) or the update call is rejected.
+  #   - MEMORY_LIMIT: despite the arg being named `memory-limit-bytes`, the v2.58.3 CLI parses it as
+  #     a size STRING and requires a whole-GB unit — a raw byte count was rejected with "size must be
+  #     defined using the G or GB unit". So the value is `2GB` (not 2147483648). CPU/memory must be a
+  #     valid Scaleway pair (see the Containers limitations docs) or the update call is rejected.
   #   - SANDBOX=v2 is the gVisor sandbox, which Scaleway recommends for faster cold starts.
   CONTAINER_MVCPU_LIMIT: '2000'
-  CONTAINER_MEMORY_LIMIT_BYTES: '2147483648'
+  CONTAINER_MEMORY_LIMIT: '2GB'
   CONTAINER_SANDBOX: v2
   # Object Storage buckets (fr-par) + Edge Services pipeline ids.
   S3_ENDPOINT: https://s3.fr-par.scw.cloud
@@ -116,13 +118,13 @@ jobs:
       # Resource + sandbox config in a SEPARATE update. If mvcpu/memory isn't a valid Scaleway pair
       # this step fails, but the new image is already live (previous step), so it's a one-value fix +
       # re-run — never a half-deploy. Arg names are for scw CLI v2.58.3: `mvcpu-limit` (mvCPU) and
-      # `memory-limit-bytes` (BYTES).
+      # `memory-limit-bytes` (a whole-GB size string despite the name, e.g. 2GB).
       - name: Assert Serverless Container resources + sandbox
         if: ${{ !inputs.dry_run }}
         run: |
           scw container container update "$CONTAINER_ID" \
             mvcpu-limit="$CONTAINER_MVCPU_LIMIT" \
-            memory-limit-bytes="$CONTAINER_MEMORY_LIMIT_BYTES" \
+            memory-limit-bytes="$CONTAINER_MEMORY_LIMIT" \
             sandbox="$CONTAINER_SANDBOX" \
             region="$SCW_REGION"
 
@@ -132,7 +134,7 @@ jobs:
           echo "DRY RUN — image built but not pushed/deployed."
           echo "Would push:   ${{ steps.tag.outputs.image }}"
           echo "Would update: container $CONTAINER_ID -> image ${{ steps.tag.outputs.image }}"
-          echo "              mvcpu-limit=$CONTAINER_MVCPU_LIMIT memory-limit-bytes=$CONTAINER_MEMORY_LIMIT_BYTES sandbox=$CONTAINER_SANDBOX"
+          echo "              mvcpu-limit=$CONTAINER_MVCPU_LIMIT memory-limit-bytes=$CONTAINER_MEMORY_LIMIT sandbox=$CONTAINER_SANDBOX"
 
   # ---------------------------------------------------------------------------
   # Frontend: build the SPA (prod mode reads app/.env.production -> VITE_API_URL)


### PR DESCRIPTION
## What happened

Deploy #10 with #99's fix: the **image update step succeeded** (the split from #99 did its job — the new image is live), and only the resource step failed:

```
Invalid value for 'memory-limit-bytes' argument: size must be defined using the G or GB unit
```

So despite the arg name, `memory-limit-bytes` in scw v2.58.3 is parsed as a **size string** and requires a **whole-GB unit** — a raw integer (`2147483648`) is rejected.

## Fix

Value → **`2GB`**. Env var renamed `CONTAINER_MEMORY_LIMIT_BYTES` → `CONTAINER_MEMORY_LIMIT` (the "bytes" name was misleading). `mvcpu-limit=2000` was already accepted, unchanged. Comments corrected.

## State

The AOT-cache-fixed image (#97) is **already deployed** on prod thanks to the image/resource split — this PR only makes the **2 vCPU + gVisor** bump actually apply. If `2GB`/`2 vCPU` still isn't a valid Scaleway tier, the image stays live and it's one more one-value tweak.

## Verification

`yaml.safe_load` clean; no stale refs. Real effect on the next Deploy — the `Assert … resources + sandbox` step should now succeed; then compare `Started … in X seconds` against **23.4s** at 1 vCPU.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_