### PR TITLE
feat: per-team season foundation with event-write validation (#109)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonException
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.model.Attendance
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
@@ -7,6 +8,7 @@ import com.github.zzave.teambalance.api.domain.model.Event
 import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,6 +24,7 @@ class EventService(
     private val eventTypeRepository: EventTypeRepository,
     private val attendanceRepository: AttendanceRepository,
     private val teamMemberRepository: TeamMemberRepository,
+    private val seasonRepository: SeasonRepository,
     private val clock: Clock,
 ) {
     companion object {
@@ -42,6 +45,9 @@ class EventService(
     fun createEvent(potential: PotentialEvent, createdBy: UUID, teamId: UUID): Event {
         val eventType = eventTypeRepository.findById(potential.eventTypeId)
             ?: throw EventTypeNotFoundException(potential.eventTypeId)
+
+        // ADR-0014: a created event's start must always fall within the configured season.
+        requireWithinSeason(potential.startTime)
 
         val event = eventRepository.save(
             Event(
@@ -86,6 +92,10 @@ class EventService(
         val eventType = eventTypeRepository.findById(eventTypeId)
             ?: throw EventTypeNotFoundException(eventTypeId)
 
+        // ADR-0014: validate the season only when the start is being moved. An unchanged start is
+        // grandfathered, so an event already outside the window (e.g. after it was shrunk) stays editable.
+        if (existing.startTime != startTime) requireWithinSeason(startTime)
+
         return eventRepository.save(
             existing.copy(
                 eventType = eventType,
@@ -102,5 +112,13 @@ class EventService(
         if (eventRepository.findById(id) == null) return false
         eventRepository.deleteById(id)
         return true
+    }
+
+    // Rejects a start that falls outside the configured season. The instant is resolved to a calendar
+    // date in the team's civil zone (the clock's zone) so the comparison matches how humans read the
+    // date. An unconfigured season (both bounds null) allows everything.
+    private fun requireWithinSeason(startTime: Instant) {
+        val startDate = startTime.atZone(clock.zone).toLocalDate()
+        if (!seasonRepository.get().allows(startDate)) throw EventOutsideSeasonException(startDate)
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
@@ -1,0 +1,31 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.model.Season
+import com.github.zzave.teambalance.api.domain.port.SeasonRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+@Transactional
+class SeasonService(
+    private val seasonRepository: SeasonRepository,
+    private val authorizationService: AuthorizationService,
+) {
+    /** The current tenant's season. Readable by any member; returns an unset season when none is configured. */
+    fun getSeason(): Season = seasonRepository.get()
+
+    /**
+     * Admin-only. Replaces the season window; passing both bounds null clears it. A configured
+     * range with end before start is rejected (400). Changing the window never touches events —
+     * a warning about now-out-of-window events is the frontend's job (ADR-0014).
+     */
+    fun setSeason(callerId: UUID, teamId: UUID, start: LocalDate?, end: LocalDate?): Season {
+        authorizationService.requireAdmin(callerId, teamId)
+        require(start == null || end == null || !end.isBefore(start)) {
+            "Season end must not be before season start"
+        }
+        return seasonRepository.save(Season(start = start, end = end))
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -30,6 +30,14 @@ class NoTeamMembershipException(userId: UUID) :
 class CannotChangeOwnRoleException(userId: UUID) :
     ForbiddenException("User $userId cannot elevate their own role", "CANNOT_SELF_PROMOTE")
 
+// `code` is the stable machine-readable discriminator for 422 rejections — a request that is
+// well-formed but violates a business rule (not a state clash, so not a 409). Mirrors the code
+// convention of ForbiddenException/ConflictException.
+sealed class UnprocessableEntityException(message: String, val code: String) : TeambalanceException(message)
+
+class EventOutsideSeasonException(start: java.time.LocalDate) :
+    UnprocessableEntityException("Event start $start falls outside the configured season", "EVENT_OUTSIDE_SEASON")
+
 // `code` is the stable machine-readable discriminator for 409 conflicts (state clashes clients can act on),
 // mirroring ForbiddenException — e.g. "display name already used" vs "would remove the last admin".
 sealed class ConflictException(message: String, val code: String) : TeambalanceException(message)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Season.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Season.kt
@@ -1,0 +1,23 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.time.LocalDate
+
+/**
+ * A per-team season window (ADR-0014). Both bounds are independently nullable: a null bound is
+ * simply unbounded on that side, so an unconfigured season (both null) constrains nothing.
+ */
+data class Season(
+    val start: LocalDate?,
+    val end: LocalDate?,
+) {
+    /** Whether any bound is set. A season with neither bound imposes no constraint. */
+    val isConfigured: Boolean get() = start != null || end != null
+
+    /** True when [date] falls within the configured window; an unbounded side never rejects. */
+    fun allows(date: LocalDate): Boolean =
+        (start == null || !date.isBefore(start)) && (end == null || !date.isAfter(end))
+
+    companion object {
+        val UNSET = Season(start = null, end = null)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/SeasonRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/SeasonRepository.kt
@@ -1,0 +1,13 @@
+package com.github.zzave.teambalance.api.domain.port
+
+import com.github.zzave.teambalance.api.domain.model.Season
+
+/**
+ * Reads and writes the current tenant's season window. The tenant is resolved from the request
+ * context (Hibernate multitenancy), so this port takes no team argument — it always operates on
+ * the singleton settings row of the active schema.
+ */
+interface SeasonRepository {
+    fun get(): Season
+    fun save(season: Season): Season
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaSeasonRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaSeasonRepositoryAdapter.kt
@@ -1,0 +1,29 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.domain.model.Season
+import com.github.zzave.teambalance.api.domain.port.SeasonRepository
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.TeamSettingsJpaEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaSeasonRepositoryAdapter(
+    private val jpaRepository: SpringDataTeamSettingsRepository,
+) : SeasonRepository {
+
+    override fun get(): Season =
+        jpaRepository.findById(TeamSettingsJpaEntity.SINGLETON_ID)
+            .map { Season(start = it.seasonStart, end = it.seasonEnd) }
+            .orElse(Season.UNSET)
+
+    // Upsert the singleton row: the migration seeds id=1, so save() merges the season bounds onto it.
+    override fun save(season: Season): Season {
+        jpaRepository.save(
+            TeamSettingsJpaEntity(
+                id = TeamSettingsJpaEntity.SINGLETON_ID,
+                seasonStart = season.start,
+                seasonEnd = season.end,
+            ),
+        )
+        return season
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamSettingsRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamSettingsRepository.kt
@@ -1,0 +1,6 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.TeamSettingsJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpringDataTeamSettingsRepository : JpaRepository<TeamSettingsJpaEntity, Short>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/TeamSettingsJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/TeamSettingsJpaEntity.kt
@@ -1,0 +1,26 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+/**
+ * The tenant's singleton settings row (see V004__team_settings.sql). The primary key is pinned to 1
+ * by a DB CHECK, so there is always exactly one row per tenant schema.
+ */
+@Entity
+@Table(name = "team_settings")
+class TeamSettingsJpaEntity(
+    @Id
+    val id: Short = SINGLETON_ID,
+    @Column(name = "season_start")
+    val seasonStart: LocalDate?,
+    @Column(name = "season_end")
+    val seasonEnd: LocalDate?,
+) {
+    companion object {
+        const val SINGLETON_ID: Short = 1
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.domain.exception.ConflictException
 import com.github.zzave.teambalance.api.domain.exception.ForbiddenException
 import com.github.zzave.teambalance.api.domain.exception.NotFoundException
 import com.github.zzave.teambalance.api.domain.exception.TeambalanceException
+import com.github.zzave.teambalance.api.domain.exception.UnprocessableEntityException
 import com.github.zzave.teambalance.api.domain.exception.UnauthenticatedException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -33,6 +34,11 @@ class GlobalExceptionHandler {
     fun handleConflict(ex: ConflictException): ResponseEntity<Map<String, String>> =
         ResponseEntity.status(HttpStatus.CONFLICT)
             .body(mapOf("error" to (ex.message ?: "Conflict"), "code" to ex.code))
+
+    @ExceptionHandler(UnprocessableEntityException::class)
+    fun handleUnprocessableEntity(ex: UnprocessableEntityException): ResponseEntity<Map<String, String>> =
+        ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(mapOf("error" to (ex.message ?: "Unprocessable"), "code" to ex.code))
 
     @ExceptionHandler(TeambalanceException::class)
     fun handleTeambalanceException(ex: TeambalanceException): ResponseEntity<Map<String, String>> =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonController.kt
@@ -1,0 +1,41 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.application.CurrentTeamProvider
+import com.github.zzave.teambalance.api.application.CurrentUserProvider
+import com.github.zzave.teambalance.api.application.SeasonService
+import com.github.zzave.teambalance.api.domain.model.Season as DomainSeason
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetSeason
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.SetSeason
+import com.github.zzave.teambalance.api.interfaces.generated.model.Season
+import com.github.zzave.teambalance.api.interfaces.generated.model.SeasonDate
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+class SeasonController(
+    private val seasonService: SeasonService,
+    private val currentUserProvider: CurrentUserProvider,
+    private val currentTeamProvider: CurrentTeamProvider,
+) : GetSeason.Handler,
+    SetSeason.Handler {
+
+    // Readable by any member of the current team; the tenant is resolved from the request context.
+    override suspend fun getSeason(request: GetSeason.Request): GetSeason.Response<*> =
+        GetSeason.Response200(seasonService.getSeason().produce())
+
+    // Admin-only (enforced in SeasonService.setSeason); a non-admin surfaces as 403 via the handler.
+    override suspend fun setSeason(request: SetSeason.Request): SetSeason.Response<*> {
+        val season = seasonService.setSeason(
+            callerId = currentUserProvider.requireCurrentUserId(),
+            teamId = currentTeamProvider.requireCurrentTeamId(),
+            start = request.body.start?.toLocalDate(),
+            end = request.body.end?.toLocalDate(),
+        )
+        return SetSeason.Response200(season.produce())
+    }
+}
+
+private fun DomainSeason.produce() =
+    Season(start = start?.let { SeasonDate(it.toString()) }, end = end?.let { SeasonDate(it.toString()) })
+
+private fun SeasonDate.toLocalDate(): LocalDate = LocalDate.parse(value)

--- a/api/src/main/resources/db/tenant-migration/V004__team_settings.sql
+++ b/api/src/main/resources/db/tenant-migration/V004__team_settings.sql
@@ -1,0 +1,12 @@
+-- Per-team settings, singleton row in each tenant schema.
+-- Phase 1 of recurring events (ADR-0014): a per-team season window bounds event writes.
+-- The CHECK (id = 1) plus a seeded row enforces exactly one settings row per team.
+
+CREATE TABLE team_settings (
+    id           SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    season_start DATE,
+    season_end   DATE
+);
+
+-- Seed the singleton with an unconfigured season (both null => no constraint on event writes).
+INSERT INTO team_settings (id) VALUES (1);

--- a/api/src/main/wirespec/season.ws
+++ b/api/src/main/wirespec/season.ws
@@ -1,0 +1,21 @@
+// A season bound is an ISO-8601 calendar date (e.g. "2026-09-01"); null means unbounded on that side.
+type SeasonDate = String
+
+type Season {
+    start: SeasonDate?,
+    end: SeasonDate?
+}
+
+type SetSeasonRequest {
+    start: SeasonDate?,
+    end: SeasonDate?
+}
+
+endpoint GetSeason GET /api/team/season -> {
+    200 -> Season
+}
+
+endpoint SetSeason PUT SetSeasonRequest /api/team/season -> {
+    200 -> Season
+    403 -> Unit
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonTest.kt
@@ -1,0 +1,53 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+/**
+ * Pure boundary logic for the season window (ADR-0014). No Spring, no DB — the lowest layer that
+ * proves the inclusive-range and unbounded-side rules.
+ */
+class SeasonTest : FunSpec({
+
+    val start = LocalDate.of(2026, 9, 1)
+    val end = LocalDate.of(2027, 4, 30)
+    val season = Season(start, end)
+
+    test("a date inside the window is allowed") {
+        season.allows(LocalDate.of(2026, 12, 15)) shouldBe true
+    }
+
+    test("both bounds are inclusive") {
+        season.allows(start) shouldBe true
+        season.allows(end) shouldBe true
+    }
+
+    test("a date before the start is rejected") {
+        season.allows(start.minusDays(1)) shouldBe false
+    }
+
+    test("a date after the end is rejected") {
+        season.allows(end.plusDays(1)) shouldBe false
+    }
+
+    test("an unset season allows every date and is not configured") {
+        Season.UNSET.isConfigured shouldBe false
+        Season.UNSET.allows(LocalDate.of(1999, 1, 1)) shouldBe true
+        Season.UNSET.allows(LocalDate.of(2999, 12, 31)) shouldBe true
+    }
+
+    test("a start-only window is unbounded on the end") {
+        val startOnly = Season(start, end = null)
+        startOnly.isConfigured shouldBe true
+        startOnly.allows(start.minusDays(1)) shouldBe false
+        startOnly.allows(end.plusYears(5)) shouldBe true
+    }
+
+    test("an end-only window is unbounded on the start") {
+        val endOnly = Season(start = null, end = end)
+        endOnly.isConfigured shouldBe true
+        endOnly.allows(start.minusYears(5)) shouldBe true
+        endOnly.allows(end.plusDays(1)) shouldBe false
+    }
+})

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
@@ -1,0 +1,269 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+private const val ADMIN_USER_ID = "b0000000-0000-0000-0000-0000000000e1"
+private const val MEMBER_USER_ID = "b0000000-0000-0000-0000-0000000000e2"
+private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+
+/**
+ * Covers the season foundation (ADR-0014, Phase 1): the GET/PUT season endpoints (round-trip,
+ * clear, admin gating) and the season-bound validation matrix wired into the single-event
+ * create/update path.
+ *
+ * All tests share the single 'public' tenant schema (see EventControllerTest), so each one that
+ * touches the season sets it explicitly and resets it to unset in a finally — otherwise a leaked
+ * window would spuriously reject other suites' event creates.
+ */
+@AutoConfigureMockMvc
+class SeasonControllerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        test("GET /api/team/season returns null bounds when no season is configured") {
+            seedTeamAndAdmin()
+            resetSeason()
+
+            perform(MockMvcRequestBuilders.get("/api/team/season"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.start").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.end").doesNotExist())
+        }
+
+        test("PUT /api/team/season by an admin sets the window and GET round-trips it") {
+            seedTeamAndAdmin()
+            try {
+                perform(
+                    MockMvcRequestBuilders.put("/api/team/season")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{ "start": "2026-09-01", "end": "2027-04-30" }"""),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isOk)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.start").value("2026-09-01"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.end").value("2027-04-30"))
+
+                perform(MockMvcRequestBuilders.get("/api/team/season"), ADMIN_USER_ID)
+                    .andExpect(MockMvcResultMatchers.status().isOk)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.start").value("2026-09-01"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.end").value("2027-04-30"))
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("PUT /api/team/season with null bounds clears the window") {
+            seedTeamAndAdmin()
+            setSeason("2026-09-01", "2027-04-30")
+            try {
+                perform(
+                    MockMvcRequestBuilders.put("/api/team/season")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{ "start": null, "end": null }"""),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isOk)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.start").doesNotExist())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.end").doesNotExist())
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("PUT /api/team/season by a non-admin member is rejected with 403") {
+            seedTeamAndAdmin()
+            seedMember(MEMBER_USER_ID, "member@test.com", role = "USER")
+            try {
+                perform(
+                    MockMvcRequestBuilders.put("/api/team/season")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{ "start": "2026-09-01", "end": "2027-04-30" }"""),
+                    MEMBER_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isForbidden)
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("POST /api/events with a start outside the season is rejected with 422") {
+            seedTeamAndAdmin()
+            setSeason("2026-09-01", "2027-04-30")
+            try {
+                perform(createEventJson(start = "2026-08-01T18:00:00Z"), ADMIN_USER_ID)
+                    .andExpect(MockMvcResultMatchers.status().isUnprocessableContent)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("EVENT_OUTSIDE_SEASON"))
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("POST /api/events with a start inside the season succeeds") {
+            seedTeamAndAdmin()
+            setSeason("2026-09-01", "2027-04-30")
+            try {
+                perform(createEventJson(start = "2026-10-01T18:00:00Z"), ADMIN_USER_ID)
+                    .andExpect(MockMvcResultMatchers.status().isCreated)
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("PUT /api/events grandfathers an unchanged out-of-window start") {
+            seedTeamAndAdmin()
+            // Event created (via SQL) before the window; the window is then set to exclude it.
+            val eventId = insertEvent(start = "2026-08-01 18:00:00+00")
+            setSeason("2026-09-01", "2027-04-30")
+            try {
+                // Same startTime as stored => start not moved => grandfathered, edit allowed.
+                perform(
+                    MockMvcRequestBuilders.put("/api/events/$eventId")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateEventBody(title = "Renamed but same date", start = "2026-08-01T18:00:00Z")),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isOk)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Renamed but same date"))
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("PUT /api/events rejects a start newly moved outside the season with 422") {
+            seedTeamAndAdmin()
+            // Event starts inside the window; moving it out must be rejected.
+            val eventId = insertEvent(start = "2026-10-01 18:00:00+00")
+            setSeason("2026-09-01", "2027-04-30")
+            try {
+                perform(
+                    MockMvcRequestBuilders.put("/api/events/$eventId")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateEventBody(title = "Moved out", start = "2026-08-01T18:00:00Z")),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isUnprocessableContent)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("EVENT_OUTSIDE_SEASON"))
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("POST /api/events with no season configured accepts any start") {
+            seedTeamAndAdmin()
+            resetSeason()
+
+            perform(createEventJson(start = "2020-01-01T18:00:00Z"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private fun perform(builder: org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder, userId: String) =
+        mockMvc.perform(builder.header("X-Team-Id", "public").header("X-User-Id", userId))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    private fun createEventJson(start: String): org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder {
+        val eventTypeId = trainingTypeId()
+        return MockMvcRequestBuilders.post("/api/events")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "eventTypeId": "$eventTypeId",
+                  "title": "Season check",
+                  "description": null,
+                  "startTime": "$start",
+                  "endTime": "2027-05-01T20:00:00Z",
+                  "location": null
+                }
+                """.trimIndent(),
+            )
+    }
+
+    private fun updateEventBody(title: String, start: String): String {
+        val eventTypeId = trainingTypeId()
+        return """
+            {
+              "eventTypeId": "$eventTypeId",
+              "title": "$title",
+              "description": null,
+              "startTime": "$start",
+              "endTime": "2027-05-01T20:00:00Z",
+              "location": null
+            }
+        """.trimIndent()
+    }
+
+    private fun trainingTypeId(): UUID =
+        jdbcTemplate.queryForObject("SELECT uuid FROM public.event_types WHERE name = 'Training'", UUID::class.java)!!
+
+    private fun insertEvent(start: String): UUID {
+        val eventId = UUID.randomUUID()
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+            VALUES ('$eventId'::uuid,
+                (SELECT id FROM public.event_types WHERE name = 'Training'),
+                'Seeded Event', '$start', '2027-05-01 20:00:00+00',
+                '$ADMIN_USER_ID'::uuid, now(), now())
+            """,
+        )
+        return eventId
+    }
+
+    private fun setSeason(start: String?, end: String?) {
+        jdbcTemplate.update(
+            "UPDATE public.team_settings SET season_start = ?::date, season_end = ?::date WHERE id = 1",
+            start,
+            end,
+        )
+    }
+
+    private fun resetSeason() = setSeason(null, null)
+
+    private fun seedTeamAndAdmin() {
+        tenantSchemaManager.provisionPlatformSchema()
+        tenantSchemaManager.provisionTenantSchema("public")
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, sport, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        seedMember(ADMIN_USER_ID, "season-admin@test.com", role = "ADMIN")
+    }
+
+    private fun seedMember(userId: String, email: String, role: String) {
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.users (id, email, display_name)
+            VALUES ('$userId'::uuid, '$email', '$email')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.execute(
+            "SELECT public.tb_add_member('$TEAM_ID'::uuid, '$userId'::uuid, '$role', 'Setter')",
+        )
+    }
+}

--- a/app/src/features/team-settings/lib/season.test.ts
+++ b/app/src/features/team-settings/lib/season.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { isSeasonConfigured, seasonChanged, validateSeasonRange } from './season'
+
+describe('validateSeasonRange', () => {
+  it('accepts an in-order range', () => {
+    expect(validateSeasonRange({ start: '2026-09-01', end: '2027-04-30' })).toBeNull()
+  })
+
+  it('accepts equal start and end', () => {
+    expect(validateSeasonRange({ start: '2026-09-01', end: '2026-09-01' })).toBeNull()
+  })
+
+  it('rejects an inverted range', () => {
+    expect(validateSeasonRange({ start: '2027-04-30', end: '2026-09-01' })).toBe(
+      'End date must be on or after the start date.',
+    )
+  })
+
+  it('accepts a half-open range (only one bound set)', () => {
+    expect(validateSeasonRange({ start: '2026-09-01' })).toBeNull()
+    expect(validateSeasonRange({ end: '2027-04-30' })).toBeNull()
+  })
+
+  it('accepts an empty season', () => {
+    expect(validateSeasonRange({})).toBeNull()
+    expect(validateSeasonRange({ start: '', end: '' })).toBeNull()
+  })
+})
+
+describe('isSeasonConfigured', () => {
+  it('is false when both bounds are empty or absent', () => {
+    expect(isSeasonConfigured({})).toBe(false)
+    expect(isSeasonConfigured({ start: '', end: '' })).toBe(false)
+  })
+
+  it('is true when either bound is set', () => {
+    expect(isSeasonConfigured({ start: '2026-09-01' })).toBe(true)
+    expect(isSeasonConfigured({ end: '2027-04-30' })).toBe(true)
+  })
+})
+
+describe('seasonChanged', () => {
+  it('detects a changed bound', () => {
+    expect(seasonChanged({ start: '2026-09-01' }, { start: '2026-10-01' })).toBe(true)
+  })
+
+  it('treats empty string and undefined as equal (not a change)', () => {
+    expect(seasonChanged({ start: undefined, end: undefined }, { start: '', end: '' })).toBe(false)
+  })
+
+  it('is false for identical bounds', () => {
+    expect(seasonChanged({ start: '2026-09-01', end: '2027-04-30' }, { start: '2026-09-01', end: '2027-04-30' })).toBe(
+      false,
+    )
+  })
+})

--- a/app/src/features/team-settings/lib/season.ts
+++ b/app/src/features/team-settings/lib/season.ts
@@ -1,0 +1,33 @@
+// Pure season-form helpers — no rendering, no network. Boundary logic the View leans on, tested
+// as Vitest units (see season.test.ts). The backend owns the authoritative event-write validation;
+// these only shape the form (range sanity + dirty/warning state).
+
+export interface SeasonBounds {
+  start?: string
+  end?: string
+}
+
+// Treat empty strings (cleared date inputs) as "unset" so '' and undefined compare equal.
+function normalize(value?: string): string | undefined {
+  return value ? value : undefined
+}
+
+/** True when either bound is set. An unset season imposes no constraint. */
+export function isSeasonConfigured(bounds: SeasonBounds): boolean {
+  return normalize(bounds.start) !== undefined || normalize(bounds.end) !== undefined
+}
+
+/** A human-readable error when the range is inverted (end before start), else null. */
+export function validateSeasonRange(bounds: SeasonBounds): string | null {
+  const start = normalize(bounds.start)
+  const end = normalize(bounds.end)
+  if (start && end && end < start) {
+    return 'End date must be on or after the start date.'
+  }
+  return null
+}
+
+/** True when the draft differs from the saved season (ignoring '' vs undefined). */
+export function seasonChanged(saved: SeasonBounds, draft: SeasonBounds): boolean {
+  return normalize(saved.start) !== normalize(draft.start) || normalize(saved.end) !== normalize(draft.end)
+}

--- a/app/src/features/team-settings/ui/TeamSettings.tsx
+++ b/app/src/features/team-settings/ui/TeamSettings.tsx
@@ -1,0 +1,24 @@
+import { useSeason, useSetSeason } from '@shared/api/season'
+import { TeamSettingsView } from './TeamSettingsView'
+
+/**
+ * Container for team settings: wires the season query and the SetSeason mutation to the
+ * presentational TeamSettingsView, and handles the loading/error shells. Admin-gating is enforced
+ * on the route (beforeLoad) and again on the backend (403), so this component assumes an admin.
+ */
+export function TeamSettings() {
+  const { data: season, isLoading, error } = useSeason()
+  const setSeason = useSetSeason()
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading…</p>
+  if (error || !season) return <p className="text-sm text-red-500">Couldn't load team settings. Please try again.</p>
+
+  return (
+    <TeamSettingsView
+      season={{ start: season.start, end: season.end }}
+      isSaving={setSeason.isPending}
+      error={setSeason.error ? 'Could not save the season. Please try again.' : null}
+      onSave={(bounds) => setSeason.mutate(bounds)}
+    />
+  )
+}

--- a/app/src/features/team-settings/ui/TeamSettingsView.stories.tsx
+++ b/app/src/features/team-settings/ui/TeamSettingsView.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, waitFor } from 'storybook/test'
+import { TeamSettingsView } from './TeamSettingsView'
+
+// TeamSettingsView is the presentational season-settings UI behind the TeamSettings container. It
+// owns only local draft state (the two date fields); the query + SetSeason mutation stay in the
+// container, so every state renders purely from props.
+const meta = {
+  title: 'features/team-settings/TeamSettingsView',
+  component: TeamSettingsView,
+  args: { onSave: fn() },
+} satisfies Meta<typeof TeamSettingsView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Unset: Story = {
+  args: { season: {} },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('No season set — events can be scheduled on any date.')).toBeInTheDocument()
+    // Nothing to save until the user picks a date.
+    await expect(canvas.getByRole('button', { name: 'Save season' })).toBeDisabled()
+  },
+}
+
+export const Set: Story = {
+  args: { season: { start: '2026-09-01', end: '2027-04-30' } },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText('Start date')).toHaveValue('2026-09-01')
+    await expect(canvas.getByLabelText('End date')).toHaveValue('2027-04-30')
+    // Pristine form: Save disabled, no change warning.
+    await expect(canvas.getByRole('button', { name: 'Save season' })).toBeDisabled()
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument()
+  },
+}
+
+export const ChangeWarning: Story = {
+  args: { season: { start: '2026-09-01', end: '2027-04-30' } },
+  play: async ({ canvas, userEvent, args }) => {
+    const start = canvas.getByLabelText('Start date')
+    await userEvent.clear(start)
+    await userEvent.type(start, '2026-10-01')
+
+    // Editing a configured season surfaces the non-blocking warning and enables Save.
+    await waitFor(() => expect(canvas.getByRole('alert')).toHaveTextContent(/won't move or delete existing events/))
+    const save = canvas.getByRole('button', { name: 'Save season' })
+    await expect(save).toBeEnabled()
+
+    await userEvent.click(save)
+    await expect(args.onSave).toHaveBeenCalledWith({ start: '2026-10-01', end: '2027-04-30' })
+  },
+}
+
+export const InvalidRange: Story = {
+  args: { season: { start: '2026-09-01', end: '2027-04-30' } },
+  play: async ({ canvas, userEvent }) => {
+    const end = canvas.getByLabelText('End date')
+    await userEvent.clear(end)
+    await userEvent.type(end, '2026-08-01')
+
+    await waitFor(() =>
+      expect(canvas.getByText('End date must be on or after the start date.')).toBeInTheDocument(),
+    )
+    // An inverted range blocks the save.
+    await expect(canvas.getByRole('button', { name: 'Save season' })).toBeDisabled()
+  },
+}

--- a/app/src/features/team-settings/ui/TeamSettingsView.tsx
+++ b/app/src/features/team-settings/ui/TeamSettingsView.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import type { SeasonInput } from '@shared/api/season'
+import { isSeasonConfigured, seasonChanged, validateSeasonRange, type SeasonBounds } from '../lib/season'
+
+interface TeamSettingsViewProps {
+  /** The saved season (the baseline the draft is compared against). */
+  season: SeasonBounds
+  isSaving?: boolean
+  /** Backend error surfaced from the container (e.g. a rejected save), shown inline. */
+  error?: string | null
+  onSave: (bounds: SeasonInput) => void
+}
+
+/**
+ * Presentational Team Settings UI: the season start/end pickers. Owns only local draft state; the
+ * query + mutation live in the TeamSettings container, so every state (unset / set / change-warning)
+ * renders purely from props (see TeamSettingsView.stories.tsx). Editing an already-configured season
+ * surfaces a non-blocking warning — changing the window never moves or deletes existing events.
+ */
+export function TeamSettingsView({ season, isSaving, error, onSave }: TeamSettingsViewProps) {
+  const [start, setStart] = useState(season.start ?? '')
+  const [end, setEnd] = useState(season.end ?? '')
+
+  const draft: SeasonBounds = { start, end }
+  const rangeError = validateSeasonRange(draft)
+  const dirty = seasonChanged(season, draft)
+  // Warn only once the user has actually changed a previously-meaningful window (or set/cleared one).
+  const showWarning = dirty && (isSeasonConfigured(season) || isSeasonConfigured(draft))
+
+  const handleSave = () => {
+    if (rangeError || !dirty) return
+    onSave({ start: start || undefined, end: end || undefined })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="font-display text-2xl font-bold">Season</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Bound your team's events to a season. Once set, events cannot be scheduled outside this window.
+        </p>
+      </div>
+
+      {!isSeasonConfigured(season) && !dirty && (
+        <p className="text-sm text-muted-foreground">No season set — events can be scheduled on any date.</p>
+      )}
+
+      <div className="flex flex-wrap gap-4">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="season-start">Start date</Label>
+          <Input
+            id="season-start"
+            type="date"
+            value={start}
+            max={end || undefined}
+            onChange={(e) => setStart(e.target.value)}
+            className="w-48"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="season-end">End date</Label>
+          <Input
+            id="season-end"
+            type="date"
+            value={end}
+            min={start || undefined}
+            onChange={(e) => setEnd(e.target.value)}
+            className="w-48"
+          />
+        </div>
+      </div>
+
+      {rangeError && <p className="text-sm text-red-500">{rangeError}</p>}
+
+      {showWarning && !rangeError && (
+        <p className="rounded-lg border border-gold/40 bg-gold/10 px-3 py-2 text-sm text-foreground" role="alert">
+          Changing the season won't move or delete existing events — some may now fall outside the new window.
+        </p>
+      )}
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      <div>
+        <Button disabled={isSaving || !dirty || !!rangeError} onClick={handleSave}>
+          {isSaving ? 'Saving…' : 'Save season'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as WelcomeIndexRouteImport } from './routes/welcome/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as MembersIndexRouteImport } from './routes/members/index'
+import { Route as TeamSettingsRouteImport } from './routes/team/settings'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
@@ -43,6 +44,11 @@ const MembersIndexRoute = MembersIndexRouteImport.update({
   path: '/members/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TeamSettingsRoute = TeamSettingsRouteImport.update({
+  id: '/team/settings',
+  path: '/team/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const InviteTokenRoute = InviteTokenRouteImport.update({
   id: '/invite/$token',
   path: '/invite/$token',
@@ -65,6 +71,7 @@ export interface FileRoutesByFullPath {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/team/settings': typeof TeamSettingsRoute
   '/members/': typeof MembersIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -75,6 +82,7 @@ export interface FileRoutesByTo {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/team/settings': typeof TeamSettingsRoute
   '/members': typeof MembersIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/welcome': typeof WelcomeIndexRoute
@@ -86,6 +94,7 @@ export interface FileRoutesById {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/team/settings': typeof TeamSettingsRoute
   '/members/': typeof MembersIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -98,6 +107,7 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/team/settings'
     | '/members/'
     | '/profile/'
     | '/welcome/'
@@ -108,6 +118,7 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/team/settings'
     | '/members'
     | '/profile'
     | '/welcome'
@@ -118,6 +129,7 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/team/settings'
     | '/members/'
     | '/profile/'
     | '/welcome/'
@@ -129,6 +141,7 @@ export interface RootRouteChildren {
   AuthVerifyRoute: typeof AuthVerifyRoute
   EventsEventIdRoute: typeof EventsEventIdRoute
   InviteTokenRoute: typeof InviteTokenRoute
+  TeamSettingsRoute: typeof TeamSettingsRoute
   MembersIndexRoute: typeof MembersIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
   WelcomeIndexRoute: typeof WelcomeIndexRoute
@@ -171,6 +184,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MembersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/team/settings': {
+      id: '/team/settings'
+      path: '/team/settings'
+      fullPath: '/team/settings'
+      preLoaderRoute: typeof TeamSettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/invite/$token': {
       id: '/invite/$token'
       path: '/invite/$token'
@@ -201,6 +221,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthVerifyRoute: AuthVerifyRoute,
   EventsEventIdRoute: EventsEventIdRoute,
   InviteTokenRoute: InviteTokenRoute,
+  TeamSettingsRoute: TeamSettingsRoute,
   MembersIndexRoute: MembersIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
   WelcomeIndexRoute: WelcomeIndexRoute,

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -126,6 +126,15 @@ function RootLayout() {
                   Members
                 </Link>
               )}
+              {isAdmin && (
+                <Link
+                  to="/team/settings"
+                  className="text-xs font-semibold text-muted-foreground hover:text-foreground"
+                  activeProps={{ className: 'text-foreground' }}
+                >
+                  Settings
+                </Link>
+              )}
               <Link
                 to="/profile"
                 className="text-xs font-semibold text-muted-foreground hover:text-foreground"

--- a/app/src/routes/team/settings.tsx
+++ b/app/src/routes/team/settings.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { authMeQueryOptions } from '@shared/api/auth'
+import { queryClient } from '@shared/api/query-client'
+import { TeamSettings } from '@features/team-settings/ui/TeamSettings'
+
+export const Route = createFileRoute('/team/settings')({
+  // Admin-only. Read the same /me query the root guard primed (from cache) and bounce non-admins
+  // home before the settings mount — race-free, mirroring the /members admin gate.
+  beforeLoad: async () => {
+    let user = null
+    try {
+      user = await queryClient.ensureQueryData(authMeQueryOptions)
+    } catch {
+      // Session unconfirmed — treat as not authorized.
+    }
+    if (user?.role !== 'ADMIN') throw redirect({ to: '/' })
+  },
+  component: TeamSettingsPage,
+})
+
+function TeamSettingsPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <TeamSettings />
+    </div>
+  )
+}

--- a/app/src/shared/api/season.ts
+++ b/app/src/shared/api/season.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from './wirespec-client'
+
+// Re-export the generated contract type so the app has a single source of truth.
+export type { Season } from './generated/model/Season'
+
+// A season bound is an ISO date string ("2026-09-01") or undefined (unbounded on that side).
+export interface SeasonInput {
+  start?: string
+  end?: string
+}
+
+// The current team's season window. Readable by any member (GET has no 403). Keyed ['season'] so a
+// SetSeason mutation invalidating that prefix refreshes every reader.
+export function useSeason() {
+  return useQuery({
+    queryKey: ['season'],
+    queryFn: async () => {
+      const res = await api.GetSeason()
+      return res.body
+    },
+  })
+}
+
+export function useSetSeason() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ start, end }: SeasonInput) => {
+      const res = await api.SetSeason({ body: { start: start || undefined, end: end || undefined } })
+      if (res.status === 403) throw new Error('You are not allowed to change the season.')
+      return res.body
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['season'] }),
+  })
+}


### PR DESCRIPTION
Implements **Phase 1** of recurring events (epic #108) per **ADR-0014**: a per-team **Season** enforced at event-write time on the existing single-event create/update path. Closes #109.

Recurring creation (Phase 2) and series edit/delete (Phase 3) are **out of scope** — no `POST /api/recurring-events`, no scope query-params, no split logic, no wizard.

## What changed

**Backend (hexagonal DDD)**
- `V004__team_settings.sql` — a singleton `team_settings` row in the **tenant schema** with nullable `season_start` / `season_end` (dates), seeded unset. New migration, no existing migration edited.
- `Season` value object + `SeasonRepository` port + `JpaSeasonRepositoryAdapter` (upserts the singleton).
- `SeasonService` (admin-gated `setSeason`, readable `getSeason`; rejects an inverted range with 400).
- Validation wired into `EventService.createEvent` / `updateEvent`.
- `season.ws` → `GetSeason GET /api/team/season -> 200 Season`, `SetSeason PUT SetSeasonRequest /api/team/season -> 200 Season` (admin-only); implemented in `SeasonController`. Generated via `make wirespec` (generated files not hand-edited).
- `EventOutsideSeasonException` → **422** with a stable `EVENT_OUTSIDE_SEASON` code (new `UnprocessableEntityException` category in the global handler).

**Frontend (Feature-Sliced Design)**
- `shared/api/season.ts` hooks — `useSeason` / `useSetSeason`.
- Admin-gated **Team Settings** page (`/team/settings`) with season start/end pickers and a **non-blocking warning** that existing events may fall outside a changed window. Nav link mirrors the `/members` admin gate.

## Validation matrix (ADR-0014)

| Case | Behaviour |
|------|-----------|
| Create, start **outside** window | **Reject (422)** |
| Create, start **inside** window | Allow |
| Update, start **unchanged** (out-of-window) | **Grandfather** — allow |
| Update, start **moved outside** window | **Reject (422)** |
| **No season** configured (both bounds null) | **No constraint** |
| GET/PUT season | Round-trips; PUT with null bounds clears |
| PUT by non-admin | **403** |

A bound only constrains when non-null (null = unbounded on that side; both null = unconstrained). Instants are resolved to a calendar date in the team's civil zone (the app clock's `Europe/Amsterdam`) before comparison. Changing the window never moves or deletes events — the frontend only warns.

## Tests (lowest layer that proves it)

- **Kotest + Testcontainers (real Postgres)** — `SeasonControllerIT`: full validation matrix on the event-write path, GET/PUT round-trip, clear, admin gating.
- **Kotest (pure)** — `SeasonTest`: inclusive-range / unbounded-side / unset boundary logic.
- **Vitest** — `season.test.ts`: pure date-boundary form logic (range sanity, dirty/warning).
- **Storybook** — `TeamSettingsView.stories.tsx`: unset / set / change-warning / invalid-range states.

**No new e2e — no new seam.** This reuses the existing admin-gated single-event write path and adds no new auth path, cross-tenant write, or external integration.

## Verification notes

`make test-app` (120 green, incl. the new stories + units), ESLint, and detekt all pass locally. Backend feature tests pass against real Postgres (`SeasonControllerIT` ×9, `SeasonTest` ×7); the full `:api:test` run is green except a pre-existing `ArchitectureTest` false-positive that only appears under a Java 21 toolchain (Spring's `aotTest` bean-definition classes get scanned by ArchUnit) — reproduced identically on clean `main`, and it does not flag any production class. This sandbox can't run the pinned Java 25 toolchain or pull DB images (both blocked by egress policy), so backend runs used a locally-installed Postgres; CI runs the pinned toolchain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEX4rPi8YgH4Ej55mi97VB)_