### PR TITLE
refactor: concentrate season validation into a SeasonPolicy domain module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,13 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   When set, Event writes with a start outside the window are rejected (unchanged starts
   grandfathered); narrowing the window only warns about existing events. Supplies default
   dates to recurring creation ([ADR-0014](docs/adr/0014-recurring-events-materialized-batch-split-season.md)).
+- **Season Policy** — The rule for *which* Event starts must fall inside the **Season** and
+  *when* it is enforced: a single create checks its new start; a recurring batch checks every
+  generated start and is rejected whole on the first offender (nothing is written); a scoped
+  edit checks only the occurrences whose start actually *moves*, **grandfathering** unchanged
+  starts — so a title-only *all* edit is never rejected and an occurrence already outside a
+  narrowed window stays editable. An unconfigured Season permits everything
+  ([ADR-0014](docs/adr/0014-recurring-events-materialized-batch-split-season.md)).
 - **Attendance** — A Member's response to an Event. One of four **Attendance States**.
 - **Attendance State** — `Attending` (green), `Maybe` (gold), `Absent` (red),
   `Not Responded` (default, no response yet). The semantic colors are fixed brand

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -1,7 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.EmptyRecurrenceException
-import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonException
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.exception.RecurrenceExceedsCapException
 import com.github.zzave.teambalance.api.domain.model.Event
@@ -10,6 +9,7 @@ import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.OccurrenceSchedule
 import com.github.zzave.teambalance.api.domain.model.Recurrence
+import com.github.zzave.teambalance.api.domain.model.SeasonPolicy
 import com.github.zzave.teambalance.api.domain.model.SeriesModification
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
@@ -57,7 +57,7 @@ class EventService(
             ?: throw EventTypeNotFoundException(potential.eventTypeId)
 
         // ADR-0014: a created event's start must always fall within the configured season.
-        requireWithinSeason(potential.startTime)
+        seasonPolicy().requireCreatable(potential.startTime)
 
         return eventRepository.save(
             Event(
@@ -107,7 +107,7 @@ class EventService(
             ?: throw EventTypeNotFoundException(eventTypeId)
 
         val dates = generateBoundedDates(recurrence)
-        requireAllWithinSeason(dates)
+        seasonPolicy().requireAllCreatable(dates)
 
         val recurringGroup = UUID.randomUUID()
 
@@ -141,13 +141,6 @@ class EventService(
             throw RecurrenceExceedsCapException(Recurrence.MAX_OCCURRENCES)
         }
         return dates
-    }
-
-    // Rejects the whole batch up front if any generated start falls outside the configured season,
-    // so no row is written when even one occurrence is out of window.
-    private fun requireAllWithinSeason(dates: List<LocalDate>) {
-        val season = seasonRepository.get()
-        dates.firstOrNull { !season.allows(it) }?.let { throw EventOutsideSeasonException(it) }
     }
 
     /**
@@ -199,9 +192,7 @@ class EventService(
         )
 
         val originalStarts = series.associate { it.id to it.startTime }
-        plan.toPersist.forEach { updated ->
-            if (updated.startTime != originalStarts[updated.id]) requireWithinSeason(updated.startTime)
-        }
+        seasonPolicy().requireEditable(plan, originalStarts)
 
         plan.toPersist.forEach { eventRepository.save(it) }
         return plan.edited.sortedBy { it.startTime }
@@ -224,11 +215,8 @@ class EventService(
     private fun seriesOf(event: Event): List<Event> =
         event.recurringGroup?.let { eventRepository.findByRecurringGroup(it) } ?: listOf(event)
 
-    // Rejects a start that falls outside the configured season. The instant is resolved to a calendar
-    // date in the team's civil zone (the clock's zone) so the comparison matches how humans read the
-    // date. An unconfigured season (both bounds null) allows everything.
-    private fun requireWithinSeason(startTime: Instant) {
-        val startDate = startTime.atZone(clock.zone).toLocalDate()
-        if (!seasonRepository.get().allows(startDate)) throw EventOutsideSeasonException(startDate)
-    }
+    // The season rule for the current tenant, resolved for this write: which starts must fall within
+    // the window (and the grandfathering of unchanged ones) is SeasonPolicy's job — Season.allows is
+    // the predicate underneath, resolved against the team's civil zone (the clock's zone).
+    private fun seasonPolicy(): SeasonPolicy = SeasonPolicy(seasonRepository.get(), clock.zone)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicy.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicy.kt
@@ -1,0 +1,55 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonException
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+
+/**
+ * Owns "what to check, and when" for the season bound (ADR-0014): every event write whose start
+ * falls outside the configured [season] is hard-rejected. *Which* starts must be checked is the
+ * domain knowledge this module concentrates — it differs by write shape:
+ *
+ *  - a **create** checks its single new start;
+ *  - a **recurring batch** checks every generated date, throwing on the first offender so the
+ *    caller writes nothing when even one occurrence is out of window;
+ *  - a **scoped edit** (ADR-0014, Decision 4) checks only the occurrences whose start actually
+ *    *moved* from its pre-edit value, **grandfathering** unchanged starts — so a title-only ALL
+ *    edit moves nothing and is never rejected, and an occurrence already outside a shrunk window
+ *    stays editable as long as the edit doesn't move it.
+ *
+ * [Season.allows] is the predicate underneath; this policy decides which dates to feed it. Pure and
+ * clock-free — the caller supplies the civil [zone] used to resolve an [Instant] to the calendar
+ * date humans read. An unconfigured season (both bounds null) allows everything.
+ */
+class SeasonPolicy(
+    private val season: Season,
+    private val zone: ZoneId,
+) {
+    /** A single created event: its start must fall within the season. */
+    fun requireCreatable(start: Instant) = requireWithinSeason(start.toSeasonDate())
+
+    /**
+     * A recurring batch: every generated date must fall within the season. Throws on the first
+     * offending date, so a caller that validates before persisting writes no rows when even one
+     * occurrence is out of window.
+     */
+    fun requireAllCreatable(dates: List<LocalDate>) = dates.forEach { requireWithinSeason(it) }
+
+    /**
+     * A scoped edit: of the rows in [plan] to be persisted, only those whose start differs from its
+     * pre-edit value in [originalStarts] are checked. An unchanged start is grandfathered (a row
+     * absent from [originalStarts] counts as moved and is checked).
+     */
+    fun requireEditable(plan: SeriesEditPlan, originalStarts: Map<UUID, Instant>) =
+        plan.toPersist
+            .filter { it.startTime != originalStarts[it.id] }
+            .forEach { requireWithinSeason(it.startTime.toSeasonDate()) }
+
+    private fun requireWithinSeason(date: LocalDate) {
+        if (!season.allows(date)) throw EventOutsideSeasonException(date)
+    }
+
+    private fun Instant.toSeasonDate(): LocalDate = atZone(zone).toLocalDate()
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicyTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicyTest.kt
@@ -1,0 +1,156 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.UUID
+
+/**
+ * Pure "what to check, and when" logic for the season bound (ADR-0014). No Spring, no DB, no clock —
+ * the lowest layer that proves each write shape checks the right starts: a create checks its single
+ * new start; a recurring batch checks every generated date (first-offender); a scoped edit checks
+ * only the occurrences whose start actually MOVED, grandfathering the rest. [Season.allows] is the
+ * predicate underneath; these tests pin which dates the policy feeds it.
+ */
+class SeasonPolicyTest : FunSpec({
+
+    val zone = ZoneId.of("Europe/Amsterdam")
+    val training = EventType(id = UUID.randomUUID(), name = "Training", color = "#123456")
+
+    // A configured autumn window: 2026-09-01 .. 2026-09-30 inclusive.
+    val season = Season(start = LocalDate.of(2026, 9, 1), end = LocalDate.of(2026, 9, 30))
+    val policy = SeasonPolicy(season, zone)
+
+    // A start at 20:30 local on the given date (the civil time humans read).
+    fun startOn(date: String): Instant =
+        LocalDate.parse(date).atTime(LocalTime.of(20, 30)).atZone(zone).toInstant()
+
+    fun event(id: UUID, start: Instant, group: UUID? = null): Event =
+        Event(
+            id = id,
+            eventType = training,
+            title = "Weekly Training",
+            description = null,
+            startTime = start,
+            endTime = start.plus(Duration.ofMinutes(90)),
+            location = "Gym",
+            references = emptyList(),
+            recurringGroup = group,
+            createdBy = UUID.randomUUID(),
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+
+    // ── CREATE (single new start) ────────────────────────────────────────────
+
+    test("requireCreatable allows a start inside the window") {
+        shouldNotThrowAny { policy.requireCreatable(startOn("2026-09-15")) }
+    }
+
+    test("requireCreatable rejects a start outside the window with the offending date") {
+        val ex = shouldThrow<EventOutsideSeasonException> { policy.requireCreatable(startOn("2026-10-01")) }
+        ex.message shouldBe "Event start 2026-10-01 falls outside the configured season"
+    }
+
+    // ── BATCH CREATE (every generated date) ──────────────────────────────────
+
+    test("requireAllCreatable allows a batch entirely inside the window") {
+        shouldNotThrowAny {
+            policy.requireAllCreatable(listOf(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 8), LocalDate.of(2026, 9, 30)))
+        }
+    }
+
+    test("requireAllCreatable rejects the batch on the FIRST out-of-window date (so no row is written)") {
+        // Two dates are out of window; the exception must name the first offender, not the last.
+        val ex = shouldThrow<EventOutsideSeasonException> {
+            policy.requireAllCreatable(
+                listOf(LocalDate.of(2026, 9, 8), LocalDate.of(2026, 10, 1), LocalDate.of(2026, 10, 8)),
+            )
+        }
+        ex.message shouldBe "Event start 2026-10-01 falls outside the configured season"
+    }
+
+    // ── SCOPED EDIT (only moved starts; grandfather the rest) ─────────────────
+
+    test("requireEditable grandfathers an ALL title-only edit: no start moves, so nothing is checked") {
+        // A whole series sitting OUTSIDE a shrunk window, edited without moving any start.
+        val out1 = event(UUID.randomUUID(), startOn("2026-10-06"))
+        val out2 = event(UUID.randomUUID(), startOn("2026-10-13"))
+        val originalStarts = mapOf(out1.id to out1.startTime, out2.id to out2.startTime)
+        // toPersist carries the same starts (only the title changed upstream) — grandfathered.
+        val plan = SeriesEditPlan(edited = listOf(out1, out2), regrouped = emptyList())
+
+        shouldNotThrowAny { policy.requireEditable(plan, originalStarts) }
+    }
+
+    test("requireEditable rejects an occurrence whose start MOVED outside the window") {
+        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val originalStarts = mapOf(original.id to original.startTime)
+        // The edit moved this occurrence's start out of the window.
+        val moved = original.copy(startTime = startOn("2026-10-15"))
+        val plan = SeriesEditPlan(edited = listOf(moved), regrouped = emptyList())
+
+        val ex = shouldThrow<EventOutsideSeasonException> { policy.requireEditable(plan, originalStarts) }
+        ex.message shouldBe "Event start 2026-10-15 falls outside the configured season"
+    }
+
+    test("requireEditable checks moved starts but grandfathers unchanged ones in the same plan") {
+        // One occurrence keeps its (out-of-window) start; another moves, but moves to INSIDE the window.
+        val kept = event(UUID.randomUUID(), startOn("2026-10-06"))
+        val original = event(UUID.randomUUID(), startOn("2026-09-01"))
+        val originalStarts = mapOf(kept.id to kept.startTime, original.id to original.startTime)
+        val moved = original.copy(startTime = startOn("2026-09-20"))
+        val plan = SeriesEditPlan(edited = listOf(kept, moved), regrouped = emptyList())
+
+        // kept is out of window but unchanged (grandfathered); moved is inside — so nothing is rejected.
+        shouldNotThrowAny { policy.requireEditable(plan, originalStarts) }
+    }
+
+    test("requireEditable checks the regrouped tail's moved starts too, not just edited ones") {
+        // A regrouped tail row that was somehow moved out of window is still validated.
+        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val originalStarts = mapOf(original.id to original.startTime)
+        val movedTail = original.copy(startTime = startOn("2026-10-20"), recurringGroup = UUID.randomUUID())
+        val plan = SeriesEditPlan(edited = emptyList(), regrouped = listOf(movedTail))
+
+        val ex = shouldThrow<EventOutsideSeasonException> { policy.requireEditable(plan, originalStarts) }
+        ex.message shouldBe "Event start 2026-10-20 falls outside the configured season"
+    }
+
+    // ── UNCONFIGURED SEASON (both bounds null) allows everything ──────────────
+
+    test("an unconfigured season allows every create, batch, and moved edit") {
+        val unset = SeasonPolicy(Season.UNSET, zone)
+        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val moved = original.copy(startTime = startOn("1999-01-01"))
+
+        shouldNotThrowAny {
+            unset.requireCreatable(startOn("1999-01-01"))
+            unset.requireAllCreatable(listOf(LocalDate.of(1999, 1, 1), LocalDate.of(2999, 12, 31)))
+            unset.requireEditable(SeriesEditPlan(listOf(moved), emptyList()), mapOf(original.id to original.startTime))
+        }
+    }
+
+    // ── Instant → date resolution happens in the supplied civil zone ──────────
+
+    test("a start is resolved to a calendar date in the clock zone, not UTC") {
+        // 2026-09-30T23:00Z is 2026-10-01 01:00 in Amsterdam (summer, +02:00) — one day PAST the
+        // window end. Resolving in UTC would wrongly read 2026-09-30 (inside); the zone rejects it.
+        val ex = shouldThrow<EventOutsideSeasonException> {
+            policy.requireCreatable(Instant.parse("2026-09-30T23:00:00Z"))
+        }
+        ex.message shouldBe "Event start 2026-10-01 falls outside the configured season"
+    }
+
+    test("the zone can also pull a start INTO the window that UTC would exclude") {
+        // 2026-08-31T23:00Z is 2026-09-01 01:00 in Amsterdam — the first day of the window.
+        // In UTC it would read 2026-08-31 (before the start) and be rejected; the zone allows it.
+        shouldNotThrowAny { policy.requireCreatable(Instant.parse("2026-08-31T23:00:00Z")) }
+    }
+})


### PR DESCRIPTION
## What & why

The single rule — *"an event's start must fall inside the configured season window"* (ADR-0014) — was decided in three divergent shapes inside `EventService`, none owning it:

- `requireWithinSeason(Instant)` — single create + edit
- `requireAllWithinSeason(List<LocalDate>)` — batch create, first-offender
- an inline **grandfather loop** in `updateEvent` reaching back into `SeriesModification`'s plan

This introduces a **missing deep module** that concentrates *what to check and when*.

## The change

**New `domain/model/SeasonPolicy.kt`** — pure, framework-free, clock-free:

| Method | Owns |
|--------|------|
| `requireCreatable(start)` | a single new start |
| `requireAllCreatable(dates)` | every batch date; throws on the **first** offender (nothing written) |
| `requireEditable(plan, originalStarts)` | only occurrences whose start **moved**; grandfathers unchanged ones |

`Season.allows(date)` stays the predicate underneath. `EventService.createEvent` / `createRecurringEvents` / `updateEvent` now delegate through it, and **`updateEvent` returns to pure delegation** (load → `SeriesModification` → `SeasonPolicy` → persist). The two private guards and the inline loop are removed.

`CONTEXT.md` gains a **Season Policy** glossary term next to Season.

## Behaviour: unchanged (structure move only)

Pinned by existing ITs — `EventSeriesControllerIT` (grandfathering), `RecurringEventControllerTest` (whole-batch rejection), `SeasonControllerIT` — plus a new exhaustive pure Kotest suite `SeasonPolicyTest` (11 cases: create in/out of window, batch first-offender, ALL title-only grandfathering, moved-start-outside-shrunk-window rejection, mixed moved/unchanged, unconfigured season, Instant→date resolution in the clock zone).

Deliberately **out of scope**: `SeasonService.setSeason`'s `start ≤ end` guard (a window-construction invariant, not the start-within-window rule); the frontend `recurrence.ts` re-enforcement (separate workstream).

## Testing

- `./gradlew :api:test` → **240 tests, 0 failures**
- `./gradlew :api:detekt` → clean
- No new e2e: no new seam introduced — the season create/edit/batch paths are already exercised by the ITs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsuw1vSmXLEMJ8eFvhLadr