### PR TITLE
chore: cache Playwright browsers in CI to speed up test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,26 @@ jobs:
 
       # Needed before `make test`: the Storybook stories run in a headless-chromium
       # Vitest browser project, and the real e2e suite also drives Chromium.
-      - name: Install Playwright browser
+      #
+      # The Chromium binary only changes when Playwright's version does, so cache
+      # ~/.cache/ms-playwright keyed on the lockfile. On a hit we skip the (slow)
+      # browser download and only re-run install-deps, which installs the apt
+      # system libraries that live outside the cached directory.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('app/package-lock.json') }}
+
+      - name: Install Playwright browser (+ system deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: app
+
+      - name: Install Playwright system deps (cached browser)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: app
 
       - run: make test


### PR DESCRIPTION
## Summary

Optimize CI test execution time by caching the Playwright browser binary across workflow runs, since it only changes when Playwright's version updates.

## Changes

- **Add browser cache step**: Cache `~/.cache/ms-playwright` keyed on `app/package-lock.json` using `actions/cache@v4`
- **Split browser installation**: 
  - On cache hit: run `npx playwright install-deps chromium` (installs only system libraries)
  - On cache miss: run `npx playwright install --with-deps chromium` (downloads browser + system deps)

## Implementation details

The Chromium binary is expensive to download but stable across runs unless Playwright's version changes. By caching the binary and keying on the lockfile, we:
- Skip the slow browser download on cache hits
- Still install required system libraries (which live outside the cache) on every run
- Automatically invalidate the cache when Playwright is upgraded

This reduces `make test` execution time significantly on subsequent runs without sacrificing correctness.

https://claude.ai/code/session_01PvvpWJhbG1Jzi5TGHZ9FwD