### PR TITLE
perf(api): pin Hibernate dialect + skip boot-time JDBC metadata probe

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -8,6 +8,16 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: none
+    properties:
+      hibernate:
+        # Startup: pin the dialect and skip Hibernate's boot-time JDBC metadata probe (the
+        # "Database version: 16.x / dialect: PostgreSQLDialect" round-trip seen in boot logs). The two
+        # go together — with the probe off Hibernate can't auto-detect the dialect, so it must be set.
+        # Every environment (prod + Testcontainers) is PostgreSQL, so this is safe app-wide.
+        # See docs/plans/2026-07-24-startup-time-optimization.md.
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        boot:
+          allow_jdbc_metadata_access: false
   data:
     jpa:
       repositories:


### PR DESCRIPTION
## What

Two Hibernate boot flags in `application.yml`:

```yaml
spring.jpa.properties.hibernate:
  dialect: org.hibernate.dialect.PostgreSQLDialect
  boot:
    allow_jdbc_metadata_access: false
```

## Why

At boot Hibernate opens a JDBC connection to detect the dialect/version — the `Database version: 16.14 / dialect: PostgreSQLDialect` round-trip visible in prod boot logs. Pinning the dialect and setting `allow_jdbc_metadata_access: false` skips that probe. The two **must** go together: with the probe off, Hibernate can't auto-detect the dialect, so it has to be set explicitly.

Every environment (prod Serverless SQL + Testcontainers/dev) is PostgreSQL, so this is safe app-wide.

## Impact

A **modest** startup trim — this targets the boot-time DB round-trip, **not** the ~5.9s reflective metamodel build (that's the native-image-vs-jOOQ decision still open). Measured on the next deploy via the `Started … in X seconds` line.

## Verification

This config **is** exercised by CI: `ProdProfileSmokeIT` and the other Testcontainers ITs boot the real Spring context (prod profile included), so a boot break from these flags fails CI here — unlike the earlier Dockerfile/deploy changes, this isn't a prod-only blind spot. Locally: YAML nesting validated; the IT boot runs in CI (Docker-enabled).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JX4qQBjWtdF6MtqthmSm)_