### PR TITLE
refactor: give an event's attendance one deep home (EventAttendance projection)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,6 +65,13 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 - **Attendance State** — `Attending` (green), `Maybe` (gold), `Absent` (red),
   `Not Responded` (default, no response yet). The semantic colors are fixed brand
   identity.
+- **Event Attendance** — The resolved attendance picture of a single Event: every current
+  Member paired with their **Attendance State** for that Event (their response, or
+  **Not Responded** when they haven't answered). Derived from the *current* roster, so a
+  Member who joins after the Event appears as Not Responded and a departed Member drops out,
+  even if they once responded (per [ADR-0009](docs/adr/0009-attendance-model-roles-in-audience-deferred.md)).
+  The summary counts, the roster, and the attending-**Position** breakdown are all views of
+  this one picture. _Avoid_: attendance list, attendance snapshot.
 - **Attendance Toggle** — The core daily interaction: a Member sets their state on an
   event. Editable by others today (trust-based) — see
   [ADR-0003](docs/adr/0003-trust-based-attendance-editing.md).

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.Attendance
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
+import com.github.zzave.teambalance.api.domain.model.EventAttendance
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.domain.port.EventRepository
@@ -9,11 +10,7 @@ import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
-import java.time.Instant
 import java.util.UUID
-
-/** Bucket label for attendees who have no position assigned. */
-const val UNASSIGNED = "Unassigned"
 
 @Service
 @Transactional
@@ -45,47 +42,25 @@ class AttendanceService(
         }
     }
 
-    /** Current active roster of a team — fetch once per request and pass into the derivations below. */
+    /** Current active roster of a team — fetch once per request and pass into the projections below. */
     fun teamMembers(teamId: UUID): List<TeamMember> = teamMemberRepository.findByTeamId(teamId)
 
-    // The roster and summary are derived from *current team membership*, not from the attendance rows
-    // that existed when the event was made. So a member who joins after an event was created shows up
-    // as NOT_RESPONDED (no pre-created row needed), and a member who left the team drops out entirely —
-    // even if they had a stale response row. A member's state is their response row's state, or
-    // NOT_RESPONDED when they have no row. `members` is passed in so a listing resolves the team once.
-    fun getAttendancesWithMembers(eventId: UUID, members: List<TeamMember>): List<Pair<Attendance, TeamMember>> {
-        val responseByUser = attendanceRepository.findByEventId(eventId).associateBy { it.userId }
-        return members.map { member ->
-            val response = responseByUser[member.userId]
-                ?: Attendance(
-                    id = member.userId,
-                    eventId = eventId,
-                    userId = member.userId,
-                    state = AttendanceState.NOT_RESPONDED,
-                    updatedAt = clock.instant(),
-                    changedBy = member.userId,
-                )
-            response to member
-        }
-    }
+    // The attendance picture is derived from *current team membership*, not from the rows that existed
+    // when the event was made: a member who joined later shows as NOT_RESPONDED (no seeded row needed)
+    // and a member who left drops out even with a stale row (#103, #114). EventAttendance concentrates
+    // that rule; `members` is passed in so a listing resolves the roster once.
 
-    fun getAttendanceSummary(eventId: UUID, members: List<TeamMember>): Map<AttendanceState, Int> {
-        val responseByUser = attendanceRepository.findByEventId(eventId).associateBy { it.userId }
-        return AttendanceState.entries.associateWith { state ->
-            members.count { (responseByUser[it.userId]?.state ?: AttendanceState.NOT_RESPONDED) == state }
-        }
-    }
+    /** The resolved attendance picture for one event — its response rows fetched once. */
+    fun attendanceFor(eventId: UUID, members: List<TeamMember>): EventAttendance =
+        EventAttendance.resolve(members, attendanceRepository.findByEventId(eventId))
 
-    fun getAttendingRoleBreakdown(eventId: UUID, members: List<TeamMember>): List<Pair<String, Int>> {
-        val attendingUserIds = attendanceRepository.findByEventId(eventId)
-            .filter { it.state == AttendanceState.ATTENDING }
-            .map { it.userId }
-            .toSet()
-        return members
-            .filter { it.userId in attendingUserIds }
-            .groupBy { it.position ?: UNASSIGNED }
-            .map { (position, grouped) -> position to grouped.size }
-            .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
+    /**
+     * The resolved picture for many events, keyed by event id, from a single response-row query —
+     * kills the per-event N+1 when producing a listing.
+     */
+    fun attendanceForAll(eventIds: List<UUID>, members: List<TeamMember>): Map<UUID, EventAttendance> {
+        val responsesByEvent = attendanceRepository.findByEventIds(eventIds).groupBy { it.eventId }
+        return eventIds.associateWith { EventAttendance.resolve(members, responsesByEvent[it] ?: emptyList()) }
     }
 
     fun findMember(userId: UUID): TeamMember? =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendance.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendance.kt
@@ -1,0 +1,64 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.util.UUID
+
+/** Bucket label for attendees who have no position assigned. */
+const val UNASSIGNED = "Unassigned"
+
+/**
+ * One member's resolved attendance for an event: their response-row state, or NOT_RESPONDED when
+ * they have no row. [responseId] is the attendance row's id when they responded, null otherwise —
+ * so a view can key off the real row while a not-responded member falls back to their user id.
+ */
+data class MemberAttendance(
+    val member: TeamMember,
+    val state: AttendanceState,
+    val responseId: UUID?,
+)
+
+/**
+ * The resolved attendance picture of a single event, computed once from the current roster and the
+ * event's response rows. Summary, roster ([entries]) and role breakdown are pure folds over the
+ * projection — the "response-row-state, else NOT_RESPONDED" rule lives here and only here, and the
+ * response rows are fetched once. Delete this and that rule scatters back across three services and
+ * the per-event listing N+1 returns.
+ */
+class EventAttendance private constructor(
+    val entries: List<MemberAttendance>,
+) {
+    /** Count of current members in each state (every state present, zero when none). */
+    fun summary(): Map<AttendanceState, Int> =
+        AttendanceState.entries.associateWith { state -> entries.count { it.state == state } }
+
+    /**
+     * Attending members grouped by position (unpositioned in the [UNASSIGNED] bucket), ordered by
+     * count descending then position label ascending.
+     */
+    fun attendingRoleBreakdown(): List<Pair<String, Int>> =
+        entries
+            .filter { it.state == AttendanceState.ATTENDING }
+            .groupBy { it.member.position ?: UNASSIGNED }
+            .map { (position, grouped) -> position to grouped.size }
+            .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
+
+    companion object {
+        /**
+         * Resolve the picture for [members] (the current roster) against the event's [responses].
+         * A member's state is their response row's state, or NOT_RESPONDED when they have no row;
+         * a stale row for someone no longer on the roster is ignored (never counted or listed).
+         */
+        fun resolve(members: List<TeamMember>, responses: List<Attendance>): EventAttendance {
+            val responseByUser = responses.associateBy { it.userId }
+            return EventAttendance(
+                members.map { member ->
+                    val response = responseByUser[member.userId]
+                    MemberAttendance(
+                        member = member,
+                        state = response?.state ?: AttendanceState.NOT_RESPONDED,
+                        responseId = response?.id,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/AttendanceRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/AttendanceRepository.kt
@@ -5,6 +5,9 @@ import java.util.UUID
 
 interface AttendanceRepository {
     fun findByEventId(eventId: UUID): List<Attendance>
+
+    /** Response rows for many events in one query — lets a listing avoid a per-event fetch. */
+    fun findByEventIds(eventIds: List<UUID>): List<Attendance>
     fun findByEventIdAndUserId(eventId: UUID, userId: UUID): Attendance?
     fun save(attendance: Attendance): Attendance
     fun saveAll(attendances: List<Attendance>): List<Attendance>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
@@ -17,6 +17,10 @@ class JpaAttendanceRepositoryAdapter(
     override fun findByEventId(eventId: UUID): List<Attendance> =
         jpaRepository.findByEventUuid(eventId).map { it.internalize() }
 
+    override fun findByEventIds(eventIds: List<UUID>): List<Attendance> =
+        if (eventIds.isEmpty()) emptyList()
+        else jpaRepository.findByEventUuidIn(eventIds).map { it.internalize() }
+
     override fun findByEventIdAndUserId(eventId: UUID, userId: UUID): Attendance? =
         jpaRepository.findByEventUuidAndUserId(eventId, userId)?.internalize()
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataAttendanceRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataAttendanceRepository.kt
@@ -7,5 +7,6 @@ import java.util.UUID
 interface SpringDataAttendanceRepository : JpaRepository<AttendanceJpaEntity, Long> {
     fun findByUuid(uuid: UUID): AttendanceJpaEntity?
     fun findByEventUuid(eventUuid: UUID): List<AttendanceJpaEntity>
+    fun findByEventUuidIn(eventUuids: List<UUID>): List<AttendanceJpaEntity>
     fun findByEventUuidAndUserId(eventUuid: UUID, userId: UUID): AttendanceJpaEntity?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
@@ -2,8 +2,8 @@ package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
-import com.github.zzave.teambalance.api.application.UNASSIGNED
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
+import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.SetAttendance
 import com.github.zzave.teambalance.api.interfaces.generated.model.Attendance
 import org.springframework.web.bind.annotation.RestController

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -2,14 +2,16 @@ package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
 import com.github.zzave.teambalance.api.application.AuthorizationService
-import com.github.zzave.teambalance.api.application.UNASSIGNED
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.application.PotentialEvent
 import com.github.zzave.teambalance.api.domain.model.AttendanceState as DomainAttendanceState
+import com.github.zzave.teambalance.api.domain.model.EventAttendance
 import com.github.zzave.teambalance.api.domain.model.EventReference as DomainEventReference
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope as DomainEventSeriesScope
+import com.github.zzave.teambalance.api.domain.model.MemberAttendance
+import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
 import com.github.zzave.teambalance.api.interfaces.generated.model.EventSeriesScope as GeneratedEventSeriesScope
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateEvent
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.DeleteEvent
@@ -46,8 +48,9 @@ class EventController(
     override suspend fun listEvents(request: ListEvents.Request): ListEvents.Response<*> {
         val members = attendanceService.teamMembers(currentTeamProvider.requireCurrentTeamId())
         val events = if (request.queries.includepast) eventService.getAllEvents() else eventService.getUpcomingEvents()
+        val attendance = attendanceService.attendanceForAll(events.map { it.id }, members)
         return ListEvents.Response200(
-            EventList(events = events.map { it.produce(attendanceService, members) })
+            EventList(events = events.map { it.produce(attendance.getValue(it.id)) })
         )
     }
 
@@ -59,7 +62,9 @@ class EventController(
             potential = request.body.consume(),
             createdBy = userId,
         )
-        return CreateEvent.Response201(event.produce(attendanceService, attendanceService.teamMembers(teamId)))
+        return CreateEvent.Response201(
+            event.produce(attendanceService.attendanceFor(event.id, attendanceService.teamMembers(teamId))),
+        )
     }
 
     override suspend fun getEvent(request: GetEvent.Request): GetEvent.Response<*> {
@@ -68,9 +73,7 @@ class EventController(
             ?: return GetEvent.Response404(Unit)
 
         val members = attendanceService.teamMembers(currentTeamProvider.requireCurrentTeamId())
-        val attendances = attendanceService.getAttendancesWithMembers(id, members)
-        val summary = attendanceService.getAttendanceSummary(id, members)
-        val roleBreakdown = attendanceService.getAttendingRoleBreakdown(id, members)
+        val attendance = attendanceService.attendanceFor(id, members)
 
         return GetEvent.Response200(
             EventDetail(
@@ -83,16 +86,8 @@ class EventController(
                 location = event.location,
                 references = event.references.externalize(),
                 recurringGroup = event.recurringGroup?.toString(),
-                attendanceSummary = summary.produce(roleBreakdown),
-                attendances = attendances.map { (a, member) ->
-                    AttendanceEntry(
-                        id = a.id.toString(),
-                        userId = a.userId.toString(),
-                        displayName = member.displayName,
-                        role = member.position ?: UNASSIGNED,
-                        state = a.state.produce(),
-                    )
-                },
+                attendanceSummary = attendance.summary().produce(attendance.attendingRoleBreakdown()),
+                attendances = attendance.entries.map { it.produce() },
             )
         )
     }
@@ -117,7 +112,8 @@ class EventController(
         ) ?: return UpdateEvent.Response404(Unit)
 
         val members = attendanceService.teamMembers(teamId)
-        return UpdateEvent.Response200(EventList(events = events.map { it.produce(attendanceService, members) }))
+        val attendance = attendanceService.attendanceForAll(events.map { it.id }, members)
+        return UpdateEvent.Response200(EventList(events = events.map { it.produce(attendance.getValue(it.id)) }))
     }
 
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
@@ -160,13 +156,9 @@ private fun List<DomainEventReference>.externalize(): List<EventReference> =
     map { EventReference(title = it.title, url = it.url) }
 
 // internal (not private) so RecurringEventController can reuse it for the batch-create response.
-internal fun com.github.zzave.teambalance.api.domain.model.Event.produce(
-    attendanceService: AttendanceService,
-    members: List<com.github.zzave.teambalance.api.domain.model.TeamMember>,
-): Event {
-    val summary = attendanceService.getAttendanceSummary(id, members)
-    val roleBreakdown = attendanceService.getAttendingRoleBreakdown(id, members)
-    return Event(
+// Takes the already-resolved projection so mapping stays free of data access (no per-event N+1).
+internal fun com.github.zzave.teambalance.api.domain.model.Event.produce(attendance: EventAttendance): Event =
+    Event(
         id = id.toString(),
         eventType = eventType.produce(),
         title = title,
@@ -176,9 +168,17 @@ internal fun com.github.zzave.teambalance.api.domain.model.Event.produce(
         location = location,
         references = references.externalize(),
         recurringGroup = recurringGroup?.toString(),
-        attendanceSummary = summary.produce(roleBreakdown),
+        attendanceSummary = attendance.summary().produce(attendance.attendingRoleBreakdown()),
     )
-}
+
+private fun MemberAttendance.produce() = AttendanceEntry(
+    // A responded member keys off their real row; a not-responded member falls back to their user id.
+    id = (responseId ?: member.userId).toString(),
+    userId = member.userId.toString(),
+    displayName = member.displayName,
+    role = member.position ?: UNASSIGNED,
+    state = state.produce(),
+)
 
 private fun com.github.zzave.teambalance.api.domain.model.EventType.produce() =
     EventTypeSummary(id = id.toString(), name = name, color = color)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
@@ -47,12 +47,14 @@ class RecurringEventController(
         )
 
         // Attendance is derived from current team membership at read time (#114), so the created
-        // occurrences carry the full NOT_RESPONDED roster without any seeded rows.
+        // occurrences carry the full NOT_RESPONDED roster without any seeded rows. Resolve the whole
+        // batch in one query so the response doesn't fan out into a per-occurrence N+1.
         val members = attendanceService.teamMembers(teamId)
+        val attendance = attendanceService.attendanceForAll(series.events.map { it.id }, members)
         return CreateRecurringEvents.Response201(
             RecurringEventSeries(
                 recurringGroup = series.recurringGroup.toString(),
-                events = series.events.map { it.produce(attendanceService, members) },
+                events = series.events.map { it.produce(attendance.getValue(it.id)) },
             ),
         )
     }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendanceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendanceTest.kt
@@ -1,0 +1,113 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Pure folds over the resolved attendance picture of an event (the EventAttendance projection).
+ * No Spring, no DB — the lowest layer that proves the "response-row-state, else NOT_RESPONDED" rule
+ * and the summary / roster / role-breakdown derivations that used to be transcribed three times in
+ * AttendanceService (and re-queried per event, causing the listing N+1).
+ */
+class EventAttendanceTest : FunSpec({
+
+    val eventId = UUID.randomUUID()
+
+    fun member(name: String, position: String? = null) = TeamMember(
+        userId = UUID.randomUUID(),
+        displayName = name,
+        role = "USER",
+        positionId = null,
+        position = position,
+        onboarded = true,
+    )
+
+    fun TeamMember.responded(state: AttendanceState) = Attendance(
+        id = UUID.randomUUID(),
+        eventId = eventId,
+        userId = userId,
+        state = state,
+        updatedAt = Instant.EPOCH,
+        changedBy = userId,
+    )
+
+    test("a member with no response row resolves to NOT_RESPONDED") {
+        val alice = member("Alice")
+
+        val projection = EventAttendance.resolve(members = listOf(alice), responses = emptyList())
+
+        projection.entries.single().state shouldBe AttendanceState.NOT_RESPONDED
+    }
+
+    test("summary counts every current member by resolved state") {
+        val attending = member("A")
+        val maybe = member("M")
+        val silent = member("N")
+
+        val projection = EventAttendance.resolve(
+            members = listOf(attending, maybe, silent),
+            responses = listOf(
+                attending.responded(AttendanceState.ATTENDING),
+                maybe.responded(AttendanceState.MAYBE),
+            ),
+        )
+
+        projection.summary() shouldBe mapOf(
+            AttendanceState.ATTENDING to 1,
+            AttendanceState.MAYBE to 1,
+            AttendanceState.ABSENT to 0,
+            AttendanceState.NOT_RESPONDED to 1,
+        )
+    }
+
+    test("a stale response from someone no longer on the roster is ignored") {
+        val current = member("Current")
+        val departed = member("Departed")
+
+        val projection = EventAttendance.resolve(
+            members = listOf(current),
+            responses = listOf(departed.responded(AttendanceState.ATTENDING)),
+        )
+
+        projection.entries.map { it.member } shouldBe listOf(current)
+        projection.summary()[AttendanceState.ATTENDING] shouldBe 0
+    }
+
+    test("role breakdown groups only ATTENDING members by position, most-attended first then alphabetical") {
+        val s1 = member("S1", position = "Setter")
+        val s2 = member("S2", position = "Setter")
+        val libero = member("L", position = "Libero")
+        val maybeSetter = member("MS", position = "Setter")
+        val unpositioned = member("U", position = null)
+
+        val projection = EventAttendance.resolve(
+            members = listOf(s1, s2, libero, maybeSetter, unpositioned),
+            responses = listOf(
+                s1.responded(AttendanceState.ATTENDING),
+                s2.responded(AttendanceState.ATTENDING),
+                libero.responded(AttendanceState.ATTENDING),
+                maybeSetter.responded(AttendanceState.MAYBE),
+                unpositioned.responded(AttendanceState.ATTENDING),
+            ),
+        )
+
+        projection.attendingRoleBreakdown() shouldBe listOf(
+            "Setter" to 2,
+            "Libero" to 1,
+            UNASSIGNED to 1,
+        )
+    }
+
+    test("responseId is the row id when responded and null when not") {
+        val responded = member("R")
+        val silent = member("S")
+        val row = responded.responded(AttendanceState.ATTENDING)
+
+        val projection = EventAttendance.resolve(members = listOf(responded, silent), responses = listOf(row))
+
+        projection.entries.first { it.member == responded }.responseId shouldBe row.id
+        projection.entries.first { it.member == silent }.responseId shouldBe null
+    }
+})

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -1,12 +1,16 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
 import io.kotest.matchers.shouldBe
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -31,6 +35,11 @@ class EventControllerTest : TeamBalanceIT() {
 
     @Autowired
     lateinit var tenantSchemaManager: TenantSchemaManager
+
+    // Spy the real adapter (it still delegates to Postgres) so we can count DB round trips and prove
+    // the listing resolves all events' attendance in one batched query instead of one query per event.
+    @MockitoSpyBean
+    lateinit var attendanceRepository: AttendanceRepository
 
     init {
         test("GET /api/events/{id} returns role for each attendee") {
@@ -739,6 +748,63 @@ class EventControllerTest : TeamBalanceIT() {
             }
 
             status shouldBe 400
+        }
+
+        test("GET /api/events resolves attendance for the whole list in one query (no N+1)") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.teams (id, name, slug, sport, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                """
+                INSERT INTO public.users (id, email, display_name)
+                VALUES ('$JAN_USER_ID'::uuid, 'jan@test.com', 'Jan de Vries')
+                ON CONFLICT DO NOTHING
+            """
+            )
+            jdbcTemplate.execute(
+                "SELECT public.tb_add_member('$TEAM_ID'::uuid, '$JAN_USER_ID'::uuid, 'USER', 'Setter')"
+            )
+
+            // Several events so a per-event fetch would show up as multiple round trips.
+            repeat(3) { i ->
+                val eventId = UUID.randomUUID()
+                jdbcTemplate.execute(
+                    """
+                    INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                    VALUES ('$eventId'::uuid,
+                        (SELECT id FROM public.event_types WHERE name = 'Training'),
+                        'N+1 Guard $i', '2050-07-0${i + 1} 20:00:00+00', '2050-07-0${i + 1} 22:00:00+00',
+                        '$JAN_USER_ID'::uuid, now(), now())
+                """
+                )
+                insertAttendance(eventId, JAN_USER_ID)
+            }
+
+            // Ignore attendance reads from the seeding/other tests sharing this context.
+            Mockito.clearInvocations(attendanceRepository)
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events?include-past=true")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+
+            // One batched query for every listed event and nothing else — no per-event fetch, which is
+            // exactly the N+1 this projection removes (reverting to findByEventId-per-event fails here).
+            Mockito.verify(attendanceRepository, Mockito.times(1)).findByEventIds(ArgumentMatchers.anyList())
+            Mockito.verifyNoMoreInteractions(attendanceRepository)
         }
     }
 


### PR DESCRIPTION
## Why

The **attendance picture of an event** was transcribed three times in `AttendanceService` — `getAttendancesWithMembers`, `getAttendanceSummary`, `getAttendingRoleBreakdown` — each independently calling `findByEventId` and re-encoding the same *"response-row state, else `NOT_RESPONDED`"* rule in a different shape. The domain→wire mapper `Event.produce` called two of them **per event**, and `listEvents`/`updateEvent`/`RecurringEventController` mapped `produce` over every event — so a "mapper" was secretly doing data access, firing ~2N attendance queries for N events (a hidden **N+1**).

That same rule was the subject of two separate prod bug fixes on opposite sides of the wire (#103 frontend, #114 backend). Poor locality — one concept with no single home.

## What

Introduce one **deep domain module**, `EventAttendance` (`domain/model/`), that resolves a per-member attendance state **once** from `(currentMembers, responseRows)`:

- `summary()`, `entries` (roster), and `attendingRoleBreakdown()` become **pure folds** over the projection. The `NOT_RESPONDED` rule lives there and only there.
- The phantom-`Attendance`-as-view-model smell is gone: a not-responded member is now `MemberAttendance(state = NOT_RESPONDED, responseId = null)` — no synthetic entity, no `clock` dependency in the read path.
- `AttendanceService` exposes `attendanceFor(eventId, members)` (single) and `attendanceForAll(eventIds, members)` (**batch — one query for the whole listing**).
- `EventController` (list/create/get/update), `RecurringEventController`, and `Event.produce` compute the projection once and fold. `Event.produce` now takes an `EventAttendance` instead of the service, so mapping does no data access. **The per-event N+1 is killed on every listing path.**
- Added `AttendanceRepository.findByEventIds` (+ JPA `findByEventUuidIn`, empty-list guarded) for the batch fetch.
- `UNASSIGNED` moved to the domain layer as its single source of truth.
- `CONTEXT.md` gains the **Event Attendance** domain term.

**Deletion test:** remove `EventAttendance` and the rule scatters back across three methods and the N+1 returns — complexity concentrates, so it's a real deep module.

## Tests (TDD)

- `EventAttendanceTest` — pure Kotest unit for the folds (not-responded default, summary counts, stale-row-ignored, role-breakdown grouping/sort, `responseId`). Written red-first.
- `EventControllerTest` — new IT spies the `AttendanceRepository` port and asserts the listing issues **exactly one** `findByEventIds` and **no** per-event `findByEventId`. **Red-green verified**: reverting `listEvents` to per-event resolution fails it with `WantedButNotInvoked`.

## Verification

- `:api:test` — **235 tests, 0 failures, 0 errors**
- `:api:detekt` — clean (includes hexagonal-boundary rules)

No new e2e: the change introduces no new auth path, cross-tenant write, or external integration — existing login/attendance flows already cover the seam.

## Notes

- No ADR — read-time derivation semantics are already governed by ADR-0009 / #114; this is a code-locality refactor.
- Frontend left as-is (secondary/optional). The client re-derivation in `attendee-panel.ts` and the attendance-state vocabulary triplication (`AttendanceToggle.tsx`, `ATTENDEE_TABS` in `\$eventId.tsx`, `attendee-panel.ts`) are noted, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)