### PR TITLE
fix: enforce write-authorization uniformly in the application layer

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -18,9 +18,24 @@ class AttendanceService(
     private val attendanceRepository: AttendanceRepository,
     private val eventRepository: EventRepository,
     private val teamMemberRepository: TeamMemberRepository,
+    private val authorizationService: AuthorizationService,
     private val clock: Clock,
 ) {
-    fun setAttendance(eventId: UUID, userId: UUID, state: AttendanceState, changedBy: UUID): Attendance? {
+    /**
+     * Records [userId]'s attendance for [eventId], attributed to [changedBy] (the authenticated
+     * caller). Editing is trust-based within a team (ADR-0003), so the gate is membership, not
+     * admin: the target [userId] must be an active member of [teamId] — the caller's server-resolved
+     * tenant. This closes the write path that previously trusted only schema routing and never
+     * checked the path [userId] against the caller's team. Returns null when the event is unknown.
+     */
+    fun setAttendance(
+        teamId: UUID,
+        eventId: UUID,
+        userId: UUID,
+        state: AttendanceState,
+        changedBy: UUID,
+    ): Attendance? {
+        authorizationService.requireMember(userId, teamId)
         if (eventRepository.findById(eventId) == null) return null
 
         val existing = attendanceRepository.findByEventIdAndUserId(eventId, userId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.exception.NoTeamMembershipException
 import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
@@ -16,7 +17,7 @@ import java.util.UUID
  *   otherwise a user can probe or act on teams they don't belong to (IDOR).
  *
  * The check is fail-closed: a missing, inactive, or wrong-team membership yields no role and is
- * therefore not admin.
+ * therefore neither a member nor an admin.
  */
 @Service
 class AuthorizationService(
@@ -27,5 +28,18 @@ class AuthorizationService(
 
     fun requireAdmin(userId: UUID, teamId: UUID) {
         if (!isAdmin(userId, teamId)) throw NotTeamAdminException(userId, teamId)
+    }
+
+    /** True when [userId] is an active member of [teamId], regardless of role. */
+    fun isMember(userId: UUID, teamId: UUID): Boolean =
+        teamMemberRepository.findRole(teamId, userId) != null
+
+    /**
+     * Asserts [userId] is an active member of [teamId] — the gate for team-scoped writes that any
+     * member may perform (e.g. trust-based attendance editing, ADR-0003). Fail-closed: a non-member
+     * yields no role and is rejected. Same security contract as [requireAdmin] on its arguments.
+     */
+    fun requireMember(userId: UUID, teamId: UUID) {
+        if (!isMember(userId, teamId)) throw NoTeamMembershipException(userId)
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -29,6 +29,7 @@ class EventService(
     private val eventRepository: EventRepository,
     private val eventTypeRepository: EventTypeRepository,
     private val seasonRepository: SeasonRepository,
+    private val authorizationService: AuthorizationService,
     private val clock: Clock,
 ) {
     companion object {
@@ -52,7 +53,10 @@ class EventService(
     // No attendance rows are seeded here: the summary and roster are derived from current team
     // membership at read time (see AttendanceService), so a member's absence of a row simply reads
     // as NOT_RESPONDED. A response then upserts their row (AttendanceService.setAttendance).
-    fun createEvent(potential: PotentialEvent, createdBy: UUID): Event {
+    // Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant), and is
+    // recorded as the event's creator.
+    fun createEvent(callerId: UUID, teamId: UUID, potential: PotentialEvent): Event {
+        authorizationService.requireAdmin(callerId, teamId)
         val eventType = eventTypeRepository.findById(potential.eventTypeId)
             ?: throw EventTypeNotFoundException(potential.eventTypeId)
 
@@ -70,7 +74,7 @@ class EventService(
                 location = potential.location,
                 references = potential.references,
                 recurringGroup = potential.recurringGroup,
-                createdBy = createdBy,
+                createdBy = callerId,
                 createdAt = clock.instant(),
             ),
         )
@@ -88,8 +92,13 @@ class EventService(
      * season, and the batch is capped at [Recurrence.MAX_OCCURRENCES].
      *
      * Runs in a single transaction (the whole batch commits or nothing does).
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant), and is
+     * recorded as the creator of every generated occurrence.
      */
     fun createRecurringEvents(
+        callerId: UUID,
+        teamId: UUID,
         eventTypeId: UUID,
         title: String,
         description: String?,
@@ -98,8 +107,8 @@ class EventService(
         durationMinutes: Long,
         references: List<EventReference>,
         recurrence: Recurrence,
-        createdBy: UUID,
     ): RecurringEventSeries {
+        authorizationService.requireAdmin(callerId, teamId)
         require(durationMinutes in 1..MAX_DURATION_MINUTES) {
             "durationMinutes must be between 1 and $MAX_DURATION_MINUTES"
         }
@@ -124,7 +133,7 @@ class EventService(
                     location = location,
                     references = references,
                     recurringGroup = recurringGroup,
-                    createdBy = createdBy,
+                    createdBy = callerId,
                     createdAt = clock.instant(),
                 ),
             )
@@ -156,8 +165,12 @@ class EventService(
      *
      * Returns the affected ("edited") occurrences ordered by start, or null when [id] is unknown.
      * Runs in one transaction — the whole reassignment commits or nothing does.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
      */
     fun updateEvent(
+        callerId: UUID,
+        teamId: UUID,
         id: UUID,
         scope: EventSeriesScope,
         eventTypeId: UUID,
@@ -168,6 +181,7 @@ class EventService(
         location: String?,
         references: List<EventReference> = emptyList(),
     ): List<Event>? {
+        authorizationService.requireAdmin(callerId, teamId)
         val target = eventRepository.findById(id) ?: return null
         val eventType = eventTypeRepository.findById(eventTypeId)
             ?: throw EventTypeNotFoundException(eventTypeId)
@@ -202,8 +216,11 @@ class EventService(
      * Deletes the occurrences in [scope] over the target's series (ADR-0014, Decision 4). A delete
      * **never splits** — survivors keep their group untouched. Returns false when [id] is unknown.
      * Runs in one transaction.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
      */
-    fun deleteEvent(id: UUID, scope: EventSeriesScope): Boolean {
+    fun deleteEvent(callerId: UUID, teamId: UUID, id: UUID, scope: EventSeriesScope): Boolean {
+        authorizationService.requireAdmin(callerId, teamId)
         val target = eventRepository.findById(id) ?: return false
         val toDelete = SeriesModification.planDelete(seriesOf(target), id, scope)
         toDelete.forEach { eventRepository.deleteById(it) }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -21,6 +21,7 @@ data class GeneratedInvitation(val token: String, val expiresAt: Instant)
 class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val teamMemberRepository: TeamMemberRepository,
+    private val authorizationService: AuthorizationService,
     private val clock: Clock,
     // App-wide secret mixed into the token hash. Supplied via INVITATION_TOKEN_SALT in live
     // environments (see application.yml); dev and test use a hardcoded value.
@@ -40,8 +41,12 @@ class InvitationService(
      * a usable link. Because the hash is one-way, a repeat call can't re-show a previous link — each
      * call mints a new one; links already shared keep working until they expire. #38 adds explicit
      * rotate/expire to invalidate them.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant), and is also
+     * recorded as the invitation's creator.
      */
-    fun generateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
+    fun generateInviteLink(callerId: UUID, teamId: UUID): GeneratedInvitation {
+        authorizationService.requireAdmin(callerId, teamId)
         val now = clock.instant()
         val token = generateToken()
         invitationRepository.save(
@@ -49,7 +54,7 @@ class InvitationService(
                 id = UUID.randomUUID(),
                 teamId = teamId,
                 tokenHash = hashToken(token),
-                createdBy = createdBy,
+                createdBy = callerId,
                 expiresAt = now.plus(INVITE_TTL),
                 createdAt = now,
             ),
@@ -72,20 +77,24 @@ class InvitationService(
         return invitation.teamId
     }
 
-    /** Invalidates every currently-active invite link for the team; already-expired ones are untouched. */
-    fun expireActiveInvitations(teamId: UUID) {
+    /**
+     * Invalidates every currently-active invite link for the team; already-expired ones are untouched.
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
+     */
+    fun expireActiveInvitations(callerId: UUID, teamId: UUID) {
+        authorizationService.requireAdmin(callerId, teamId)
         invitationRepository.expireActive(teamId, Instant.now(clock))
     }
 
     /**
      * Invalidates the team's active invite link(s) and mints a fresh one in its place. Atomic: the
      * expire and the mint share one transaction, so a failure to mint rolls the expire back rather
-     * than leaving the team with no usable link.
+     * than leaving the team with no usable link. Admin-only (the nested calls re-assert it).
      */
     @Transactional
-    fun rotateInviteLink(teamId: UUID, createdBy: UUID): GeneratedInvitation {
-        expireActiveInvitations(teamId)
-        return generateInviteLink(teamId, createdBy)
+    fun rotateInviteLink(callerId: UUID, teamId: UUID): GeneratedInvitation {
+        expireActiveInvitations(callerId, teamId)
+        return generateInviteLink(callerId, teamId)
     }
 
     private fun generateToken(): String {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
+import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
 import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
@@ -13,15 +14,22 @@ import java.util.UUID
 class AttendanceController(
     private val attendanceService: AttendanceService,
     private val currentUserProvider: CurrentUserProvider,
+    private val currentTeamProvider: CurrentTeamProvider,
 ) : SetAttendance.Handler {
 
     override suspend fun setAttendance(request: SetAttendance.Request): SetAttendance.Response<*> {
+        val teamId = currentTeamProvider.requireCurrentTeamId()
         val eventId = UUID.fromString(request.path.eventId)
         val userId = UUID.fromString(request.path.userId)
         val state = AttendanceState.valueOf(request.body.state)
 
-        val attendance = attendanceService.setAttendance(eventId, userId, state, currentUserProvider.requireCurrentUserId())
-            ?: return SetAttendance.Response404(Unit)
+        val attendance = attendanceService.setAttendance(
+            teamId = teamId,
+            eventId = eventId,
+            userId = userId,
+            state = state,
+            changedBy = currentUserProvider.requireCurrentUserId(),
+        ) ?: return SetAttendance.Response404(Unit)
 
         val member = attendanceService.findMember(userId)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -1,7 +1,6 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
-import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
@@ -38,7 +37,6 @@ class EventController(
     private val attendanceService: AttendanceService,
     private val currentUserProvider: CurrentUserProvider,
     private val currentTeamProvider: CurrentTeamProvider,
-    private val authorizationService: AuthorizationService,
 ) : ListEvents.Handler,
     CreateEvent.Handler,
     GetEvent.Handler,
@@ -57,10 +55,10 @@ class EventController(
     override suspend fun createEvent(request: CreateEvent.Request): CreateEvent.Response<*> {
         val teamId = currentTeamProvider.requireCurrentTeamId()
         val userId = currentUserProvider.requireCurrentUserId()
-        authorizationService.requireAdmin(userId, teamId)
         val event = eventService.createEvent(
+            callerId = userId,
+            teamId = teamId,
             potential = request.body.consume(),
-            createdBy = userId,
         )
         return CreateEvent.Response201(
             event.produce(attendanceService.attendanceFor(event.id, attendanceService.teamMembers(teamId))),
@@ -96,10 +94,12 @@ class EventController(
     // EventList of the affected occurrences. The scope query param defaults to THIS when absent.
     override suspend fun updateEvent(request: UpdateEvent.Request): UpdateEvent.Response<*> {
         val teamId = currentTeamProvider.requireCurrentTeamId()
-        authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), teamId)
+        val userId = currentUserProvider.requireCurrentUserId()
         val id = UUID.fromString(request.path.id)
         val req = request.body
         val events = eventService.updateEvent(
+            callerId = userId,
+            teamId = teamId,
             id = id,
             scope = request.queries.scope.consume(),
             eventTypeId = UUID.fromString(req.eventTypeId),
@@ -117,9 +117,10 @@ class EventController(
     }
 
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
-        authorizationService.requireAdmin(currentUserProvider.requireCurrentUserId(), currentTeamProvider.requireCurrentTeamId())
+        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserProvider.requireCurrentUserId()
         val id = UUID.fromString(request.path.id)
-        return if (eventService.deleteEvent(id, request.queries.scope.consume())) {
+        return if (eventService.deleteEvent(callerId = userId, teamId = teamId, id = id, scope = request.queries.scope.consume())) {
             DeleteEvent.Response204(Unit)
         } else {
             DeleteEvent.Response404(Unit)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -1,6 +1,5 @@
 package com.github.zzave.teambalance.api.interfaces
 
-import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.InvitationService
@@ -17,7 +16,6 @@ class InvitationController(
     private val invitationService: InvitationService,
     private val currentUserProvider: CurrentUserProvider,
     private val currentTeamProvider: CurrentTeamProvider,
-    private val authorizationService: AuthorizationService,
 ) : CreateInvitation.Handler,
     AcceptInvitation.Handler,
     ExpireInvitations.Handler,
@@ -26,9 +24,8 @@ class InvitationController(
     override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
         val teamId = currentTeamProvider.requireCurrentTeamId()
-        authorizationService.requireAdmin(userId, teamId)
 
-        val invitation = invitationService.generateInviteLink(teamId = teamId, createdBy = userId)
+        val invitation = invitationService.generateInviteLink(callerId = userId, teamId = teamId)
         return CreateInvitation.Response201(
             Invitation(
                 token = invitation.token,
@@ -47,18 +44,16 @@ class InvitationController(
     override suspend fun expireInvitations(request: ExpireInvitations.Request): ExpireInvitations.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
         val teamId = currentTeamProvider.requireCurrentTeamId()
-        authorizationService.requireAdmin(userId, teamId)
 
-        invitationService.expireActiveInvitations(teamId)
+        invitationService.expireActiveInvitations(callerId = userId, teamId = teamId)
         return ExpireInvitations.Response204(Unit)
     }
 
     override suspend fun rotateInvitation(request: RotateInvitation.Request): RotateInvitation.Response<*> {
         val userId = currentUserProvider.requireCurrentUserId()
         val teamId = currentTeamProvider.requireCurrentTeamId()
-        authorizationService.requireAdmin(userId, teamId)
 
-        val invitation = invitationService.rotateInviteLink(teamId = teamId, createdBy = userId)
+        val invitation = invitationService.rotateInviteLink(callerId = userId, teamId = teamId)
         return RotateInvitation.Response201(
             Invitation(
                 token = invitation.token,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
@@ -1,7 +1,6 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
-import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
@@ -23,18 +22,18 @@ class RecurringEventController(
     private val attendanceService: AttendanceService,
     private val currentUserProvider: CurrentUserProvider,
     private val currentTeamProvider: CurrentTeamProvider,
-    private val authorizationService: AuthorizationService,
 ) : CreateRecurringEvents.Handler {
 
-    // Admin-only, mirroring single-event create. Season/cap/empty violations surface as 422 via the
-    // GlobalExceptionHandler; a non-admin surfaces as 403.
+    // Admin-only, mirroring single-event create — enforced in EventService.createRecurringEvents.
+    // Season/cap/empty violations surface as 422 via the GlobalExceptionHandler; a non-admin as 403.
     override suspend fun createRecurringEvents(request: CreateRecurringEvents.Request): CreateRecurringEvents.Response<*> {
         val teamId = currentTeamProvider.requireCurrentTeamId()
         val userId = currentUserProvider.requireCurrentUserId()
-        authorizationService.requireAdmin(userId, teamId)
 
         val body = request.body
         val series = eventService.createRecurringEvents(
+            callerId = userId,
+            teamId = teamId,
             eventTypeId = UUID.fromString(body.eventTypeId),
             title = body.title,
             description = body.description,
@@ -43,7 +42,6 @@ class RecurringEventController(
             durationMinutes = body.durationMinutes,
             references = body.references.internalize(),
             recurrence = body.recurrence.consume(),
-            createdBy = userId,
         )
 
         // Attendance is derived from current team membership at read time (#114), so the created

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.exception.NoTeamMembershipException
 import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
@@ -64,6 +65,29 @@ class AuthorizationServiceTest : FunSpec() {
         test("requireAdmin throws NotTeamAdminException for a non-admin") {
             shouldThrow<NotTeamAdminException> {
                 service.requireAdmin(memberId, teamId)
+            }
+        }
+
+        test("isMember is true for any active member of that team, admin or not") {
+            service.isMember(adminId, teamId) shouldBe true
+            service.isMember(memberId, teamId) shouldBe true
+        }
+
+        test("isMember is false for a user with no membership on that team") {
+            service.isMember(strangerId, teamId) shouldBe false
+        }
+
+        test("isMember is false for a member of a different team (cross-team isolation)") {
+            service.isMember(memberId, otherTeamId) shouldBe false
+        }
+
+        test("requireMember passes through silently for a plain (non-admin) member") {
+            service.requireMember(memberId, teamId)
+        }
+
+        test("requireMember throws NoTeamMembershipException for a non-member") {
+            shouldThrow<NoTeamMembershipException> {
+                service.requireMember(strangerId, teamId)
             }
         }
     }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -1,0 +1,133 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
+import com.github.zzave.teambalance.api.domain.model.EventType
+import com.github.zzave.teambalance.api.domain.model.Recurrence
+import com.github.zzave.teambalance.api.domain.model.RecurrenceFrequency
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.port.EventRepository
+import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.SeasonRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+// The write use cases are admin-guarded in the service now (uniform write-authorization seam), so a
+// non-admin caller must be rejected *before* any repository work — these fakes therefore fail loudly
+// if touched, proving the guard short-circuits rather than the call merely erroring downstream.
+private class ExplodingEventRepo : EventRepository {
+    override fun findById(id: UUID): Event? = error("repository must not be reached for an unauthorized caller")
+    override fun findUpcoming(since: Instant): List<Event> = error("unused")
+    override fun findAll(): List<Event> = error("unused")
+    override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
+    override fun save(event: Event): Event = error("unused")
+    override fun deleteById(id: UUID) = error("unused")
+}
+
+private class ExplodingEventTypeRepo : EventTypeRepository {
+    override fun findAll(): List<EventType> = error("unused")
+    override fun findById(id: UUID): EventType? = error("repository must not be reached for an unauthorized caller")
+}
+
+private class ExplodingSeasonRepo : SeasonRepository {
+    override fun get() = error("unused")
+    override fun save(season: com.github.zzave.teambalance.api.domain.model.Season) = error("unused")
+}
+
+// USER for everyone except the seeded admins — models "a real member who simply isn't an admin".
+private class EventFakeMemberRepo(private val admins: Set<UUID>) : TeamMemberRepository {
+    override fun findRole(teamId: UUID, userId: UUID): Role = if (userId in admins) Role.ADMIN else Role.USER
+    override fun findByTeamId(teamId: UUID): List<TeamMember> = emptyList()
+    override fun findDisplayName(userId: UUID): String? = null
+    override fun findMembersByUserIds(userIds: Set<UUID>): Map<UUID, TeamMember> = emptyMap()
+    override fun findTeamId(userId: UUID): UUID? = null
+    override fun addMember(teamId: UUID, userId: UUID) = Unit
+    override fun updateRole(teamId: UUID, userId: UUID, role: Role) = Unit
+    override fun deactivate(teamId: UUID, userId: UUID) = Unit
+    override fun assignPosition(teamId: UUID, userId: UUID, positionId: UUID?) = Unit
+    override fun markOnboarded(teamId: UUID, userId: UUID, at: Instant) = Unit
+    override fun countAdmins(teamId: UUID): Int = admins.size
+}
+
+class EventServiceTest : FunSpec() {
+    init {
+        val teamId = UUID.randomUUID()
+        val nonAdmin = UUID.randomUUID()
+
+        val service = EventService(
+            ExplodingEventRepo(),
+            ExplodingEventTypeRepo(),
+            ExplodingSeasonRepo(),
+            AuthorizationService(EventFakeMemberRepo(admins = emptySet())),
+            Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+        )
+
+        val potential = PotentialEvent(
+            eventTypeId = UUID.randomUUID(),
+            title = "Match",
+            description = null,
+            startTime = Instant.parse("2026-08-01T20:00:00Z"),
+            endTime = Instant.parse("2026-08-01T22:00:00Z"),
+            location = null,
+        )
+
+        test("createEvent by a non-admin is rejected before any repository access") {
+            shouldThrow<NotTeamAdminException> { service.createEvent(nonAdmin, teamId, potential) }
+        }
+
+        test("updateEvent by a non-admin is rejected before any repository access") {
+            shouldThrow<NotTeamAdminException> {
+                service.updateEvent(
+                    callerId = nonAdmin,
+                    teamId = teamId,
+                    id = UUID.randomUUID(),
+                    scope = EventSeriesScope.THIS,
+                    eventTypeId = UUID.randomUUID(),
+                    title = "x",
+                    description = null,
+                    startTime = potential.startTime,
+                    endTime = potential.endTime,
+                    location = null,
+                )
+            }
+        }
+
+        test("deleteEvent by a non-admin is rejected before any repository access") {
+            shouldThrow<NotTeamAdminException> {
+                service.deleteEvent(nonAdmin, teamId, UUID.randomUUID(), EventSeriesScope.THIS)
+            }
+        }
+
+        test("createRecurringEvents by a non-admin is rejected before any repository access") {
+            shouldThrow<NotTeamAdminException> {
+                service.createRecurringEvents(
+                    callerId = nonAdmin,
+                    teamId = teamId,
+                    eventTypeId = UUID.randomUUID(),
+                    title = "Training",
+                    description = null,
+                    location = null,
+                    timeOfDay = LocalTime.of(20, 0),
+                    durationMinutes = 90,
+                    references = emptyList(),
+                    recurrence = Recurrence(
+                        frequency = RecurrenceFrequency.WEEKLY,
+                        weekdays = setOf(DayOfWeek.TUESDAY),
+                        startDate = LocalDate.of(2026, 8, 1),
+                        endDate = LocalDate.of(2026, 8, 31),
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -1,0 +1,96 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
+import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+// Records saves and always resolves a live invitation for the accept path (token hashing is not the
+// subject here — authorization is).
+private class FakeInvitationRepo(private val live: Invitation) : InvitationRepository {
+    val saved = mutableListOf<Invitation>()
+    var expiredTeam: UUID? = null
+    override fun save(invitation: Invitation): Invitation { saved += invitation; return invitation }
+    override fun findByTokenHash(tokenHash: String): Invitation = live
+    override fun expireActive(teamId: UUID, now: Instant) { expiredTeam = teamId }
+}
+
+// USER for everyone except the seeded admins; records joins so the open accept path can be asserted.
+private class InviteFakeMemberRepo(private val admins: Set<UUID>) : TeamMemberRepository {
+    val joined = mutableListOf<Pair<UUID, UUID>>()
+    override fun findRole(teamId: UUID, userId: UUID): Role = if (userId in admins) Role.ADMIN else Role.USER
+    override fun addMember(teamId: UUID, userId: UUID) { joined += teamId to userId }
+    override fun findByTeamId(teamId: UUID): List<TeamMember> = emptyList()
+    override fun findDisplayName(userId: UUID): String? = null
+    override fun findMembersByUserIds(userIds: Set<UUID>): Map<UUID, TeamMember> = emptyMap()
+    override fun findTeamId(userId: UUID): UUID? = null
+    override fun updateRole(teamId: UUID, userId: UUID, role: Role) = Unit
+    override fun deactivate(teamId: UUID, userId: UUID) = Unit
+    override fun assignPosition(teamId: UUID, userId: UUID, positionId: UUID?) = Unit
+    override fun markOnboarded(teamId: UUID, userId: UUID, at: Instant) = Unit
+    override fun countAdmins(teamId: UUID): Int = admins.size
+}
+
+class InvitationServiceTest : FunSpec() {
+    init {
+        val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+        val teamId = UUID.randomUUID()
+        val adminId = UUID.randomUUID()
+        val nonAdmin = UUID.randomUUID()
+
+        val liveInvitation = Invitation(
+            id = UUID.randomUUID(),
+            teamId = teamId,
+            tokenHash = "hash",
+            createdBy = adminId,
+            expiresAt = Instant.EPOCH.plus(Duration.ofDays(1)),
+            createdAt = Instant.EPOCH,
+        )
+
+        fun newService(): Triple<InvitationService, FakeInvitationRepo, InviteFakeMemberRepo> {
+            val invitations = FakeInvitationRepo(liveInvitation)
+            val members = InviteFakeMemberRepo(admins = setOf(adminId))
+            val service = InvitationService(invitations, members, AuthorizationService(members), clock, "salt")
+            return Triple(service, invitations, members)
+        }
+
+        test("generateInviteLink by a non-admin is forbidden") {
+            val (service, _, _) = newService()
+            shouldThrow<NotTeamAdminException> { service.generateInviteLink(callerId = nonAdmin, teamId = teamId) }
+        }
+
+        test("expireActiveInvitations by a non-admin is forbidden") {
+            val (service, _, _) = newService()
+            shouldThrow<NotTeamAdminException> { service.expireActiveInvitations(callerId = nonAdmin, teamId = teamId) }
+        }
+
+        test("rotateInviteLink by a non-admin is forbidden") {
+            val (service, _, _) = newService()
+            shouldThrow<NotTeamAdminException> { service.rotateInviteLink(callerId = nonAdmin, teamId = teamId) }
+        }
+
+        test("generateInviteLink by an admin mints a link attributed to the caller") {
+            val (service, invitations, _) = newService()
+            val result = service.generateInviteLink(callerId = adminId, teamId = teamId)
+            result.token.isNotBlank() shouldBe true
+            invitations.saved.single().createdBy shouldBe adminId
+        }
+
+        test("acceptInvitation requires no admin role — any authenticated user may join") {
+            val (service, _, members) = newService()
+            val joinedTeam = service.acceptInvitation(token = "anything", userId = nonAdmin)
+            joinedTeam shouldBe teamId
+            members.joined shouldBe listOf(teamId to nonAdmin)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceAuthorizationIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceAuthorizationIT.kt
@@ -1,0 +1,130 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+/**
+ * Attendance editing is trust-based *within a team* (ADR-0003): any member may edit another member's
+ * attendance. That trust stops at the team boundary — a caller must not be able to write attendance
+ * for a `userId` that is not a member of their resolved team. This is the membership/tenant gate that
+ * was previously missing on the write path (the tenant schema alone did not scope the target user).
+ *
+ * Following AttendanceControllerTest's cross-team pattern: teams carry unique schema names, the
+ * caller's resolved team id comes from their own membership, while the event lives in the
+ * `public`-pinned schema (the X-Team-Id test shim), so only the *target user's* membership is in play.
+ */
+@AutoConfigureMockMvc
+class AttendanceAuthorizationIT : TeamBalanceIT() {
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var jdbcTemplate: JdbcTemplate
+    @Autowired lateinit var tenantSchemaManager: TenantSchemaManager
+
+    init {
+        test("setAttendance for a user outside the caller's team is rejected with 403") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            // The caller is an ordinary member of their own team.
+            val callerTeamId = UUID.randomUUID()
+            val callerId = newTeamMember(callerTeamId, "caller@test.com", "Cara Caller")
+
+            // The outsider belongs to a *different* team — not the caller's.
+            val otherTeamId = UUID.randomUUID()
+            val outsiderId = newTeamMember(otherTeamId, "outsider@test.com", "Otto Outsider")
+
+            // A real event in the caller's tenant, so only the target-user membership is in question.
+            val eventId = insertEvent(callerId)
+
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$outsiderId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"state":"ATTENDING"}""")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", callerId),
+            ).andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(result))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("NO_TEAM_MEMBERSHIP"))
+
+            // And nothing was written for the outsider.
+            attendanceRowCount(eventId, outsiderId) shouldBe 0
+        }
+
+        test("setAttendance for a fellow team member still succeeds (trust-based editing, ADR-0003)") {
+            tenantSchemaManager.provisionPlatformSchema()
+            tenantSchemaManager.provisionTenantSchema("public")
+
+            val teamId = UUID.randomUUID()
+            val callerId = newTeamMember(teamId, "editor2@test.com", "Ed Editor")
+            val teammateId = joinTeam(teamId, "mate2@test.com", "Tina Teammate")
+
+            val eventId = insertEvent(callerId)
+
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$teammateId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"state":"ATTENDING"}""")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", callerId),
+            ).andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(result))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+
+            attendanceRowCount(eventId, teammateId) shouldBe 1
+        }
+    }
+
+    // Creates a team (with a unique schema mapping) and joins a brand-new USER to it.
+    private fun newTeamMember(teamId: UUID, email: String, name: String): String {
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, sport, schema_name)
+            VALUES ('$teamId'::uuid, 'Team $teamId', 'authz-$teamId', 'Volleyball', 'authz-$teamId')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        return joinTeam(teamId, email, name)
+    }
+
+    private fun joinTeam(teamId: UUID, email: String, name: String): String {
+        val userId = UUID.randomUUID().toString()
+        jdbcTemplate.execute(
+            "INSERT INTO public.users (id, email, display_name) VALUES ('$userId'::uuid, '$email', '$name') ON CONFLICT DO NOTHING",
+        )
+        jdbcTemplate.execute("SELECT public.tb_add_member('$teamId'::uuid, '$userId'::uuid, 'USER', 'Setter')")
+        return userId
+    }
+
+    private fun insertEvent(createdBy: String): UUID {
+        val eventId = UUID.randomUUID()
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+            VALUES ('$eventId'::uuid,
+                (SELECT id FROM public.event_types WHERE name = 'Training'),
+                'Authz Test', '2050-07-01 20:00:00+00', '2050-07-01 22:00:00+00',
+                '$createdBy'::uuid, now(), now())
+            """,
+        )
+        return eventId
+    }
+
+    private fun attendanceRowCount(eventId: UUID, userId: String): Int =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM public.attendances a JOIN public.events e ON e.id = a.event_id " +
+                "WHERE e.uuid = '$eventId'::uuid AND a.user_id = '$userId'::uuid",
+            Long::class.java,
+        )!!.toInt()
+}


### PR DESCRIPTION
## Why

Write-authorization was enforced at **inconsistent depths** and one path had **no gate at all**:

- **Controller-level:** `EventController`, `InvitationController` (the `requireAdmin` prelude hand-rolled three times), `RecurringEventController`.
- **Service-level:** `MemberService`, `SeasonService`, `PositionService`.
- **Absent:** `AttendanceController.setAttendance`.

There was no single answer to *"where is write-authorization enforced?"*.

## The `setAttendance` gap was real (IDOR-shaped)

`setAttendance` took both `eventId` and `userId` from the request path and used the authenticated principal only as `changedBy`. Nothing verified the caller could write attendance for that path `userId` — only tenant schema routing scoped the write, which the target `userId` sidesteps.

Proven with a failing MockMvc/Testcontainers test **before** any fix: a caller could set attendance (**HTTP 200**) for a `userId` outside their team. It now returns **403** and writes nothing. (Cross-tenant *events* were already hidden as 404 by schema routing; the foreign *target user* against an in-tenant event was not.)

Attendance editing stays trust-based within a team (ADR-0003) — any member may edit a fellow member's attendance — so the gate is **membership, not admin**. Trust stops at the team boundary.

## What changed (authorization lines only)

- **`AuthorizationService`** — add `isMember` / `requireMember` alongside `isAdmin` / `requireAdmin`. Fail-closed; a non-member throws `NoTeamMembershipException` → 403 via the existing `GlobalExceptionHandler`.
- **`AttendanceService.setAttendance`** — takes the server-resolved `teamId`, gates the target `userId` on team membership first.
- **`EventService`** (create/update/delete/recurring) and **`InvitationService`** (generate/expire/rotate) — `requireAdmin` pushed down so every write use case is self-protecting. `acceptInvitation` stays open (the join flow).
- **Controllers** (`Attendance`, `Event`, `Invitation`, `Recurring`) — stop hand-rolling the prelude and drop the now-unused `AuthorizationService` injection. They only resolve the authenticated principal + server-resolved tenant and pass them down. **HTTP statuses unchanged.**

**Result: one enforcement point — the application layer.** `callerId`/`teamId` are never client-supplied (`teamId` comes from `CurrentTeamContext`, set by `SessionTenantContextFilter` from the caller's own membership row — the same row that pins the tenant schema).

## Testing (lowest layer that proves each behaviour)

- `AttendanceAuthorizationIT` — regression guard: outsider → 403, teammate → 200 (Testcontainers, the new cross-team write seam).
- `AuthorizationServiceTest` — extended with `isMember` / `requireMember` (pure).
- `EventServiceTest`, `InvitationServiceTest` — new pure units proving each relocated guard rejects non-admins at the service layer, and that `acceptInvitation` stays open.
- Existing controller ITs (events/invitations/recurring non-admin → 403) stay green — proof the relocated guard still fires from its new home.

`make test-api`: **245 tests, 0 failures**. detekt: clean. `security-review` skill over the diff: **no new vulnerabilities**.

No new e2e: the change introduces no new auth *seam* beyond what the existing login/attendance flows and the ITs above already exercise.

## Sibling-branch overlap

Touches `EventController` / `RecurringEventController` (candidate #1) and `EventService` (candidate #2), but only authorization lines — the rebase should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdmFuH2w9pQA1V53sM5T5e