### PR TITLE
fix(api): pin platform Flyway migrations to the public schema

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/PlatformSchemaInitializer.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/PlatformSchemaInitializer.kt
@@ -7,10 +7,12 @@ import org.springframework.stereotype.Component
 /**
  * Runs the platform (`public`) schema migrations once at application startup.
  *
- * Spring's auto-Flyway is not used for the platform schema (the app owns migration
- * explicitly so it can also provision per-tenant schemas — see [TenantSchemaManager]).
- * Without this hook the platform schema is only ever migrated from tests, so every
- * persistence call in a real run fails with `relation "public...." does not exist`.
+ * Both this hook and Spring Boot's auto-Flyway migrate `classpath:db/migration`; both are pinned
+ * to the `public` schema (`spring.flyway.schemas` for auto-Flyway, `.schemas("public")` here). The
+ * pin is essential: without it Flyway targets the connection's ambient search_path, which in prod
+ * defaulted to a tenant schema — and a platform migration then lands in the wrong schema (see the
+ * incident that added the pin). This explicit hook also owns per-tenant provisioning via
+ * [TenantSchemaManager]; it baselines so it runs cleanly against the already-populated schema.
  */
 @Component
 class PlatformSchemaInitializer(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManager.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManager.kt
@@ -10,6 +10,11 @@ class TenantSchemaManager(private val dataSource: DataSource) {
     fun provisionPlatformSchema() {
         Flyway.configure()
             .dataSource(dataSource)
+            // Pin the platform schema explicitly. Without this, Flyway targets the connection's
+            // ambient search_path, which in prod defaulted to a tenant schema (left over from manual
+            // tenant provisioning) — so a new platform migration landed in that tenant schema instead
+            // of `public`. Pinning makes it deterministic, mirroring provisionTenantSchema's .schemas().
+            .schemas("public")
             .locations("classpath:db/migration")
             .baselineOnMigrate(true)
             .baselineVersion("0")

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -3,9 +3,6 @@ spring:
     url: jdbc:postgresql://localhost:5432/teambalance
     username: teambalance
     password: teambalance
-  flyway:
-    schemas:
-      - public
 
 teambalance:
   invitation:

--- a/api/src/main/resources/application-e2e.yml
+++ b/api/src/main/resources/application-e2e.yml
@@ -7,9 +7,6 @@ spring:
     url: jdbc:postgresql://localhost:5432/teambalance
     username: teambalance
     password: teambalance
-  flyway:
-    schemas:
-      - public
 
 teambalance:
   invitation:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -28,6 +28,12 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    # Pin the platform migrations to `public` for ALL profiles. Without this, Boot's auto-Flyway
+    # targets the connection's ambient search_path; in prod that defaulted to a tenant schema (left
+    # over from manual tenant provisioning), so a platform migration landed in the tenant schema
+    # instead of `public`. Platform tables (users, teams, sessions, …) live in `public` by design.
+    schemas:
+      - public
   jackson:
     default-property-inclusion: non_null
   session:


### PR DESCRIPTION
## Prod incident

After the Spring Session JDBC change ([#113](https://github.com/ZzAve/teambalance-app/pull/113)) deployed, login failed:
```
org.postgresql.util.PSQLException: ERROR: relation "public.spring_session" does not exist
```
The `V005` table had been created in the **tenant** schema `tovo_heren_4`, not `public`.

## Root cause

Platform migrations (`db/migration`) didn't pin a target schema, so Flyway used the connection's **ambient `search_path`**. In prod that `search_path` defaults to a tenant schema (left over from manual tenant provisioning), so the newest platform migration landed there. `V001–V004` predate that default and are correctly in `public` — which is why login worked right up to the session lookup.

`dev`/`e2e` already pinned `spring.flyway.schemas: [public]`; **prod (base) did not** — that was the gap.

## Fix — pin `public` on both platform-migration paths

- **`application.yml` (base):** `spring.flyway.schemas: [public]` for Boot's auto-Flyway (all profiles), removing the now-redundant per-profile pins in `dev`/`e2e`.
- **`TenantSchemaManager.provisionPlatformSchema()`:** `.schemas("public")`, mirroring `provisionTenantSchema`'s explicit `.schemas(schemaName)`.
- Corrected `PlatformSchemaInitializer`'s stale KDoc (Boot auto-Flyway *is* used — the false claim helped hide this).

## Verification

Reproduced the exact prod condition on a throwaway Postgres whose default `search_path` is `tovo_heren_4, public`, then booted the app:
- `spring_session` + `spring_session_attributes` created in **`public`**; **0** tables in the tenant schema.
- Login works end-to-end (`request:202 verify:200 me:200`).
- Full `:api:test` (all green) + `:api:detekt` clean.

## Deploy / remediation

Merging + deploying this restores login on its own: `public.flyway_schema_history` is at `V004`, so the fixed boot applies `V005` to `public`. The misplaced `tovo_heren_4.spring_session*` tables (and any stray tenant `flyway_schema_history`) are harmless leftovers to drop afterward. See the PR discussion / runbook for the exact cleanup SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
