### PR TITLE
feat: recurring events — Phase 3 (series edit/delete, Level-3 split scopes)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -5,9 +5,12 @@ import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonExcep
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.exception.RecurrenceExceedsCapException
 import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventEdit
 import com.github.zzave.teambalance.api.domain.model.EventReference
+import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.OccurrenceSchedule
 import com.github.zzave.teambalance.api.domain.model.Recurrence
+import com.github.zzave.teambalance.api.domain.model.SeriesModification
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
@@ -147,8 +150,23 @@ class EventService(
         dates.firstOrNull { !season.allows(it) }?.let { throw EventOutsideSeasonException(it) }
     }
 
+    /**
+     * Applies a scoped edit over a recurring series (ADR-0014, Decision 4). A group-less event is a
+     * one-occurrence series, so any scope simply edits that row; otherwise the whole group is loaded
+     * and [SeriesModification] computes the split/reassignment matrix (detach + new-group-after for
+     * THIS, before-kept + new-group-for-tail for FOLLOWING, whole-group for ALL). Bulk scopes
+     * propagate every field except each occurrence's own calendar date.
+     *
+     * Season validation still fires, and grandfathers unchanged starts: only occurrences whose start
+     * actually moves are checked, so an occurrence already outside a shrunk window stays editable
+     * (e.g. an ALL edit that changes only the title touches no start and is never rejected).
+     *
+     * Returns the affected ("edited") occurrences ordered by start, or null when [id] is unknown.
+     * Runs in one transaction — the whole reassignment commits or nothing does.
+     */
     fun updateEvent(
         id: UUID,
+        scope: EventSeriesScope,
         eventTypeId: UUID,
         title: String,
         description: String?,
@@ -156,34 +174,55 @@ class EventService(
         endTime: Instant,
         location: String?,
         references: List<EventReference> = emptyList(),
-    ): Event? {
-        val existing = eventRepository.findById(id) ?: return null
+    ): List<Event>? {
+        val target = eventRepository.findById(id) ?: return null
         val eventType = eventTypeRepository.findById(eventTypeId)
             ?: throw EventTypeNotFoundException(eventTypeId)
 
-        // ADR-0014: validate the season only when the start is being moved. An unchanged start is
-        // grandfathered, so an event already outside the window (e.g. after it was shrunk) stays editable.
-        if (existing.startTime != startTime) requireWithinSeason(startTime)
-
+        val series = seriesOf(target)
         // Replace-semantics (ADR-0016): the incoming list is the new full set of references.
-        return eventRepository.save(
-            existing.copy(
+        val plan = SeriesModification.planEdit(
+            series = series,
+            targetId = id,
+            scope = scope,
+            edit = EventEdit(
                 eventType = eventType,
                 title = title,
                 description = description,
-                startTime = startTime,
-                endTime = endTime,
                 location = location,
                 references = references,
+                startTime = startTime,
+                endTime = endTime,
             ),
+            newTailGroup = UUID.randomUUID(),
+            zone = clock.zone,
         )
+
+        val originalStarts = series.associate { it.id to it.startTime }
+        plan.toPersist.forEach { updated ->
+            if (updated.startTime != originalStarts[updated.id]) requireWithinSeason(updated.startTime)
+        }
+
+        plan.toPersist.forEach { eventRepository.save(it) }
+        return plan.edited.sortedBy { it.startTime }
     }
 
-    fun deleteEvent(id: UUID): Boolean {
-        if (eventRepository.findById(id) == null) return false
-        eventRepository.deleteById(id)
+    /**
+     * Deletes the occurrences in [scope] over the target's series (ADR-0014, Decision 4). A delete
+     * **never splits** — survivors keep their group untouched. Returns false when [id] is unknown.
+     * Runs in one transaction.
+     */
+    fun deleteEvent(id: UUID, scope: EventSeriesScope): Boolean {
+        val target = eventRepository.findById(id) ?: return false
+        val toDelete = SeriesModification.planDelete(seriesOf(target), id, scope)
+        toDelete.forEach { eventRepository.deleteById(it) }
         return true
     }
+
+    // A group-less event is a one-occurrence series (its own row); otherwise the whole group,
+    // start-time ordered — the "before/after" axis every scoped operation splits on.
+    private fun seriesOf(event: Event): List<Event> =
+        event.recurringGroup?.let { eventRepository.findByRecurringGroup(it) } ?: listOf(event)
 
     // Rejects a start that falls outside the configured season. The instant is resolved to a calendar
     // date in the team's civil zone (the clock's zone) so the comparison matches how humans read the

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventSeriesScope.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventSeriesScope.kt
@@ -1,0 +1,17 @@
+package com.github.zzave.teambalance.api.domain.model
+
+/**
+ * The reach of a scoped edit or delete over a recurring series (ADR-0014, Decision 4). A series is
+ * just the set of [Event] rows sharing a `recurringGroup`; there is no stored rule, so every scoped
+ * operation is row-reassignment + field updates.
+ */
+enum class EventSeriesScope {
+    /** Only the target occurrence. An edit detaches it and splits the series around it. */
+    THIS,
+
+    /** The target occurrence and every later one; the earlier occurrences stay as their own series. */
+    THIS_AND_FOLLOWING,
+
+    /** Every occurrence in the group; the group itself is left intact. */
+    ALL,
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
@@ -1,0 +1,150 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.UUID
+
+/**
+ * The concrete field values a scoped edit carries onto its affected occurrences (ADR-0014).
+ *
+ * The date-carrying part of [startTime]/[endTime] is honoured verbatim only for a single-occurrence
+ * ([EventSeriesScope.THIS]) edit — the one scope allowed to move an occurrence's calendar date. A
+ * bulk scope takes only the wall-clock **time-of-day** and the **duration** from them and keeps each
+ * occurrence's own date, so a changed time-of-day propagates but the per-occurrence date never does.
+ */
+data class EventEdit(
+    val eventType: EventType,
+    val title: String,
+    val description: String?,
+    val location: String?,
+    val references: List<EventReference>,
+    val startTime: Instant,
+    val endTime: Instant,
+)
+
+/**
+ * The result of planning a scoped edit: [edited] are the occurrences the edit's fields were applied
+ * to (the "affected N" the UI previews); [regrouped] are occurrences only moved to a new group with
+ * their fields intact (the detached tail of a [EventSeriesScope.THIS] edit). Their union is the full
+ * set of rows to persist.
+ */
+data class SeriesEditPlan(
+    val edited: List<Event>,
+    val regrouped: List<Event>,
+) {
+    val toPersist: List<Event> get() = edited + regrouped
+}
+
+/**
+ * Pure row-reassignment + field-update logic for the Level-3 edit/delete scopes (ADR-0014,
+ * Decision 4). No Spring, no DB, no clock — mints nothing itself (the caller supplies a fresh tail
+ * group) so the split matrix is exhaustively unit-testable. The transactional apply (load the group,
+ * validate the season, save/delete the rows) is the service's job.
+ */
+object SeriesModification {
+
+    /**
+     * Plans a scoped edit of [targetId] within [series] (all rows sharing the target's group, any
+     * order). [newTailGroup] is the freshly-minted group for a detached tail; [zone] resolves the
+     * wall-clock time-of-day for bulk scopes. Occurrences left entirely untouched are omitted.
+     *
+     *  - **THIS** → the target detaches (`group = null`) with the edit applied, its date free to
+     *    move; every occurrence *after* it moves to [newTailGroup] with its fields intact; the
+     *    occurrences *before* are untouched. Three disconnected things.
+     *  - **THIS_AND_FOLLOWING** → the target + every following occurrence move to [newTailGroup] with
+     *    the edit applied (each keeps its own date); the occurrences before are untouched.
+     *  - **ALL** → every occurrence gets the edit (each keeps its own date); the group is unchanged.
+     */
+    fun planEdit(
+        series: List<Event>,
+        targetId: UUID,
+        scope: EventSeriesScope,
+        edit: EventEdit,
+        newTailGroup: UUID,
+        zone: ZoneId,
+    ): SeriesEditPlan {
+        val ordered = series.sortedBy { it.startTime }
+        val idx = ordered.indexOfFirst { it.id == targetId }
+        require(idx >= 0) { "target $targetId is not part of the series" }
+        val target = ordered[idx]
+
+        return when (scope) {
+            EventSeriesScope.THIS -> SeriesEditPlan(
+                edited = listOf(target.applyMoved(edit, group = null)),
+                regrouped = ordered.drop(idx + 1).map { it.copy(recurringGroup = newTailGroup) },
+            )
+
+            EventSeriesScope.THIS_AND_FOLLOWING -> {
+                // With no occurrences before the target, the "tail" is the whole series — there is
+                // nothing to split away from, so keep the existing group (null for a standalone
+                // event) rather than mint a pointless new group of identical membership.
+                val tailGroup = if (idx > 0) newTailGroup else target.recurringGroup
+                SeriesEditPlan(
+                    edited = ordered.drop(idx).map { it.applyBulk(edit, group = tailGroup, zone = zone) },
+                    regrouped = emptyList(),
+                )
+            }
+
+            EventSeriesScope.ALL -> SeriesEditPlan(
+                edited = ordered.map { it.applyBulk(edit, group = it.recurringGroup, zone = zone) },
+                regrouped = emptyList(),
+            )
+        }
+    }
+
+    /**
+     * The ids to delete for a scoped delete of [targetId] within [series]. A delete **never splits**
+     * — survivors keep their group untouched (ADR-0014, Decision 4).
+     *
+     *  - **THIS** → just the target.
+     *  - **THIS_AND_FOLLOWING** → the target and every later occurrence.
+     *  - **ALL** → every occurrence in the group.
+     */
+    fun planDelete(
+        series: List<Event>,
+        targetId: UUID,
+        scope: EventSeriesScope,
+    ): List<UUID> {
+        val ordered = series.sortedBy { it.startTime }
+        val idx = ordered.indexOfFirst { it.id == targetId }
+        require(idx >= 0) { "target $targetId is not part of the series" }
+
+        return when (scope) {
+            EventSeriesScope.THIS -> listOf(targetId)
+            EventSeriesScope.THIS_AND_FOLLOWING -> ordered.drop(idx).map { it.id }
+            EventSeriesScope.ALL -> ordered.map { it.id }
+        }
+    }
+
+    // A single occurrence moving freely: start/end are taken verbatim, so its calendar date may move.
+    private fun Event.applyMoved(edit: EventEdit, group: UUID?): Event =
+        copy(
+            eventType = edit.eventType,
+            title = edit.title,
+            description = edit.description,
+            location = edit.location,
+            references = edit.references,
+            startTime = edit.startTime,
+            endTime = edit.endTime,
+            recurringGroup = group,
+        )
+
+    // A bulk-affected occurrence: keep its own calendar date, but re-anchor to the edit's wall-clock
+    // time-of-day and apply the edit's duration — so a time change propagates, a date change does not.
+    private fun Event.applyBulk(edit: EventEdit, group: UUID?, zone: ZoneId): Event {
+        val timeOfDay = edit.startTime.atZone(zone).toLocalTime()
+        val duration = Duration.between(edit.startTime, edit.endTime)
+        val newStart = OccurrenceSchedule.startInstant(startTime.atZone(zone).toLocalDate(), timeOfDay, zone)
+        return copy(
+            eventType = edit.eventType,
+            title = edit.title,
+            description = edit.description,
+            location = edit.location,
+            references = edit.references,
+            startTime = newStart,
+            endTime = newStart.plus(duration),
+            recurringGroup = group,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
@@ -8,6 +8,7 @@ interface EventRepository {
     fun findById(id: UUID): Event?
     fun findUpcoming(since: Instant): List<Event>
     fun findAll(): List<Event>
+    fun findByRecurringGroup(group: UUID): List<Event>
     fun save(event: Event): Event
     fun deleteById(id: UUID)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -25,6 +25,9 @@ class JpaEventRepositoryAdapter(
     override fun findAll(): List<Event> =
         jpaRepository.findAllByOrderByStartTimeDesc().map { it.internalize() }
 
+    override fun findByRecurringGroup(group: UUID): List<Event> =
+        jpaRepository.findByRecurringGroupOrderByStartTimeAsc(group).map { it.internalize() }
+
     override fun save(event: Event): Event {
         val eventTypeEntity = eventTypeJpaRepository.findByUuid(event.eventType.id)
             ?: throw EventTypeNotFoundException(event.eventType.id)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
@@ -9,4 +9,5 @@ interface SpringDataEventRepository : JpaRepository<EventJpaEntity, Long> {
     fun findByUuid(uuid: UUID): EventJpaEntity?
     fun findByStartTimeGreaterThanOrderByStartTimeAsc(since: Instant): List<EventJpaEntity>
     fun findAllByOrderByStartTimeDesc(): List<EventJpaEntity>
+    fun findByRecurringGroupOrderByStartTimeAsc(recurringGroup: UUID): List<EventJpaEntity>
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -9,6 +9,8 @@ import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.application.PotentialEvent
 import com.github.zzave.teambalance.api.domain.model.AttendanceState as DomainAttendanceState
 import com.github.zzave.teambalance.api.domain.model.EventReference as DomainEventReference
+import com.github.zzave.teambalance.api.domain.model.EventSeriesScope as DomainEventSeriesScope
+import com.github.zzave.teambalance.api.interfaces.generated.model.EventSeriesScope as GeneratedEventSeriesScope
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateEvent
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.DeleteEvent
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetEvent
@@ -95,13 +97,16 @@ class EventController(
         )
     }
 
+    // Scoped edit (ADR-0014, Phase 3): a bulk scope touches many rows, so the success type is an
+    // EventList of the affected occurrences. The scope query param defaults to THIS when absent.
     override suspend fun updateEvent(request: UpdateEvent.Request): UpdateEvent.Response<*> {
         val teamId = currentTeamProvider.requireCurrentTeamId()
         authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), teamId)
         val id = UUID.fromString(request.path.id)
         val req = request.body
-        val event = eventService.updateEvent(
+        val events = eventService.updateEvent(
             id = id,
+            scope = request.queries.scope.consume(),
             eventTypeId = UUID.fromString(req.eventTypeId),
             title = req.title,
             description = req.description,
@@ -111,18 +116,26 @@ class EventController(
             references = req.references.internalize(),
         ) ?: return UpdateEvent.Response404(Unit)
 
-        return UpdateEvent.Response200(event.produce(attendanceService, attendanceService.teamMembers(teamId)))
+        val members = attendanceService.teamMembers(teamId)
+        return UpdateEvent.Response200(EventList(events = events.map { it.produce(attendanceService, members) }))
     }
 
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
         authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), currentTeamProvider.requireCurrentTeamId())
         val id = UUID.fromString(request.path.id)
-        return if (eventService.deleteEvent(id)) {
+        return if (eventService.deleteEvent(id, request.queries.scope.consume())) {
             DeleteEvent.Response204(Unit)
         } else {
             DeleteEvent.Response404(Unit)
         }
     }
+}
+
+// A missing scope query param defaults to THIS (ADR-0014); otherwise it maps 1:1 to the domain enum.
+private fun GeneratedEventSeriesScope?.consume(): DomainEventSeriesScope = when (this) {
+    null, GeneratedEventSeriesScope.THIS -> DomainEventSeriesScope.THIS
+    GeneratedEventSeriesScope.THIS_AND_FOLLOWING -> DomainEventSeriesScope.THIS_AND_FOLLOWING
+    GeneratedEventSeriesScope.ALL -> DomainEventSeriesScope.ALL
 }
 
 private fun com.github.zzave.teambalance.api.interfaces.generated.model.CreateEventRequest.consume() =

--- a/api/src/main/wirespec/events.ws
+++ b/api/src/main/wirespec/events.ws
@@ -7,6 +7,13 @@ enum AttendanceState {
     NOT_RESPONDED
 }
 
+// Level-3 edit/delete scope (ADR-0014): row-reassignment + field updates over a recurring_group. Default THIS.
+enum EventSeriesScope {
+    THIS,
+    THIS_AND_FOLLOWING,
+    ALL
+}
+
 type EventTypeSummary {
     id: String,
     name: String,
@@ -103,12 +110,12 @@ endpoint GetEvent GET /api/events/{id: String} -> {
     404 -> Unit
 }
 
-endpoint UpdateEvent PUT UpdateEventRequest /api/events/{id: String} -> {
-    200 -> Event
+endpoint UpdateEvent PUT UpdateEventRequest /api/events/{id: String} ? {scope: EventSeriesScope?} -> {
+    200 -> EventList
     404 -> Unit
 }
 
-endpoint DeleteEvent DELETE /api/events/{id: String} -> {
+endpoint DeleteEvent DELETE /api/events/{id: String} ? {scope: EventSeriesScope?} -> {
     204 -> Unit
     404 -> Unit
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
@@ -1,0 +1,204 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.UUID
+
+/**
+ * Pure split/reassignment matrix for the Level-3 edit/delete scopes (ADR-0014, Decision 4). No
+ * Spring, no DB, no clock — the lowest layer that proves the group reassignments, the "affected"
+ * set, that a bulk scope keeps each occurrence's own date while propagating the time-of-day, and
+ * that a delete never splits. First / middle / last occurrences are all covered.
+ */
+class SeriesModificationTest : FunSpec({
+
+    val zone = ZoneId.of("Europe/Amsterdam")
+    val training = EventType(id = UUID.randomUUID(), name = "Training", color = "#123456")
+    val match = EventType(id = UUID.randomUUID(), name = "Match", color = "#abcdef")
+    val originalGroup = UUID.randomUUID()
+    val tailGroup = UUID.fromString("00000000-0000-0000-0000-0000000000aa")
+
+    // A four-occurrence weekly series: Tuesdays 20:30 local, 90 minutes, sharing one group.
+    fun occurrence(date: String, group: UUID? = originalGroup): Event {
+        val start = LocalDate.parse(date).atTime(LocalTime.of(20, 30)).atZone(zone).toInstant()
+        return Event(
+            id = UUID.nameUUIDFromBytes(date.toByteArray()),
+            eventType = training,
+            title = "Weekly Training",
+            description = "old",
+            startTime = start,
+            endTime = start.plus(Duration.ofMinutes(90)),
+            location = "Gym",
+            references = emptyList(),
+            recurringGroup = group,
+            createdBy = UUID.randomUUID(),
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+    }
+
+    val d1 = occurrence("2026-09-01")
+    val d2 = occurrence("2026-09-08")
+    val d3 = occurrence("2026-09-15")
+    val d4 = occurrence("2026-09-22")
+    // Deliberately unsorted, to prove the planner orders by start time itself.
+    val series = listOf(d3, d1, d4, d2)
+
+    // An edit that changes the type/title/description/location and moves the time-of-day 20:30 → 19:00,
+    // keeping the 90-minute duration. Its date (on d2, 2026-09-08) is only honoured for THIS.
+    fun editOn(date: String = "2026-09-08", time: LocalTime = LocalTime.of(19, 0)): EventEdit {
+        val start = LocalDate.parse(date).atTime(time).atZone(zone).toInstant()
+        return EventEdit(
+            eventType = match,
+            title = "Friendly Match",
+            description = "new",
+            location = "Sportcampus",
+            references = emptyList(),
+            startTime = start,
+            endTime = start.plus(Duration.ofMinutes(90)),
+        )
+    }
+
+    fun timeOfDay(instant: Instant): LocalTime = instant.atZone(zone).toLocalTime()
+    fun localDate(instant: Instant): LocalDate = instant.atZone(zone).toLocalDate()
+
+    // ── EDIT / THIS ─────────────────────────────────────────────────────────
+
+    test("edit THIS on a middle occurrence detaches it, regroups the tail, leaves the head untouched") {
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.THIS, editOn(), tailGroup, zone)
+
+        // Only d2 is edited; it detaches from any group.
+        plan.edited.map { it.id } shouldContainExactly listOf(d2.id)
+        val editedD2 = plan.edited.single()
+        editedD2.recurringGroup shouldBe null
+        editedD2.title shouldBe "Friendly Match"
+        editedD2.eventType shouldBe match
+        // THIS may move the date/time verbatim — 2026-09-08 19:00.
+        localDate(editedD2.startTime) shouldBe LocalDate.parse("2026-09-08")
+        timeOfDay(editedD2.startTime) shouldBe LocalTime.of(19, 0)
+
+        // Everything after d2 (d3, d4) moves to the fresh tail group, fields intact.
+        plan.regrouped.map { it.id } shouldContainExactly listOf(d3.id, d4.id)
+        plan.regrouped.forEach {
+            it.recurringGroup shouldBe tailGroup
+            it.title shouldBe "Weekly Training"
+        }
+        // d1 (before) is untouched — absent from the plan entirely.
+        plan.toPersist.map { it.id } shouldContainExactly listOf(d2.id, d3.id, d4.id)
+    }
+
+    test("edit THIS on the first occurrence regroups the whole tail and detaches only the first") {
+        val plan = SeriesModification.planEdit(series, d1.id, EventSeriesScope.THIS, editOn(date = "2026-09-01"), tailGroup, zone)
+
+        plan.edited.map { it.id } shouldContainExactly listOf(d1.id)
+        plan.edited.single().recurringGroup shouldBe null
+        plan.regrouped.map { it.id } shouldContainExactly listOf(d2.id, d3.id, d4.id)
+        plan.regrouped.forEach { it.recurringGroup shouldBe tailGroup }
+    }
+
+    test("edit THIS on the last occurrence detaches it and leaves no tail to regroup") {
+        val plan = SeriesModification.planEdit(series, d4.id, EventSeriesScope.THIS, editOn(date = "2026-09-22"), tailGroup, zone)
+
+        plan.edited.map { it.id } shouldContainExactly listOf(d4.id)
+        plan.edited.single().recurringGroup shouldBe null
+        plan.regrouped.shouldBeEmpty()
+    }
+
+    // ── EDIT / THIS_AND_FOLLOWING ───────────────────────────────────────────
+
+    test("edit THIS_AND_FOLLOWING moves target+following to a new group, keeps the head, propagates time not date") {
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.THIS_AND_FOLLOWING, editOn(), tailGroup, zone)
+
+        // d2, d3, d4 are all edited and land in the new tail group.
+        plan.edited.map { it.id } shouldContainExactly listOf(d2.id, d3.id, d4.id)
+        plan.regrouped.shouldBeEmpty()
+        plan.edited.forEach {
+            it.recurringGroup shouldBe tailGroup
+            it.title shouldBe "Friendly Match"
+            // Time-of-day propagates to every affected occurrence…
+            timeOfDay(it.startTime) shouldBe LocalTime.of(19, 0)
+        }
+        // …but each keeps its OWN calendar date — the date does not propagate.
+        localDate(plan.edited[0].startTime) shouldBe LocalDate.parse("2026-09-08")
+        localDate(plan.edited[1].startTime) shouldBe LocalDate.parse("2026-09-15")
+        localDate(plan.edited[2].startTime) shouldBe LocalDate.parse("2026-09-22")
+        // Duration is preserved (19:00 + 90m = 20:30).
+        plan.edited.forEach { Duration.between(it.startTime, it.endTime) shouldBe Duration.ofMinutes(90) }
+        // d1 (before the target) is left untouched.
+        plan.toPersist.map { it.id } shouldNotContain d1.id
+    }
+
+    // ── EDIT / ALL ──────────────────────────────────────────────────────────
+
+    test("edit ALL applies to every occurrence, keeps the original group, keeps each own date") {
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.ALL, editOn(), tailGroup, zone)
+
+        plan.edited.map { it.id } shouldContainExactly listOf(d1.id, d2.id, d3.id, d4.id)
+        plan.regrouped.shouldBeEmpty()
+        plan.edited.forEach {
+            // The group is unchanged — no split.
+            it.recurringGroup shouldBe originalGroup
+            it.title shouldBe "Friendly Match"
+            timeOfDay(it.startTime) shouldBe LocalTime.of(19, 0)
+        }
+        localDate(plan.edited[0].startTime) shouldBe LocalDate.parse("2026-09-01")
+        localDate(plan.edited[3].startTime) shouldBe LocalDate.parse("2026-09-22")
+    }
+
+    test("edit ALL that does not change the time-of-day leaves every start exactly where it was") {
+        // Same 20:30 as the originals — grandfathering hinges on the start being genuinely unchanged.
+        val plan = SeriesModification.planEdit(
+            series, d2.id, EventSeriesScope.ALL, editOn(time = LocalTime.of(20, 30)), tailGroup, zone,
+        )
+        plan.edited.forEach { edited ->
+            val original = series.single { it.id == edited.id }
+            edited.startTime shouldBe original.startTime
+        }
+    }
+
+    // ── DELETE (never splits) ───────────────────────────────────────────────
+
+    test("delete THIS removes only the target and never touches the survivors' group") {
+        SeriesModification.planDelete(series, d2.id, EventSeriesScope.THIS) shouldContainExactly listOf(d2.id)
+    }
+
+    test("delete THIS_AND_FOLLOWING removes the target and every later occurrence") {
+        SeriesModification.planDelete(series, d2.id, EventSeriesScope.THIS_AND_FOLLOWING) shouldContainExactly
+            listOf(d2.id, d3.id, d4.id)
+    }
+
+    test("delete ALL removes every occurrence in the group") {
+        SeriesModification.planDelete(series, d3.id, EventSeriesScope.ALL) shouldContainExactly
+            listOf(d1.id, d2.id, d3.id, d4.id)
+    }
+
+    // ── Standalone (group-less) event behaves as a one-occurrence series ─────
+
+    test("a standalone event edits only itself regardless of scope, staying group-less") {
+        val standalone = occurrence("2026-12-01", group = null)
+        val edit = editOn(date = "2026-12-01")
+        EventSeriesScope.entries.forEach { scope ->
+            val plan = SeriesModification.planEdit(listOf(standalone), standalone.id, scope, edit, tailGroup, zone)
+            plan.edited.map { it.id } shouldContainExactly listOf(standalone.id)
+            plan.regrouped.shouldBeEmpty()
+            plan.edited.single().recurringGroup shouldBe null
+        }
+    }
+
+    test("an unknown target id is rejected") {
+        shouldThrow<IllegalArgumentException> {
+            SeriesModification.planEdit(series, UUID.randomUUID(), EventSeriesScope.THIS, editOn(), tailGroup, zone)
+        }
+        shouldThrow<IllegalArgumentException> {
+            SeriesModification.planDelete(series, UUID.randomUUID(), EventSeriesScope.ALL)
+        }
+    }
+})

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -577,7 +577,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Updated by admin"))
+                // UpdateEvent now returns an EventList of affected occurrences (ADR-0014 Phase 3).
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].title").value("Updated by admin"))
         }
 
         test("DELETE /api/events/{id} by an admin succeeds") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventReferencesControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventReferencesControllerTest.kt
@@ -200,8 +200,9 @@ class EventReferencesControllerTest : TeamBalanceIT() {
 
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.references.length()").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.references[0].title").value("New Only"))
+                // UpdateEvent now returns an EventList of affected occurrences (ADR-0014 Phase 3).
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].references.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].references[0].title").value("New Only"))
 
             // The two old references are gone; only the new set remains (replace-semantics).
             val rows = jdbcTemplate.queryForList(

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
@@ -1,0 +1,409 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+private const val ADMIN_USER_ID = "b0000000-0000-0000-0000-0000000000e1"
+private const val MEMBER_USER_ID = "b0000000-0000-0000-0000-0000000000e2"
+private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+
+/**
+ * Level-3 series edit/delete over a materialized series (ADR-0014, Phase 3). Proves the exact
+ * row/group outcome of each scope against a real Postgres — the transactional wiring the pure
+ * [com.github.zzave.teambalance.api.domain.model.SeriesModificationTest] cannot reach: that the
+ * split reassigns real rows, that a bulk edit keeps each occurrence's own calendar date while a
+ * changed time-of-day propagates, that a delete never splits, and that season grandfathering
+ * still holds. The clock zone is Europe/Amsterdam, so a September 18:30Z start reads as 20:30 local.
+ */
+@AutoConfigureMockMvc
+class EventSeriesControllerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        // ── EDIT ─────────────────────────────────────────────────────────────
+
+        test("PUT scope=THIS on a middle occurrence detaches it, regroups the tail, keeps the head") {
+            seedTeamAndAdmin()
+            resetSeason()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "THIS-mid")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            // Edit the 2nd of four; THIS may also move its date (to 2026-09-09 19:00 local).
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$e2?scope=THIS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Detached", start = "2026-09-09T17:00:00Z", end = "2026-09-09T18:30:00Z")),
+                ADMIN_USER_ID,
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                // Only the target is "affected" — the tail is merely regrouped, not edited.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].id").value(e2.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].title").value("Detached"))
+
+            groupOf(e2) shouldBe null // detached
+            titleOf(e2) shouldBe "Detached"
+            groupOf(e1) shouldBe group // head kept
+            titleOf(e1) shouldBe "THIS-mid"
+
+            // The tail (e3, e4) shares one fresh group, distinct from the original and non-null.
+            val tail = groupOf(e3)
+            tail.shouldNotBeNull()
+            tail shouldBe groupOf(e4)
+            (tail == group) shouldBe false
+            titleOf(e3) shouldBe "THIS-mid" // tail is regrouped, not re-titled
+        }
+
+        test("PUT scope=THIS on the first occurrence regroups the whole tail, and on the last leaves no tail") {
+            seedTeamAndAdmin()
+            resetSeason()
+
+            val gFirst = UUID.randomUUID()
+            val ev = seedSeries(gFirst, "THIS-first")
+            val f1 = ev[0]
+            val f2 = ev[1]
+            val f3 = ev[2]
+            val f4 = ev[3]
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$f1?scope=THIS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "First detached", start = "2026-09-01T17:00:00Z", end = "2026-09-01T18:30:00Z")),
+                ADMIN_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            groupOf(f1) shouldBe null
+            val tail = groupOf(f2)
+            tail.shouldNotBeNull()
+            listOf(f3, f4).forEach { groupOf(it) shouldBe tail }
+            (tail == gFirst) shouldBe false
+
+            val gLast = UUID.randomUUID()
+            val evLast = seedSeries(gLast, "THIS-last")
+            val l1 = evLast[0]
+            val l4 = evLast[3]
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$l4?scope=THIS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Last detached", start = "2026-09-22T17:00:00Z", end = "2026-09-22T18:30:00Z")),
+                ADMIN_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            groupOf(l4) shouldBe null
+            groupOf(l1) shouldBe gLast // head untouched, no tail to regroup
+        }
+
+        test("PUT scope=THIS_AND_FOLLOWING moves target+following to a new group, propagates time but not date") {
+            seedTeamAndAdmin()
+            resetSeason()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "FOLLOWING")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            // Edit e2 onward, moving the wall-clock time 20:30 → 19:00 local (17:00Z in CEST).
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$e2?scope=THIS_AND_FOLLOWING")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Tail edited", start = "2026-09-08T17:00:00Z", end = "2026-09-08T18:30:00Z")),
+                ADMIN_USER_ID,
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events.length()").value(3))
+
+            // Head kept as-is.
+            groupOf(e1) shouldBe group
+            titleOf(e1) shouldBe "FOLLOWING"
+            startAt(e1) shouldBe "2026-09-01 18:30:00+00" // 20:30 local, unmoved
+
+            // Target + following: one fresh group, edited, time-of-day propagated…
+            val newGroup = groupOf(e2)
+            newGroup.shouldNotBeNull()
+            (newGroup == group) shouldBe false
+            listOf(e2, e3, e4).forEach {
+                groupOf(it) shouldBe newGroup
+                titleOf(it) shouldBe "Tail edited"
+            }
+            // …but each keeps its OWN calendar date — only the time-of-day (→17:00Z) changed.
+            startAt(e2) shouldBe "2026-09-08 17:00:00+00"
+            startAt(e3) shouldBe "2026-09-15 17:00:00+00"
+            startAt(e4) shouldBe "2026-09-22 17:00:00+00"
+        }
+
+        test("PUT scope=ALL edits every occurrence, keeps the group, keeps each own date") {
+            seedTeamAndAdmin()
+            resetSeason()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "ALL")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            // Drive the edit from a middle occurrence to prove ALL reaches the whole group either way.
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$e3?scope=ALL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Whole series", start = "2026-09-15T17:00:00Z", end = "2026-09-15T18:30:00Z")),
+                ADMIN_USER_ID,
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events.length()").value(4))
+
+            listOf(e1, e2, e3, e4).forEach {
+                groupOf(it) shouldBe group // no split
+                titleOf(it) shouldBe "Whole series"
+            }
+            startAt(e1) shouldBe "2026-09-01 17:00:00+00"
+            startAt(e2) shouldBe "2026-09-08 17:00:00+00"
+            startAt(e4) shouldBe "2026-09-22 17:00:00+00"
+        }
+
+        // ── DELETE (never splits) ─────────────────────────────────────────────
+
+        test("DELETE scope=THIS removes only the target; survivors keep their group (no split)") {
+            seedTeamAndAdmin()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "DEL-this")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            perform(MockMvcRequestBuilders.delete("/api/events/$e2?scope=THIS"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            exists(e2) shouldBe false
+            listOf(e1, e3, e4).forEach {
+                exists(it) shouldBe true
+                groupOf(it) shouldBe group // untouched — a delete never regroups survivors
+            }
+        }
+
+        test("DELETE scope=THIS_AND_FOLLOWING removes the target and every later occurrence") {
+            seedTeamAndAdmin()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "DEL-following")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            perform(MockMvcRequestBuilders.delete("/api/events/$e3?scope=THIS_AND_FOLLOWING"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            listOf(e1, e2).forEach { exists(it) shouldBe true; groupOf(it) shouldBe group }
+            listOf(e3, e4).forEach { exists(it) shouldBe false }
+        }
+
+        test("DELETE scope=ALL removes every occurrence in the group") {
+            seedTeamAndAdmin()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "DEL-all")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+
+            perform(MockMvcRequestBuilders.delete("/api/events/$e2?scope=ALL"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            listOf(e1, e2, e3, e4).forEach { exists(it) shouldBe false }
+        }
+
+        // ── Season grandfathering across a bulk scope ─────────────────────────
+
+        test("PUT scope=ALL changing only the title grandfathers a whole series that sits outside a shrunk season") {
+            seedTeamAndAdmin()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "GRANDFATHER")
+            val e1 = ev[0]
+            val e2 = ev[1]
+            val e3 = ev[2]
+            val e4 = ev[3]
+            // Window set AFTER creation, excluding every occurrence.
+            setSeason("2027-01-01", "2027-04-30")
+            try {
+                // Same start as stored (20:30 local = 18:30Z) ⇒ no start moves ⇒ grandfathered.
+                perform(
+                    MockMvcRequestBuilders.put("/api/events/$e1?scope=ALL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(editBody(title = "Renamed in place", start = "2026-09-01T18:30:00Z", end = "2026-09-01T20:00:00Z")),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isOk)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.events.length()").value(4))
+
+                listOf(e1, e2, e3, e4).forEach { titleOf(it) shouldBe "Renamed in place" }
+                startAt(e2) shouldBe "2026-09-08 18:30:00+00" // unchanged
+            } finally {
+                resetSeason()
+            }
+        }
+
+        test("PUT scope=ALL that moves the time-of-day of an out-of-season series is rejected with 422") {
+            seedTeamAndAdmin()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "GRANDFATHER-move")
+            val e1 = ev[0]
+            setSeason("2027-01-01", "2027-04-30")
+            try {
+                // Changing the time-of-day moves every start ⇒ season validation fires ⇒ rejected.
+                perform(
+                    MockMvcRequestBuilders.put("/api/events/$e1?scope=ALL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(editBody(title = "Moved time", start = "2026-09-01T17:00:00Z", end = "2026-09-01T18:30:00Z")),
+                    ADMIN_USER_ID,
+                )
+                    .andExpect(MockMvcResultMatchers.status().isUnprocessableContent)
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("EVENT_OUTSIDE_SEASON"))
+
+                // All-or-nothing: the rejected transaction left the series untouched.
+                titleOf(e1) shouldBe "GRANDFATHER-move"
+            } finally {
+                resetSeason()
+            }
+        }
+
+        // ── Auth + missing target ─────────────────────────────────────────────
+
+        test("PUT with a scope by a non-admin member is rejected with 403") {
+            seedTeamAndAdmin()
+            resetSeason()
+            seedMember(MEMBER_USER_ID, "series-member@test.com", role = "USER")
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "AUTH")
+            val e2 = ev[1]
+
+            perform(
+                MockMvcRequestBuilders.put("/api/events/$e2?scope=ALL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Nope", start = "2026-09-08T17:00:00Z", end = "2026-09-08T18:30:00Z")),
+                MEMBER_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isForbidden)
+
+            titleOf(e2) shouldBe "AUTH" // unchanged
+        }
+
+        test("DELETE scope=ALL on an unknown id is a 404") {
+            seedTeamAndAdmin()
+            perform(MockMvcRequestBuilders.delete("/api/events/${UUID.randomUUID()}?scope=ALL"), ADMIN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private fun perform(builder: MockHttpServletRequestBuilder, userId: String) =
+        mockMvc.perform(builder.header("X-Team-Id", "public").header("X-User-Id", userId))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    // Four weekly occurrences (Tuesdays 2026-09-01, 08, 15, 22) at 20:30 local (18:30Z, CEST),
+    // 90 minutes long, sharing [group]. Returned in chronological order.
+    private fun seedSeries(group: UUID, title: String): List<UUID> =
+        listOf("2026-09-01", "2026-09-08", "2026-09-15", "2026-09-22").map { date ->
+            val id = UUID.randomUUID()
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, recurring_group, created_by, created_at, updated_at)
+                VALUES ('$id'::uuid,
+                    (SELECT id FROM public.event_types WHERE name = 'Training'),
+                    '$title', '$date 18:30:00+00', '$date 20:00:00+00', '$group'::uuid,
+                    '$ADMIN_USER_ID'::uuid, now(), now())
+                """,
+            )
+            id
+        }
+
+    private fun editBody(title: String, start: String, end: String): String {
+        val eventTypeId = trainingTypeId()
+        return """
+            {
+              "eventTypeId": "$eventTypeId",
+              "title": "$title",
+              "description": null,
+              "startTime": "$start",
+              "endTime": "$end",
+              "location": null
+            }
+        """.trimIndent()
+    }
+
+    private fun trainingTypeId(): UUID =
+        jdbcTemplate.queryForObject("SELECT uuid FROM public.event_types WHERE name = 'Training'", UUID::class.java)!!
+
+    private fun groupOf(id: UUID): UUID? =
+        jdbcTemplate.queryForObject("SELECT recurring_group FROM public.events WHERE uuid = ?", UUID::class.java, id)
+
+    private fun titleOf(id: UUID): String =
+        jdbcTemplate.queryForObject("SELECT title FROM public.events WHERE uuid = ?", String::class.java, id)!!
+
+    // start_time rendered as a UTC wall-clock string, so date-preservation vs time-propagation is exact.
+    private fun startAt(id: UUID): String =
+        jdbcTemplate.queryForObject(
+            "SELECT to_char(start_time AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') || '+00' FROM public.events WHERE uuid = ?",
+            String::class.java,
+            id,
+        )!!
+
+    private fun exists(id: UUID): Boolean =
+        jdbcTemplate.queryForObject("SELECT count(*) FROM public.events WHERE uuid = ?", Long::class.java, id)!! > 0
+
+    private fun setSeason(start: String?, end: String?) {
+        jdbcTemplate.update(
+            "UPDATE public.team_settings SET season_start = ?::date, season_end = ?::date WHERE id = 1",
+            start,
+            end,
+        )
+    }
+
+    private fun resetSeason() = setSeason(null, null)
+
+    private fun seedTeamAndAdmin() {
+        tenantSchemaManager.provisionPlatformSchema()
+        tenantSchemaManager.provisionTenantSchema("public")
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, sport, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        seedMember(ADMIN_USER_ID, "series-admin@test.com", role = "ADMIN")
+    }
+
+    private fun seedMember(userId: String, email: String, role: String) {
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.users (id, email, display_name)
+            VALUES ('$userId'::uuid, '$email', '$email')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.execute("SELECT public.tb_add_member('$TEAM_ID'::uuid, '$userId'::uuid, '$role', 'Setter')")
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
@@ -140,7 +140,8 @@ class SeasonControllerIT : TeamBalanceIT() {
                     ADMIN_USER_ID,
                 )
                     .andExpect(MockMvcResultMatchers.status().isOk)
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Renamed but same date"))
+                    // UpdateEvent now returns an EventList of affected occurrences (ADR-0014 Phase 3).
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].title").value("Renamed but same date"))
             } finally {
                 resetSeason()
             }

--- a/app/src/entities/event/lib/series-affected.test.ts
+++ b/app/src/entities/event/lib/series-affected.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import type { Event } from '@shared/api/events'
+import { buildAffectedPreview } from './series-affected'
+
+const event = (id: string, startTime: string): Event => ({
+  id,
+  eventType: { id: 'et-1', name: 'Training', color: '#225C9C' },
+  title: 'Training',
+  description: undefined,
+  startTime,
+  endTime: startTime,
+  location: undefined,
+  references: [],
+  recurringGroup: 'group-1',
+  attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
+})
+
+// Four occurrences, deliberately out of order to prove chronological sorting.
+const siblings = [
+  event('c', '2026-09-15T18:30:00Z'),
+  event('a', '2026-09-01T18:30:00Z'),
+  event('d', '2026-09-22T18:30:00Z'),
+  event('b', '2026-09-08T18:30:00Z'),
+]
+
+describe('buildAffectedPreview', () => {
+  it('returns null when the current occurrence is not among the siblings', () => {
+    expect(buildAffectedPreview(siblings, 'missing', 'ALL')).toBeNull()
+  })
+
+  it('orders occurrences chronologically and flags the current one', () => {
+    const preview = buildAffectedPreview(siblings, 'b', 'THIS')!
+    expect(preview.nodes.map((n) => n.id)).toEqual(['a', 'b', 'c', 'd'])
+    expect(preview.nodes.filter((n) => n.isCurrent).map((n) => n.id)).toEqual(['b'])
+  })
+
+  it('THIS affects only the current occurrence', () => {
+    const preview = buildAffectedPreview(siblings, 'b', 'THIS')!
+    expect(preview.affectedCount).toBe(1)
+    expect(preview.total).toBe(4)
+    expect(preview.nodes.filter((n) => n.affected).map((n) => n.id)).toEqual(['b'])
+  })
+
+  it('THIS_AND_FOLLOWING affects the current occurrence and every later one', () => {
+    const preview = buildAffectedPreview(siblings, 'b', 'THIS_AND_FOLLOWING')!
+    expect(preview.affectedCount).toBe(3)
+    expect(preview.nodes.filter((n) => n.affected).map((n) => n.id)).toEqual(['b', 'c', 'd'])
+    // The earlier occurrence is untouched.
+    expect(preview.nodes.find((n) => n.id === 'a')!.affected).toBe(false)
+  })
+
+  it('ALL affects every occurrence regardless of which one is current', () => {
+    const preview = buildAffectedPreview(siblings, 'c', 'ALL')!
+    expect(preview.affectedCount).toBe(4)
+    expect(preview.nodes.every((n) => n.affected)).toBe(true)
+  })
+
+  it('THIS_AND_FOLLOWING on the last occurrence affects only it', () => {
+    const preview = buildAffectedPreview(siblings, 'd', 'THIS_AND_FOLLOWING')!
+    expect(preview.affectedCount).toBe(1)
+    expect(preview.nodes.filter((n) => n.affected).map((n) => n.id)).toEqual(['d'])
+  })
+
+  it('a single-occurrence series is fully affected by any scope', () => {
+    const one = [event('solo', '2026-09-01T18:30:00Z')]
+    for (const scope of ['THIS', 'THIS_AND_FOLLOWING', 'ALL'] as const) {
+      const preview = buildAffectedPreview(one, 'solo', scope)!
+      expect(preview.affectedCount).toBe(1)
+      expect(preview.total).toBe(1)
+    }
+  })
+})

--- a/app/src/entities/event/lib/series-affected.ts
+++ b/app/src/entities/event/lib/series-affected.ts
@@ -1,0 +1,57 @@
+import type { Event, EventSeriesScope } from '@shared/api/events'
+
+export interface AffectedNode {
+  id: string
+  startTime: string
+  /** True when a scoped edit/delete reaches this occurrence. */
+  affected: boolean
+  /** True for the occurrence the action was opened on. */
+  isCurrent: boolean
+}
+
+export interface AffectedPreview {
+  scope: EventSeriesScope
+  /** The whole series in chronological order, each flagged affected / current. */
+  nodes: AffectedNode[]
+  affectedCount: number
+  total: number
+}
+
+// The inclusive [lo, hi] index range a scope reaches, mirroring the backend split matrix
+// (ADR-0014): THIS is the single occurrence, THIS_AND_FOLLOWING runs to the end, ALL is everything.
+function affectedRange(scope: EventSeriesScope, currentIndex: number, total: number): [number, number] {
+  switch (scope) {
+    case 'THIS':
+      return [currentIndex, currentIndex]
+    case 'THIS_AND_FOLLOWING':
+      return [currentIndex, total - 1]
+    case 'ALL':
+      return [0, total - 1]
+  }
+}
+
+/**
+ * Builds the before│this│after affected-preview for a scoped series edit/delete (ADR-0014,
+ * prototype B). Pure: sorts [siblings] chronologically, marks which occurrences a [scope] reaches
+ * relative to [currentId], and counts them ("Affects N of M"). Returns null when the current
+ * occurrence is not among the siblings (nothing to preview).
+ */
+export function buildAffectedPreview(
+  siblings: Event[],
+  currentId: string,
+  scope: EventSeriesScope,
+): AffectedPreview | null {
+  const sorted = [...siblings].sort((a, b) => a.startTime.localeCompare(b.startTime))
+  const currentIndex = sorted.findIndex((e) => e.id === currentId)
+  if (currentIndex === -1) return null
+
+  const [lo, hi] = affectedRange(scope, currentIndex, sorted.length)
+  const nodes: AffectedNode[] = sorted.map((e, i) => ({
+    id: e.id,
+    startTime: e.startTime,
+    affected: i >= lo && i <= hi,
+    isCurrent: i === currentIndex,
+  }))
+
+  return { scope, nodes, affectedCount: hi - lo + 1, total: sorted.length }
+}

--- a/app/src/features/edit-event/ui/DeleteEventDialog.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialog.tsx
@@ -10,28 +10,35 @@ import {
   DialogTitle,
 } from '@shared/ui/dialog'
 import { Button } from '@shared/ui/button'
-import { useDeleteEvent } from '@shared/api/events'
+import { useDeleteEvent, type Event, type EventSeriesScope } from '@shared/api/events'
+import { SeriesScopeField } from './SeriesScopeField'
 
 interface DeleteEventDialogProps {
   eventId: string
   title: string
-  /** True when the event is one occurrence of a series — clarifies that only this one is removed. */
-  partOfSeries?: boolean
+  /** Every occurrence sharing this event's recurring group. A single-element (or empty) list is standalone. */
+  siblings?: Event[]
 }
 
 /**
- * Single-event delete (ADR-0014 Phase 2, "This event" scope only). A recurring occurrence is
- * deleted like any standalone event and never splits the series (Decision 4); bulk delete is Phase 3.
- * On success it navigates back to the event list, since the detail route no longer exists.
+ * Delete one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no
+ * siblings) deletes itself with the default THIS scope and no prompt. For a series, the
+ * SeriesScopeField drives which occurrences go — and a delete **never splits** (survivors keep
+ * their group). On success it navigates back to the event list, since the detail route may be gone.
  */
-export function DeleteEventDialog({ eventId, title, partOfSeries = false }: DeleteEventDialogProps) {
+export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEventDialogProps) {
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
   const deleteEvent = useDeleteEvent()
 
+  const isSeries = siblings.length > 1
+  const [scope, setScope] = useState<EventSeriesScope>('THIS')
+
   const handleDelete = () => {
-    deleteEvent.mutate(eventId, { onSuccess: () => navigate({ to: '/' }) })
+    deleteEvent.mutate({ id: eventId, scope }, { onSuccess: () => navigate({ to: '/' }) })
   }
+
+  const confirmLabel = deleteEvent.isPending ? 'Deleting…' : isSeries && scope !== 'THIS' ? 'Delete events' : 'Delete event'
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -45,12 +52,20 @@ export function DeleteEventDialog({ eventId, title, partOfSeries = false }: Dele
       </Button>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete this event?</DialogTitle>
+          <DialogTitle>{isSeries ? 'Delete from series?' : 'Delete this event?'}</DialogTitle>
           <DialogDescription>
             {title} will be removed for everyone, along with its attendance.
-            {partOfSeries && ' Only this occurrence is deleted — the rest of the series stays.'}
           </DialogDescription>
         </DialogHeader>
+        {isSeries && (
+          <SeriesScopeField
+            siblings={siblings}
+            currentId={eventId}
+            scope={scope}
+            onScopeChange={setScope}
+            variant="delete"
+          />
+        )}
         {deleteEvent.isError && (
           <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
             Could not delete the event. Please try again.
@@ -60,12 +75,8 @@ export function DeleteEventDialog({ eventId, title, partOfSeries = false }: Dele
           <Button variant="outline" onClick={() => setOpen(false)} disabled={deleteEvent.isPending}>
             Cancel
           </Button>
-          <Button
-            variant="destructive"
-            onClick={handleDelete}
-            disabled={deleteEvent.isPending}
-          >
-            {deleteEvent.isPending ? 'Deleting…' : 'Delete event'}
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteEvent.isPending}>
+            {confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/src/features/edit-event/ui/EditEventDialog.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialog.tsx
@@ -5,13 +5,16 @@ import { Button } from '@shared/ui/button'
 import { Input } from '@shared/ui/input'
 import { Label } from '@shared/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shared/ui/select'
-import { useUpdateEvent, type EventDetail } from '@shared/api/events'
+import { useUpdateEvent, type Event, type EventDetail, type EventSeriesScope } from '@shared/api/events'
 import { useEventTypes } from '@shared/api/event-types'
 import { ReferenceRowsEditor } from '@entities/event/ui/ReferenceRowsEditor'
 import { cleanReferences, toReferenceRows, type ReferenceRow } from '@entities/event/lib/references'
+import { SeriesScopeField } from './SeriesScopeField'
 
 interface EditEventDialogProps {
   event: EventDetail
+  /** Every occurrence sharing this event's recurring group. A single-element (or empty) list is standalone. */
+  siblings?: Event[]
 }
 
 // ISO instant → the value a <input type="datetime-local"> expects ('YYYY-MM-DDTHH:mm' in local time).
@@ -21,17 +24,30 @@ function toLocalInput(iso: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
+// Swap the time-of-day into a 'YYYY-MM-DDTHH:mm' local string, keeping its date.
+function withTime(local: string, time: string): string {
+  return `${local.slice(0, 10)}T${time}`
+}
+
 /**
- * Single-event edit (ADR-0014 Phase 2, "This event" scope only — bulk/split scopes are Phase 3).
- * A recurring occurrence is edited exactly like any standalone event; the group is untouched.
+ * Edit one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no siblings)
+ * edits itself exactly as before — the scope prompt is hidden and the request carries the default
+ * THIS. For a series, the SeriesScopeField drives the scope; bulk scopes lock the per-occurrence
+ * date (only the time-of-day propagates), so the date input is swapped for a time-only input.
  */
-export function EditEventDialog({ event }: EditEventDialogProps) {
+export function EditEventDialog({ event, siblings = [] }: EditEventDialogProps) {
   const [open, setOpen] = useState(false)
   const { data: eventTypes } = useEventTypes()
   const updateEvent = useUpdateEvent()
 
+  const isSeries = siblings.length > 1
+  const [scope, setScope] = useState<EventSeriesScope>('THIS')
+  const dateLocked = isSeries && scope !== 'THIS'
+
   const [typeId, setTypeId] = useState(event.eventType.id)
   const [title, setTitle] = useState(event.title)
+  const [start, setStart] = useState(toLocalInput(event.startTime))
+  const [end, setEnd] = useState(toLocalInput(event.endTime))
   // Seed the editor from the event's existing links — updateEvent has replace-semantics, so the
   // full set must be sent back on every save or the links would be wiped.
   const [references, setReferences] = useState<ReferenceRow[]>(toReferenceRows(event.references))
@@ -42,11 +58,14 @@ export function EditEventDialog({ event }: EditEventDialogProps) {
     updateEvent.mutate(
       {
         id: event.id,
+        scope,
         eventTypeId: typeId,
         title,
         description: (form.get('description') as string) || undefined,
-        startTime: new Date(form.get('startTime') as string).toISOString(),
-        endTime: new Date(form.get('endTime') as string).toISOString(),
+        // For a bulk scope the date is locked to the occurrence's own date; only the time-of-day
+        // (and duration) matters — the backend re-anchors each occurrence to its own date.
+        startTime: new Date(start).toISOString(),
+        endTime: new Date(end).toISOString(),
         location: (form.get('location') as string) || undefined,
         references: cleanReferences(references),
       },
@@ -67,6 +86,15 @@ export function EditEventDialog({ event }: EditEventDialogProps) {
           <DialogTitle>Edit event</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {isSeries && (
+            <SeriesScopeField
+              siblings={siblings}
+              currentId={event.id}
+              scope={scope}
+              onScopeChange={setScope}
+              variant="edit"
+            />
+          )}
           <div>
             <Label htmlFor="edit-type">Type</Label>
             <Select value={typeId} onValueChange={setTypeId}>
@@ -89,14 +117,53 @@ export function EditEventDialog({ event }: EditEventDialogProps) {
             <Label htmlFor="edit-title">Title</Label>
             <Input id="edit-title" required value={title} onChange={(e) => setTitle(e.target.value)} />
           </div>
-          <div>
-            <Label htmlFor="edit-start">Start time</Label>
-            <Input id="edit-start" name="startTime" type="datetime-local" required defaultValue={toLocalInput(event.startTime)} />
-          </div>
-          <div>
-            <Label htmlFor="edit-end">End time</Label>
-            <Input id="edit-end" name="endTime" type="datetime-local" required defaultValue={toLocalInput(event.endTime)} />
-          </div>
+          {dateLocked ? (
+            <>
+              <div>
+                <Label htmlFor="edit-start-time">Start time</Label>
+                <Input
+                  id="edit-start-time"
+                  type="time"
+                  required
+                  value={start.slice(11, 16)}
+                  onChange={(e) => setStart((s) => withTime(s, e.target.value))}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-end-time">End time</Label>
+                <Input
+                  id="edit-end-time"
+                  type="time"
+                  required
+                  value={end.slice(11, 16)}
+                  onChange={(e) => setEnd((s) => withTime(s, e.target.value))}
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <div>
+                <Label htmlFor="edit-start">Start time</Label>
+                <Input
+                  id="edit-start"
+                  type="datetime-local"
+                  required
+                  value={start}
+                  onChange={(e) => setStart(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-end">End time</Label>
+                <Input
+                  id="edit-end"
+                  type="datetime-local"
+                  required
+                  value={end}
+                  onChange={(e) => setEnd(e.target.value)}
+                />
+              </div>
+            </>
+          )}
           <div>
             <Label htmlFor="edit-location">Location (optional)</Label>
             <Input id="edit-location" name="location" defaultValue={event.location ?? ''} />

--- a/app/src/features/edit-event/ui/SeriesScopeField.stories.tsx
+++ b/app/src/features/edit-event/ui/SeriesScopeField.stories.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import type { Event, EventSeriesScope } from '@shared/api/events'
+import { makeEvent } from '@shared/testing/event-fixtures'
+import { SeriesScopeField } from './SeriesScopeField'
+
+// Four weekly occurrences sharing a group; the 2nd ('b') is the one being edited/deleted.
+const SIBLINGS: Event[] = [
+  makeEvent({ id: 'a', startTime: '2026-09-01T18:30:00Z', recurringGroup: 'g1' }),
+  makeEvent({ id: 'b', startTime: '2026-09-08T18:30:00Z', recurringGroup: 'g1' }),
+  makeEvent({ id: 'c', startTime: '2026-09-15T18:30:00Z', recurringGroup: 'g1' }),
+  makeEvent({ id: 'd', startTime: '2026-09-22T18:30:00Z', recurringGroup: 'g1' }),
+]
+
+// Stateful harness: `scope` is owned by the parent dialog in production, so the story holds it to
+// make the segmented control interactive. The story's args drive the variant + starting scope.
+function Harness({ variant, initialScope }: { variant: 'edit' | 'delete'; initialScope: EventSeriesScope }) {
+  const [scope, setScope] = useState<EventSeriesScope>(initialScope)
+  return (
+    <div className="max-w-md">
+      <SeriesScopeField siblings={SIBLINGS} currentId="b" scope={scope} onScopeChange={setScope} variant={variant} />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'features/edit-event/SeriesScopeField',
+  component: Harness,
+} satisfies Meta<typeof Harness>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const EditThis: Story = {
+  args: { variant: 'edit', initialScope: 'THIS' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Affects 1 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'This event' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(canvas.getByText(/Splits the series into three/)).toBeInTheDocument()
+    // THIS keeps the date free, so no lock note.
+    await expect(canvas.queryByText(/keeps its own date/)).not.toBeInTheDocument()
+  },
+}
+
+export const EditThisAndFollowing: Story = {
+  args: { variant: 'edit', initialScope: 'THIS' },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'This & following' }))
+    await expect(canvas.getByText('Affects 3 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'This & following' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(canvas.getByText(/Splits the series in two/)).toBeInTheDocument()
+    // A bulk scope locks the per-occurrence date.
+    await expect(canvas.getByText(/keeps its own date/)).toBeInTheDocument()
+  },
+}
+
+export const EditAll: Story = {
+  args: { variant: 'edit', initialScope: 'ALL' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Affects 4 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'All events' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(canvas.getByText(/No split/)).toBeInTheDocument()
+    await expect(canvas.getByText(/keeps its own date/)).toBeInTheDocument()
+  },
+}
+
+export const DeleteThis: Story = {
+  args: { variant: 'delete', initialScope: 'THIS' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Removes 1 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByText(/Removes just this occurrence/)).toBeInTheDocument()
+    // Delete never locks a date — that note is edit-only.
+    await expect(canvas.queryByText(/keeps its own date/)).not.toBeInTheDocument()
+  },
+}
+
+export const DeleteThisAndFollowing: Story = {
+  args: { variant: 'delete', initialScope: 'THIS' },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'This & following' }))
+    await expect(canvas.getByText('Removes 3 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByText(/every later one/)).toBeInTheDocument()
+  },
+}
+
+export const DeleteAll: Story = {
+  args: { variant: 'delete', initialScope: 'ALL' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Removes 4 of 4 events')).toBeInTheDocument()
+    await expect(canvas.getByText(/Removes the entire series/)).toBeInTheDocument()
+  },
+}

--- a/app/src/features/edit-event/ui/SeriesScopeField.tsx
+++ b/app/src/features/edit-event/ui/SeriesScopeField.tsx
@@ -1,0 +1,149 @@
+import { Lock, Split } from 'lucide-react'
+import type { Event, EventSeriesScope } from '@shared/api/events'
+import { buildAffectedPreview } from '@entities/event/lib/series-affected'
+
+interface SeriesScopeFieldProps {
+  /** Every occurrence sharing the current event's recurring group (any order). */
+  siblings: Event[]
+  currentId: string
+  scope: EventSeriesScope
+  onScopeChange: (scope: EventSeriesScope) => void
+  /** 'edit' shows the accent/date-lock treatment; 'delete' shows the removed/kept treatment. */
+  variant?: 'edit' | 'delete'
+}
+
+const SCOPES: { value: EventSeriesScope; label: string }[] = [
+  { value: 'THIS', label: 'This event' },
+  { value: 'THIS_AND_FOLLOWING', label: 'This & following' },
+  { value: 'ALL', label: 'All events' },
+]
+
+// Plain-language split semantics per scope — accurate to the backend (a delete never splits).
+const EDIT_CAPTION: Record<EventSeriesScope, string> = {
+  THIS: 'Splits the series into three: everything before, this one on its own (its date can move), and everything after — each independent.',
+  THIS_AND_FOLLOWING:
+    'Splits the series in two: occurrences before stay as they are; this one and every later one become a new series with the edited details.',
+  ALL: 'No split — the edit applies to every occurrence in the one series.',
+}
+
+const DELETE_CAPTION: Record<EventSeriesScope, string> = {
+  THIS: 'Removes just this occurrence; the rest of the series stays.',
+  THIS_AND_FOLLOWING: 'Removes this occurrence and every later one; the earlier ones stay as a shorter series.',
+  ALL: 'Removes the entire series.',
+}
+
+function formatOccurrence(iso: string): string {
+  return new Date(iso).toLocaleDateString('nl-NL', { day: 'numeric', month: 'short' })
+}
+
+/**
+ * The scope selector + live affected-preview shown when editing or deleting one occurrence of a
+ * recurring series (ADR-0014, Phase 3 — the guided scope prompt from prototype A over prototype B's
+ * before│this│after timeline). Presentational: `scope` and its setter are owned by the dialog, so
+ * every state is a plain render arg. Standalone events don't render this at all.
+ */
+export function SeriesScopeField({
+  siblings,
+  currentId,
+  scope,
+  onScopeChange,
+  variant = 'edit',
+}: SeriesScopeFieldProps) {
+  const preview = buildAffectedPreview(siblings, currentId, scope)
+  if (!preview) return null
+
+  const danger = variant === 'delete'
+  const verb = danger ? 'Removes' : 'Affects'
+  const caption = danger ? DELETE_CAPTION[scope] : EDIT_CAPTION[scope]
+  // Full literal classes — Tailwind can't see interpolated names.
+  const panelClass = danger ? 'border-red-500/20 bg-red-500/5' : 'border-blue/20 bg-blue/5'
+  const countClass = danger ? 'text-red-500' : 'text-blue'
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <p className="mb-1.5 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          {danger ? 'Delete' : 'Apply to'}
+        </p>
+        {/* Segmented scope control — exactly one is pressed. */}
+        <div role="group" aria-label="Scope" className="flex gap-1.5">
+          {SCOPES.map(({ value, label }) => {
+            const active = scope === value
+            return (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={active}
+                onClick={() => onScopeChange(value)}
+                className={[
+                  'flex-1 rounded-lg border px-2 py-2 text-xs font-semibold transition-colors',
+                  active
+                    ? danger
+                      ? 'border-red-500 bg-red-500 text-white'
+                      : 'border-blue bg-blue text-white'
+                    : 'border-border text-muted-foreground hover:bg-muted/60',
+                ].join(' ')}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Affected panel: count + before│this│after timeline + split caption. */}
+      <div className={`rounded-xl border p-3 ${panelClass}`}>
+        <p className={`text-sm font-bold ${countClass}`}>
+          {verb} {preview.affectedCount} of {preview.total} event{preview.total === 1 ? '' : 's'}
+        </p>
+
+        <AffectedTimeline preview={preview} danger={danger} />
+
+        <p className="mt-2.5 flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Split size={13} className="mt-0.5 shrink-0" />
+          <span>{caption}</span>
+        </p>
+      </div>
+
+      {/* Bulk edit locks the per-occurrence date — a changed time still propagates. */}
+      {!danger && scope !== 'THIS' && (
+        <p className="flex items-start gap-1.5 rounded-lg bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+          <Lock size={13} className="mt-0.5 shrink-0" />
+          <span>Each occurrence keeps its own date; the time &amp; details apply to all affected events.</span>
+        </p>
+      )}
+    </div>
+  )
+}
+
+function AffectedTimeline({
+  preview,
+  danger,
+}: {
+  preview: NonNullable<ReturnType<typeof buildAffectedPreview>>
+  danger: boolean
+}) {
+  const hit = danger ? 'bg-red-500' : 'bg-blue'
+  return (
+    <div className="mt-2 flex items-center gap-1" aria-hidden="true">
+      {preview.nodes.map((node, i) => {
+        // A split marker sits where affected and unaffected occurrences meet (edit's visual split).
+        const prev = preview.nodes[i - 1]
+        const boundary = prev && prev.affected !== node.affected
+        return (
+          <div key={node.id} className="flex items-center gap-1">
+            {boundary && <span className="h-4 w-px shrink-0 bg-border" data-testid="split-marker" />}
+            <span
+              title={formatOccurrence(node.startTime)}
+              className={[
+                'h-2.5 w-2.5 rounded-full transition-colors',
+                node.affected ? hit : 'bg-border',
+                node.isCurrent ? (danger ? 'ring-2 ring-red-500/40' : 'ring-2 ring-blue/40') : '',
+              ].join(' ')}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -216,11 +216,11 @@ function EventDetailPage() {
       {/* Part of a series peek */}
       {seriesPeek && <SeriesPeek peek={seriesPeek} />}
 
-      {/* Admin Actions — single-event ("This event") edit/delete; bulk scopes are Phase 3 */}
+      {/* Admin Actions — scoped series edit/delete (ADR-0014 Phase 3); standalone events skip the prompt */}
       {isAdmin && (
         <div className="mt-6 flex gap-2.5 border-t border-border/40 pt-5">
-          <EditEventDialog event={event} />
-          <DeleteEventDialog eventId={event.id} title={event.title} partOfSeries={!!event.recurringGroup} />
+          <EditEventDialog event={event} siblings={siblings} />
+          <DeleteEventDialog eventId={event.id} title={event.title} siblings={siblings} />
         </div>
       )}
     </div>

--- a/app/src/shared/api/events.ts
+++ b/app/src/shared/api/events.ts
@@ -11,8 +11,10 @@ export type { AttendanceSummary } from './generated/model/AttendanceSummary'
 export type { RoleCount } from './generated/model/RoleCount'
 export type { EventTypeSummary } from './generated/model/EventTypeSummary'
 export type { EventReference } from './generated/model/EventReference'
+export type { EventSeriesScope } from './generated/model/EventSeriesScope'
 
 import type { EventReference } from './generated/model/EventReference'
+import type { EventSeriesScope } from './generated/model/EventSeriesScope'
 
 export interface EventInput {
   eventTypeId: string
@@ -58,11 +60,13 @@ export function useCreateEvent() {
   })
 }
 
+// A scoped edit touches many rows (ADR-0014 Phase 3), so the response is an EventList of the
+// affected occurrences. `scope` defaults to THIS — a standalone event or a single-occurrence edit.
 export function useUpdateEvent() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ id, ...event }: EventInput & { id: string }) => {
-      const res = await api.UpdateEvent({ id, body: event as UpdateEventRequest })
+    mutationFn: async ({ id, scope = 'THIS', ...event }: EventInput & { id: string; scope?: EventSeriesScope }) => {
+      const res = await api.UpdateEvent({ id, scope, body: event as UpdateEventRequest })
       return res.body
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
@@ -72,7 +76,8 @@ export function useUpdateEvent() {
 export function useDeleteEvent() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) => api.DeleteEvent({ id }),
+    mutationFn: ({ id, scope = 'THIS' }: { id: string; scope?: EventSeriesScope }) =>
+      api.DeleteEvent({ id, scope }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
   })
 }

--- a/app/src/shared/api/wirespec-client.test.ts
+++ b/app/src/shared/api/wirespec-client.test.ts
@@ -110,7 +110,7 @@ describe('wirespec-client adapter', () => {
       const response = fakeResponse({ status: 204 })
       stubFetch(response)
 
-      const res = await api.DeleteEvent({ id: 'evt-1' })
+      const res = await api.DeleteEvent({ id: 'evt-1', scope: undefined })
 
       expect(res.status).toBe(204)
       // The adapter must short-circuit on 204 rather than trying to read/parse an absent body.


### PR DESCRIPTION
Implements **Phase 3** of recurring events (#111, sub-issue of #108) per **ADR-0014**: full `This / This-and-following / All` edit & delete over a materialized series, using the split model — there is no stored rule, so every scoped operation is **row-reassignment + field updates**.

## Scope matrix (ADR-0014, Decision 4)

**Edit** — `UpdateEvent PUT /api/events/{id}?scope=…`, success type is now **`EventList`** (a bulk edit touches many rows):

| Scope | Group reassignment | Fields |
|---|---|---|
| `THIS` (default) | target detaches (`group = null`); occurrences **after** → a new group; occurrences **before** kept | applied to the target only; its **date may move** |
| `THIS_AND_FOLLOWING` | before kept; target + following → a new group | applied to target + following (each keeps its own date) |
| `ALL` | group unchanged | applied to every occurrence (each keeps its own date) |

> Refinement: when the target is the **first** occurrence (nothing before it), `THIS_AND_FOLLOWING` keeps the existing group instead of minting a pointless new one — it's equivalent to `ALL`. A standalone (group-less) event therefore stays group-less under any scope.

**Delete** — `DeleteEvent DELETE /api/events/{id}?scope=…` removes the rows in scope and **never splits** (survivors keep their group untouched).

## Propagation rule

Bulk scopes (`THIS_AND_FOLLOWING` / `ALL`) propagate **every field except each occurrence's own calendar date** — a changed **time-of-day** re-anchors each occurrence on its own date (duration preserved); only `THIS` may move a single occurrence's date. Enforced server-side, not just in the UI.

## Season validation (Phase 1) still applies

Grandfathering holds: a start is validated only when it **actually moves**, so an `ALL` edit that changes only the title touches no start and is never rejected, while a time-of-day change on an out-of-window series is rejected `422`.

## Changes

- **Wirespec**: `EventSeriesScope = THIS | THIS_AND_FOLLOWING | ALL` (optional query param, defaults `THIS`) on `UpdateEvent` + `DeleteEvent`; `UpdateEvent` success → `EventList`. `make wirespec` regenerated (generated sources are gitignored).
- **Backend**: pure `SeriesModification.planEdit/planDelete` (domain, clock-free, exhaustively unit-testable) computes the split matrix; `EventService` applies it transactionally with season grandfathering; `EventRepository.findByRecurringGroup` added; controller maps the scope + returns the affected `EventList`.
- **Frontend**: on a **series** event, Edit/Delete present a scope selector over a live **before│this│after** affected-preview with an "Affects N of M" count and split markers; **standalone** events skip the prompt. Bulk-scope edits lock the per-occurrence date (with an "each keeps its own date" note). `useUpdateEvent` consumes the `EventList` response; both mutations carry a `scope`.

## Tests

- **Kotest (pure)** `SeriesModificationTest` — the full matrix: detach + new-group-after (THIS), before-kept + new-group-for-tail (FOLLOWING), whole-group (ALL); bulk propagation changes all-but-date; time-of-day propagation; delete surviving sets & never-splits; first/middle/last occurrences; standalone.
- **Testcontainers IT** `EventSeriesControllerIT` — the exact row/group DB outcome of each edit & delete scope, date-preservation vs time-propagation, season grandfathering (allowed) and time-move rejection (`422`), admin gate, 404.
- **Vitest** `buildAffectedPreview` — the affected-range/count logic; existing `UpdateEvent`-response tests updated to the `EventList` shape.
- **Vitest + Storybook** `SeriesScopeField` — selector + affected-preview + date-lock states.

## No new e2e

No new auth / cross-tenant / external seam is introduced (the admin gate and event write path already exist), so per the PR gate **no e2e flow is added**. Coverage sits at the lowest layer that proves it (pure units + Testcontainers IT + stories).

Closes #111.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147BW3MLSpnnPc3mNH3D3LU


https://github.com/user-attachments/assets/23876842-75ce-47b8-ac3c-277898ba0877




---
_Generated by [Claude Code](https://claude.ai/code/session_0147BW3MLSpnnPc3mNH3D3LU)_