### PR TITLE
test: pin recurrence & split rules across the client/server seam

### DIFF
--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
@@ -1,0 +1,114 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+
+/**
+ * CROSS-SEAM CONTRACT for the two recurrence rules that live in both Kotlin and TypeScript and must
+ * stay in lockstep (ADR-0014): occurrence generation and the edit/delete split matrix. This spec and
+ * its frontend twins (`app/src/**/*.contract.test.ts`) read the SAME golden fixture
+ * (`contracts/recurrence-rules.golden.json`). If the Kotlin implementation drifts from the vectors,
+ * `make test-api` fails; if the TypeScript one drifts, `make test-app` fails — so the wizard's instant
+ * local preview can never silently disagree with the backend it mimics.
+ *
+ * The fixture is the single source of truth: it is NOT re-derived here. This spec only feeds each
+ * vector through the real domain logic and asserts the pinned result.
+ */
+class RecurrenceContractTest : FunSpec({
+
+    val fixture = loadGoldenFixture()
+
+    test("MAX_OCCURRENCES matches the shared contract cap") {
+        Recurrence.MAX_OCCURRENCES shouldBe fixture["maxOccurrences"].asInt()
+    }
+
+    context("occurrence generation matches the golden vectors") {
+        fixture["occurrences"].forEach { case ->
+            test(case["name"].asText()) {
+                val recurrence = Recurrence(
+                    frequency = RecurrenceFrequency.valueOf(case["frequency"].asText()),
+                    weekdays = case["weekdays"].map { DayOfWeek.valueOf(it.asText()) }.toSet(),
+                    startDate = LocalDate.parse(case["startDate"].asText()),
+                    endDate = LocalDate.parse(case["endDate"].asText()),
+                )
+                recurrence.occurrences().map { it.toString() } shouldBe case["expected"].map { it.asText() }
+            }
+        }
+    }
+
+    context("the edit/delete split matrix matches the golden vectors") {
+        fixture["splits"].forEach { case ->
+            val name = case["name"].asText()
+            val scope = EventSeriesScope.valueOf(case["scope"].asText())
+            // The fixture keys occurrences by stable string ids; map them to UUIDs deterministically
+            // so the backend Event model can carry them, then translate results back for comparison.
+            val idByUuid = case["series"].associate { uuidOf(it["id"].asText()) to it["id"].asText() }
+            val series = case["series"].map { event(it["id"].asText(), Instant.parse(it["startTime"].asText())) }
+            val currentId = uuidOf(case["currentId"].asText())
+            val expected = case["affectedIds"].map { it.asText() }
+
+            // A scoped DELETE's affected set is exactly the ids it removes.
+            test("$name — planDelete") {
+                SeriesModification.planDelete(series, currentId, scope)
+                    .map { idByUuid.getValue(it) } shouldBe expected
+            }
+
+            // A scoped EDIT's affected set is its `edited` occurrences — the "affects N" the UI
+            // previews (the regrouped THIS-tail keeps its fields and is deliberately not "affected").
+            test("$name — planEdit.edited") {
+                SeriesModification.planEdit(series, currentId, scope, EDIT, TAIL_GROUP, ZoneId.of("UTC"))
+                    .edited.map { idByUuid.getValue(it.id) } shouldBe expected
+            }
+        }
+    }
+})
+
+private val OBJECT_MAPPER = ObjectMapper()
+private val TAIL_GROUP: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000aa")
+private val EVENT_TYPE = EventType(id = UUID.fromString("00000000-0000-0000-0000-0000000000e7"), name = "Training", color = "#225C9C")
+private val EDIT = EventEdit(
+    eventType = EVENT_TYPE,
+    title = "edited",
+    description = null,
+    location = null,
+    references = emptyList(),
+    startTime = Instant.parse("2026-01-01T18:00:00Z"),
+    endTime = Instant.parse("2026-01-01T19:30:00Z"),
+)
+
+private fun uuidOf(id: String): UUID = UUID.nameUUIDFromBytes(id.toByteArray())
+
+private fun event(id: String, startTime: Instant): Event = Event(
+    id = uuidOf(id),
+    eventType = EVENT_TYPE,
+    title = "Training",
+    description = null,
+    startTime = startTime,
+    endTime = startTime,
+    location = null,
+    references = emptyList(),
+    recurringGroup = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    createdBy = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+    createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+)
+
+/**
+ * Load the shared cross-language fixture by walking up from the test's working directory to the repo
+ * root — so the exact same file backs both `make test-api` and `make test-app`, cwd-independently.
+ */
+private fun loadGoldenFixture(): JsonNode {
+    val relative = "contracts/recurrence-rules.golden.json"
+    val file = generateSequence(File(System.getProperty("user.dir")).absoluteFile) { it.parentFile }
+        .map { File(it, relative) }
+        .firstOrNull { it.isFile }
+        ?: error("Golden fixture '$relative' not found above ${System.getProperty("user.dir")}")
+    return OBJECT_MAPPER.readTree(file)
+}

--- a/app/src/entities/event/lib/series-affected.contract.test.ts
+++ b/app/src/entities/event/lib/series-affected.contract.test.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import type { Event, EventSeriesScope } from '@shared/api/events'
+import { buildAffectedPreview } from './series-affected'
+
+// CROSS-SEAM CONTRACT — the edit/delete split matrix lives in both this file's `series-affected.ts`
+// and the backend's `SeriesModification.planEdit/planDelete` and must stay in lockstep (ADR-0014).
+// This spec and the Kotlin `RecurrenceContractTest` read the SAME golden fixture, so a change to
+// either implementation that diverges from the pinned vectors fails its own suite in CI.
+
+interface SplitCase {
+  name: string
+  series: { id: string; startTime: string }[]
+  currentId: string
+  scope: EventSeriesScope
+  affectedIds: string[]
+}
+interface GoldenFixture {
+  splits: SplitCase[]
+}
+
+function loadGoldenFixture(): GoldenFixture {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  for (let i = 0; i < 12; i++) {
+    const candidate = resolve(dir, 'contracts/recurrence-rules.golden.json')
+    if (existsSync(candidate)) return JSON.parse(readFileSync(candidate, 'utf8')) as GoldenFixture
+    dir = dirname(dir)
+  }
+  throw new Error('golden fixture contracts/recurrence-rules.golden.json not found')
+}
+
+const event = (id: string, startTime: string): Event => ({
+  id,
+  eventType: { id: 'et-1', name: 'Training', color: '#225C9C' },
+  title: 'Training',
+  description: undefined,
+  startTime,
+  endTime: startTime,
+  location: undefined,
+  references: [],
+  recurringGroup: 'group-1',
+  attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
+})
+
+const fixture = loadGoldenFixture()
+
+describe('series split-matrix contract', () => {
+  for (const c of fixture.splits) {
+    it(c.name, () => {
+      const siblings = c.series.map((s) => event(s.id, s.startTime))
+      const preview = buildAffectedPreview(siblings, c.currentId, c.scope)!
+      expect(preview.nodes.filter((n) => n.affected).map((n) => n.id)).toEqual(c.affectedIds)
+    })
+  }
+})

--- a/app/src/features/create-recurring-events/model/recurrence.contract.test.ts
+++ b/app/src/features/create-recurring-events/model/recurrence.contract.test.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import type { RecurrenceFrequency, Weekday } from '@shared/api/recurring-events'
+import { generateOccurrences, MAX_OCCURRENCES } from './recurrence'
+
+// CROSS-SEAM CONTRACT — the occurrence-generation rule lives in both this file's `recurrence.ts` and
+// the backend's `Recurrence.occurrences()` and must stay in lockstep (ADR-0014). This spec and the
+// Kotlin `RecurrenceContractTest` read the SAME golden fixture, so a change to either implementation
+// that diverges from the pinned vectors fails its own suite in CI. See the fixture's `_doc`.
+
+interface OccurrenceCase {
+  name: string
+  frequency: RecurrenceFrequency
+  weekdays: Weekday[]
+  startDate: string
+  endDate: string
+  expected: string[]
+}
+interface GoldenFixture {
+  maxOccurrences: number
+  occurrences: OccurrenceCase[]
+}
+
+// Walk up from this test file to the repo root to read the shared fixture — the exact same file the
+// backend contract test loads, resolved cwd-independently.
+function loadGoldenFixture(): GoldenFixture {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  for (let i = 0; i < 12; i++) {
+    const candidate = resolve(dir, 'contracts/recurrence-rules.golden.json')
+    if (existsSync(candidate)) return JSON.parse(readFileSync(candidate, 'utf8')) as GoldenFixture
+    dir = dirname(dir)
+  }
+  throw new Error('golden fixture contracts/recurrence-rules.golden.json not found')
+}
+
+const fixture = loadGoldenFixture()
+
+describe('recurrence generation contract', () => {
+  it('MAX_OCCURRENCES matches the shared contract cap', () => {
+    expect(MAX_OCCURRENCES).toBe(fixture.maxOccurrences)
+  })
+
+  for (const c of fixture.occurrences) {
+    it(c.name, () => {
+      expect(
+        generateOccurrences({
+          frequency: c.frequency,
+          weekdays: c.weekdays,
+          startDate: c.startDate,
+          endDate: c.endDate,
+        }),
+      ).toEqual(c.expected)
+    })
+  }
+})

--- a/contracts/recurrence-rules.golden.json
+++ b/contracts/recurrence-rules.golden.json
@@ -1,0 +1,177 @@
+{
+  "_doc": [
+    "SINGLE SOURCE OF TRUTH for the two recurrence domain rules that exist in both Kotlin and",
+    "TypeScript and must stay in lockstep (ADR-0014):",
+    "  1. occurrence generation  — api Recurrence.occurrences()  ↔  app generateOccurrences()",
+    "  2. the edit/delete split  — api SeriesModification.planEdit/planDelete  ↔  app buildAffectedPreview()",
+    "Read by BOTH `make test-api` (RecurrenceContractTest.kt) and `make test-app`",
+    "(recurrence.contract.test.ts, series-affected.contract.test.ts). Any change to either",
+    "implementation that diverges from these vectors fails CI, so the wizard's instant local",
+    "preview can never silently drift from the backend it mimics. Change the rule in ONE place,",
+    "update these vectors, and both suites re-pin. Keep vectors small and deterministic: the shared",
+    "200 cap is pinned as the scalar `maxOccurrences` (not by aligning 200-element lists, whose",
+    "over-cap tails are allowed to differ). Weekday/frequency strings are the contract enum names."
+  ],
+  "maxOccurrences": 200,
+  "occurrences": [
+    {
+      "name": "weekly, single weekday, whole month",
+      "frequency": "WEEKLY",
+      "weekdays": ["TUESDAY"],
+      "startDate": "2026-09-01",
+      "endDate": "2026-09-30",
+      "expected": ["2026-09-01", "2026-09-08", "2026-09-15", "2026-09-22", "2026-09-29"]
+    },
+    {
+      "name": "weekly interleaves multiple weekdays chronologically",
+      "frequency": "WEEKLY",
+      "weekdays": ["TUESDAY", "THURSDAY"],
+      "startDate": "2026-09-07",
+      "endDate": "2026-09-20",
+      "expected": ["2026-09-08", "2026-09-10", "2026-09-15", "2026-09-17"]
+    },
+    {
+      "name": "biweekly keeps every OTHER occurrence per weekday (not every other row)",
+      "frequency": "BIWEEKLY",
+      "weekdays": ["TUESDAY", "THURSDAY"],
+      "startDate": "2026-09-07",
+      "endDate": "2026-10-04",
+      "expected": ["2026-09-08", "2026-09-10", "2026-09-22", "2026-09-24"]
+    },
+    {
+      "name": "biweekly on a single weekday alternates weeks",
+      "frequency": "BIWEEKLY",
+      "weekdays": ["TUESDAY"],
+      "startDate": "2026-09-01",
+      "endDate": "2026-09-30",
+      "expected": ["2026-09-01", "2026-09-15", "2026-09-29"]
+    },
+    {
+      "name": "both range boundaries are inclusive",
+      "frequency": "WEEKLY",
+      "weekdays": ["TUESDAY"],
+      "startDate": "2026-09-01",
+      "endDate": "2026-09-08",
+      "expected": ["2026-09-01", "2026-09-08"]
+    },
+    {
+      "name": "a range with no matching weekday yields nothing",
+      "frequency": "WEEKLY",
+      "weekdays": ["SUNDAY"],
+      "startDate": "2026-09-07",
+      "endDate": "2026-09-11",
+      "expected": []
+    },
+    {
+      "name": "a single-day range including the weekday yields exactly one",
+      "frequency": "WEEKLY",
+      "weekdays": ["TUESDAY"],
+      "startDate": "2026-09-01",
+      "endDate": "2026-09-01",
+      "expected": ["2026-09-01"]
+    },
+    {
+      "name": "weekly across the autumn DST fallback keeps exact 7-day calendar steps",
+      "frequency": "WEEKLY",
+      "weekdays": ["TUESDAY"],
+      "startDate": "2026-10-06",
+      "endDate": "2026-11-03",
+      "expected": ["2026-10-06", "2026-10-13", "2026-10-20", "2026-10-27", "2026-11-03"]
+    }
+  ],
+  "splits": [
+    {
+      "name": "THIS on a middle occurrence affects only it",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "b",
+      "scope": "THIS",
+      "affectedIds": ["b"]
+    },
+    {
+      "name": "THIS_AND_FOLLOWING on a middle occurrence affects it and every later one",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "b",
+      "scope": "THIS_AND_FOLLOWING",
+      "affectedIds": ["b", "c", "d"]
+    },
+    {
+      "name": "ALL affects every occurrence regardless of the current one",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "b",
+      "scope": "ALL",
+      "affectedIds": ["a", "b", "c", "d"]
+    },
+    {
+      "name": "THIS on the first occurrence affects only the first",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "a",
+      "scope": "THIS",
+      "affectedIds": ["a"]
+    },
+    {
+      "name": "THIS_AND_FOLLOWING on the last occurrence affects only the last",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "d",
+      "scope": "THIS_AND_FOLLOWING",
+      "affectedIds": ["d"]
+    },
+    {
+      "name": "ALL from the last occurrence still affects every occurrence",
+      "series": [
+        { "id": "c", "startTime": "2026-09-15T18:30:00Z" },
+        { "id": "a", "startTime": "2026-09-01T18:30:00Z" },
+        { "id": "d", "startTime": "2026-09-22T18:30:00Z" },
+        { "id": "b", "startTime": "2026-09-08T18:30:00Z" }
+      ],
+      "currentId": "d",
+      "scope": "ALL",
+      "affectedIds": ["a", "b", "c", "d"]
+    },
+    {
+      "name": "a single-occurrence series is fully affected by THIS",
+      "series": [{ "id": "solo", "startTime": "2026-09-01T18:30:00Z" }],
+      "currentId": "solo",
+      "scope": "THIS",
+      "affectedIds": ["solo"]
+    },
+    {
+      "name": "a single-occurrence series is fully affected by THIS_AND_FOLLOWING",
+      "series": [{ "id": "solo", "startTime": "2026-09-01T18:30:00Z" }],
+      "currentId": "solo",
+      "scope": "THIS_AND_FOLLOWING",
+      "affectedIds": ["solo"]
+    },
+    {
+      "name": "a single-occurrence series is fully affected by ALL",
+      "series": [{ "id": "solo", "startTime": "2026-09-01T18:30:00Z" }],
+      "currentId": "solo",
+      "scope": "ALL",
+      "affectedIds": ["solo"]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Two domain rules from ADR-0014 each exist in **both** Kotlin and TypeScript and had to agree by hand — the code comments literally admitted the coupling:

1. **Occurrence generation** — backend `Recurrence.occurrences()` vs frontend `generateOccurrences` (weekly/biweekly per-weekday stride, the 200 cap).
2. **Scope-affected matrix** — backend `SeriesModification.planEdit/planDelete` vs frontend `affectedRange`/`buildAffectedPreview` (the THIS / THIS_AND_FOLLOWING / ALL split).

Nothing spanned the seam, so a change to the biweekly stride, the cap, or the split semantics could silently desync the wizard's **live preview** from what the backend actually does — the preview would lie.

## Decision: contract test, not a dry-run endpoint

The seam is real, not accidental. Both previews are instant-interactive (the calendar re-renders on every weekday/frequency/date-range change; the affected preview re-runs as the user flips the scope radio). A server-driven "dry-run" endpoint would put a debounced round-trip + loading state on interactions that are currently instant — a bigger change **and** a UX regression, for a rule that is small, pure, and ADR-locked.

So instead of removing a duplication that is genuinely justified, this pins both implementations to a **single shared golden fixture** read by both suites. Drift now fails CI instead of shipping a lying preview, and the instant-preview UX is preserved.

## What's here

- `contracts/recurrence-rules.golden.json` — the one source of truth: 8 occurrence vectors + 9 split-matrix vectors + the `maxOccurrences: 200` scalar. The cap is pinned as a scalar rather than by aligning 200-element lists (whose over-cap tails are legitimately allowed to differ between impls).
- `RecurrenceContractTest.kt` (`make test-api`, 27 tests) — feeds each vector through the real `Recurrence.occurrences()` and `SeriesModification.planEdit/planDelete`.
- `recurrence.contract.test.ts` + `series-affected.contract.test.ts` (`make test-app`, 18 tests) — feed the **same** vectors through `generateOccurrences()` and `buildAffectedPreview()`.

Both sides use a walk-up-to-repo-root loader so the *identical file* backs both suites, cwd-independently — two files that must agree would just relocate the drift. **No production code changed**; the well-designed backend deep modules were left untouched.

## Proof the test spans the seam (mutation)

| Mutation (one impl only) | Result |
|---|---|
| Backend `Recurrence.kt` biweekly stride `% 2` → `% 3` | `make test-api` red — only the 2 biweekly vectors failed |
| Frontend `series-affected.ts` `THIS_AND_FOLLOWING` → `[i, i]` | `make test-app` red — the split vector failed |

Each language's implementation is pinned to the shared fixture, so a change to the biweekly stride, the cap, or the split semantics in *either* impl now fails CI. Both mutations reverted.

## Verification

- `make lint` → detekt ✓, eslint ✓
- `make test-api` → BUILD SUCCESSFUL (full Testcontainers suite)
- `make test-app` → 234/234
- pre-commit gate also ran real e2e → 7/7

**PR gate:** no new e2e — this is a test-only contract pin and introduces no new auth / cross-tenant / integration seam, so per the gate it doesn't warrant a flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDkdooonsuj63YD4HeJc8W