### PR TITLE
fix: silence Vite %VITE_API_URL% warning in dev/e2e

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -1,0 +1,5 @@
+# Dev/e2e run `vite` in development mode and talk to the backend through the Vite proxy
+# (/api → localhost:8080), so the SPA is same-origin and needs no API base URL. Defining it
+# empty (rather than leaving it unset) lets Vite substitute %VITE_API_URL% in index.html to ""
+# instead of warning that it's undefined. Prod's split-origin URL lives in .env.production.
+VITE_API_URL=

--- a/app/index.html
+++ b/app/index.html
@@ -8,8 +8,8 @@
       Cold-start wake-up. The prod backend scales to zero, so kick it awake as early as possible —
       during HTML parse, before the JS bundle even downloads — so the container is already warming
       by the time the session probe runs. Fire-and-forget against the cheap public /api/ping (204,
-      no DB, no auth). Vite substitutes %VITE_API_URL% at build; in dev it's left unsubstituted and
-      we fall back to a relative URL (same-origin via the Vite proxy). Prod is split-origin
+      no DB, no auth). Vite substitutes %VITE_API_URL% at build; dev/e2e define it empty so it
+      resolves to a relative URL (same-origin via the Vite proxy). Prod is split-origin
       (app.teambalance.nl → api.teambalance.nl), so we also warm DNS/TLS with a preconnect.
     -->
     <script>


### PR DESCRIPTION
## What

Adds `app/.env.development` defining `VITE_API_URL=` (empty) and updates the `index.html` comment to match.

## Why

`app/index.html` uses Vite's HTML env substitution `%VITE_API_URL%` (for the cold-start wake-up preconnect). The variable was only defined in `.env.production`, so under `npm run dev` — development mode, used by both `make app` and the e2e `webServer` — Vite couldn't find it in the loaded env and logged this on every HTML transform:

```
(!) %VITE_API_URL% is not defined in env variables found in /index.html. Is the variable mistyped?
```

It was harmless noise (the runtime already guards with `api.charAt(0) === '%'`, so all tests passed), but it spammed the e2e output. Defining the variable empty in development mirrors the existing `.env.production` and lets Vite substitute the placeholder to `""` instead of warning.

## Behavior

Unchanged. Empty base URL → relative requests → the Vite proxy (`/api → localhost:8080`), exactly as before. `wirespec-client.ts` uses `?? ''`, and the served `index.html` now emits `var api = ''`.

## Verification

- Booted the dev server standalone: **0** `VITE_API_URL is not defined` warnings; served HTML shows `var api = ''`.
- Pre-push gate all green: detekt, `:api:test`, 228 Vitest tests, and the real `make e2e` suite (7 passed) — e2e log now free of the warning.

No new test added: this is log-noise only with no behavior change and no new seam (per the PR gate in CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)