### PR TITLE
test: shells-down + prop-contract spies for members/settings/invite/recurring (#133)

### DIFF
--- a/app/src/features/create-recurring-events/ui/RecurringEventsWizard.stories.tsx
+++ b/app/src/features/create-recurring-events/ui/RecurringEventsWizard.stories.tsx
@@ -75,6 +75,20 @@ export const OverCap: Story = {
   },
 }
 
+// Prop-contract: walking the wizard to the end and confirming fires onSubmit with the assembled
+// request — the chosen type + auto-filled title carry through the three steps to the mutation.
+export const CreateSeries: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await chooseTraining(canvas, userEvent)
+    await userEvent.click(canvas.getByRole('button', { name: /Next/ }))
+    await userEvent.click(canvas.getByRole('button', { name: /Next/ }))
+    await userEvent.click(canvas.getByRole('button', { name: /Create/ }))
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ eventTypeId: 'et-1', title: 'Training' }),
+    )
+  },
+}
+
 // Submitting — the confirm button reflects the pending mutation.
 export const Submitting: Story = {
   args: { isPending: true },

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
@@ -59,6 +59,24 @@ export const Generated: Story = {
   },
 }
 
+// Prop-contract: rotating the link fires onRotate — the container swaps in a fresh token.
+export const RotateLink: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Rotate link' }))
+    await expect(args.onRotate).toHaveBeenCalled()
+  },
+}
+
+// Prop-contract: expiring the link fires onExpire — the container invalidates the token.
+export const ExpireLink: Story = {
+  args: { isPending: false, isError: false, link: LINK, copied: false },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Expire link' }))
+    await expect(args.onExpire).toHaveBeenCalled()
+  },
+}
+
 export const Copied: Story = {
   args: { isPending: false, isError: false, link: LINK, copied: true },
   play: async ({ canvas }) => {

--- a/app/src/features/manage-members/ui/MemberRoster.tsx
+++ b/app/src/features/manage-members/ui/MemberRoster.tsx
@@ -5,8 +5,9 @@ import { MemberRosterView } from './MemberRosterView'
 
 /**
  * Container for the admin roster: wires the members query and the update/remove mutations to the
- * presentational MemberRosterView, and handles the loading/error shells. Promote/demote reuses the
- * update mutation with the toggled role and the unchanged display name.
+ * presentational MemberRosterView. Pure wiring — the load/error/data shells live in the View
+ * (props-driven), so this seam is covered by e2e, not a story. Promote/demote reuses the update
+ * mutation with the toggled role and the unchanged display name. See ADR-0017.
  */
 export function MemberRoster() {
   const { data: members, isLoading, error } = useMembers()
@@ -28,39 +29,30 @@ export function MemberRoster() {
       : null
 
   return (
-    <div>
-      <h2 className="font-display text-2xl font-bold">Members</h2>
-
-      {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
-      {error && <p className="mt-4 text-sm text-red-500">Couldn't load members. Please try again.</p>}
-
-      {members && (
-        <div className="mt-4">
-          <MemberRosterView
-            members={members}
-            positions={positions ?? []}
-            savingUserId={savingUserId}
-            errorMessage={activeError?.message ?? null}
-            onRename={(userId, displayName) => {
-              const member = members.find((m) => m.userId === userId)
-              if (member)
-                updateMember.mutate({ userId, displayName, role: member.role, positionId: member.position?.id ?? null })
-            }}
-            onToggleRole={(member) =>
-              updateMember.mutate({
-                userId: member.userId,
-                displayName: member.displayName,
-                role: toggleRole(member.role),
-                positionId: member.position?.id ?? null,
-              })
-            }
-            onChangePosition={(member, positionId) =>
-              updateMember.mutate({ userId: member.userId, displayName: member.displayName, role: member.role, positionId })
-            }
-            onRemove={(member) => removeMember.mutate({ userId: member.userId })}
-          />
-        </div>
-      )}
-    </div>
+    <MemberRosterView
+      members={members}
+      positions={positions ?? []}
+      isLoading={isLoading}
+      isError={!!error}
+      savingUserId={savingUserId}
+      errorMessage={activeError?.message ?? null}
+      onRename={(userId, displayName) => {
+        const member = members?.find((m) => m.userId === userId)
+        if (member)
+          updateMember.mutate({ userId, displayName, role: member.role, positionId: member.position?.id ?? null })
+      }}
+      onToggleRole={(member) =>
+        updateMember.mutate({
+          userId: member.userId,
+          displayName: member.displayName,
+          role: toggleRole(member.role),
+          positionId: member.position?.id ?? null,
+        })
+      }
+      onChangePosition={(member, positionId) =>
+        updateMember.mutate({ userId: member.userId, displayName: member.displayName, role: member.role, positionId })
+      }
+      onRemove={(member) => removeMember.mutate({ userId: member.userId })}
+    />
   )
 }

--- a/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
@@ -36,6 +36,23 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+export const Loading: Story = {
+  args: { isLoading: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Loading…')).toBeInTheDocument()
+    // The roster is suppressed while the query is in flight — no rows yet.
+    await expect(canvas.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Couldn't load members. Please try again.")).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+  },
+}
+
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByLabelText('Display name for Ada Lovelace')).toHaveValue('Ada Lovelace')
@@ -75,6 +92,40 @@ export const RemoveConfirmOpen: Story = {
     const dialog = within(document.body)
     await expect(await dialog.findByText(/Remove Alan Turing from the team/)).toBeInTheDocument()
     await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  },
+}
+
+// Prop-contract: editing a row's name surfaces its Save button; clicking it fires onRename with the
+// member's id and the trimmed new name — proving the rename wiring survives a dependency bump.
+export const RenameMember: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    const field = canvas.getByLabelText('Display name for Grace Hopper')
+    await userEvent.clear(field)
+    await userEvent.type(field, 'Grace M. Hopper')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+    await expect(args.onRename).toHaveBeenCalledWith('u2', 'Grace M. Hopper')
+  },
+}
+
+// Prop-contract: promoting/demoting reuses the update mutation — the first "Make member" (the first
+// admin, Ada) fires onToggleRole with that member.
+export const ToggleRole: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Make member' })[0])
+    await expect(args.onToggleRole).toHaveBeenCalledWith(MEMBERS[0])
+  },
+}
+
+// Prop-contract: a row Remove opens the confirm dialog (a portal); confirming there fires onRemove
+// with the member. The row buttons go aria-hidden while the modal is open, so the dialog's Remove is
+// unambiguous.
+export const RemoveMember: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Remove' })[0])
+    const dialog = within(document.body)
+    await expect(await dialog.findByText(/Remove Ada Lovelace from the team/)).toBeInTheDocument()
+    await userEvent.click(dialog.getByRole('button', { name: 'Remove' }))
+    await expect(args.onRemove).toHaveBeenCalledWith(MEMBERS[0])
   },
 }
 

--- a/app/src/features/manage-members/ui/MemberRosterView.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.tsx
@@ -15,9 +15,13 @@ import {
 import { isLastAdmin } from '../lib/roster'
 
 interface MemberRosterViewProps {
-  members: Member[]
+  members?: Member[]
   /** The team's position vocabulary, offered per row so an admin can (re)assign a member. */
   positions: Position[]
+  /** The members query is in flight — render the loading shell instead of the roster. */
+  isLoading?: boolean
+  /** The members query failed — render the error shell instead of the roster. */
+  isError?: boolean
   /** userId currently mid-mutation — its row's actions show a pending/disabled state. */
   savingUserId?: string | null
   /** A refusal surfaced by the container (e.g. LAST_ADMIN); shown as an inline banner. */
@@ -29,13 +33,19 @@ interface MemberRosterViewProps {
 }
 
 /**
- * Presentational admin roster. Owns only local view state (per-row name edits + the remove-confirm
- * dialog target); the queries and mutations live in the MemberRoster container. Props-only, so
- * every state (roster, confirm dialog open, last-admin refusal) renders as a story.
+ * Presentational admin roster — the complete section, heading and all. Owns only local view state
+ * (per-row name edits + the remove-confirm dialog target); the queries and mutations live in the
+ * MemberRoster container.
+ *
+ * The load/error/data shells are props-driven (isLoading / isError) rather than lived in the
+ * container, so every state — loading / error / roster / confirm dialog open / last-admin refusal —
+ * renders purely from props as a story, with no network. See ADR-0017.
  */
 export function MemberRosterView({
-  members,
+  members = [],
   positions,
+  isLoading,
+  isError,
   savingUserId,
   errorMessage,
   onRename,
@@ -46,53 +56,64 @@ export function MemberRosterView({
   const [confirmTarget, setConfirmTarget] = useState<Member | null>(null)
 
   return (
-    <div className="flex flex-col gap-3">
-      {errorMessage && (
-        <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
-          {errorMessage}
-        </p>
+    <div>
+      <h2 className="font-display text-2xl font-bold">Members</h2>
+
+      {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
+      {isError && (
+        <p className="mt-4 text-sm text-red-500">Couldn't load members. Please try again.</p>
       )}
 
-      <ul className="divide-y divide-border rounded-lg border border-border">
-        {members.map((member) => (
-          <MemberRow
-            key={member.userId}
-            member={member}
-            positions={positions}
-            lastAdmin={isLastAdmin(members, member.userId)}
-            isSaving={savingUserId === member.userId}
-            onRename={onRename}
-            onToggleRole={onToggleRole}
-            onChangePosition={onChangePosition}
-            onRequestRemove={setConfirmTarget}
-          />
-        ))}
-      </ul>
+      {!isLoading && !isError && (
+        <div className="mt-4 flex flex-col gap-3">
+          {errorMessage && (
+            <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+              {errorMessage}
+            </p>
+          )}
 
-      <Dialog open={confirmTarget !== null} onOpenChange={(open) => { if (!open) setConfirmTarget(null) }}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove member</DialogTitle>
-            <DialogDescription>
-              Remove {confirmTarget?.displayName} from the team? They will lose access until re-invited.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmTarget(null)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                if (confirmTarget) onRemove(confirmTarget)
-                setConfirmTarget(null)
-              }}
-            >
-              Remove
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {members.map((member) => (
+              <MemberRow
+                key={member.userId}
+                member={member}
+                positions={positions}
+                lastAdmin={isLastAdmin(members, member.userId)}
+                isSaving={savingUserId === member.userId}
+                onRename={onRename}
+                onToggleRole={onToggleRole}
+                onChangePosition={onChangePosition}
+                onRequestRemove={setConfirmTarget}
+              />
+            ))}
+          </ul>
+
+          <Dialog open={confirmTarget !== null} onOpenChange={(open) => { if (!open) setConfirmTarget(null) }}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Remove member</DialogTitle>
+                <DialogDescription>
+                  Remove {confirmTarget?.displayName} from the team? They will lose access until re-invited.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setConfirmTarget(null)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    if (confirmTarget) onRemove(confirmTarget)
+                    setConfirmTarget(null)
+                  }}
+                >
+                  Remove
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/src/features/team-settings/ui/TeamSettings.tsx
+++ b/app/src/features/team-settings/ui/TeamSettings.tsx
@@ -3,19 +3,19 @@ import { TeamSettingsView } from './TeamSettingsView'
 
 /**
  * Container for team settings: wires the season query and the SetSeason mutation to the
- * presentational TeamSettingsView, and handles the loading/error shells. Admin-gating is enforced
- * on the route (beforeLoad) and again on the backend (403), so this component assumes an admin.
+ * presentational TeamSettingsView. Pure wiring — the load/error/data shells live in the View
+ * (props-driven), so this seam is covered by e2e, not a story. Admin-gating is enforced on the route
+ * (beforeLoad) and again on the backend (403), so this component assumes an admin. See ADR-0017.
  */
 export function TeamSettings() {
   const { data: season, isLoading, error } = useSeason()
   const setSeason = useSetSeason()
 
-  if (isLoading) return <p className="text-sm text-muted-foreground">Loading…</p>
-  if (error || !season) return <p className="text-sm text-red-500">Couldn't load team settings. Please try again.</p>
-
   return (
     <TeamSettingsView
-      season={{ start: season.start, end: season.end }}
+      season={season ? { start: season.start, end: season.end } : undefined}
+      isLoading={isLoading}
+      isError={!!error}
       isSaving={setSeason.isPending}
       error={setSeason.error ? 'Could not save the season. Please try again.' : null}
       onSave={(bounds) => setSeason.mutate(bounds)}

--- a/app/src/features/team-settings/ui/TeamSettingsView.stories.tsx
+++ b/app/src/features/team-settings/ui/TeamSettingsView.stories.tsx
@@ -15,6 +15,23 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+export const Loading: Story = {
+  args: { isLoading: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Loading…')).toBeInTheDocument()
+    // The form is suppressed while the query is in flight — no save control yet.
+    await expect(canvas.queryByRole('button', { name: 'Save season' })).not.toBeInTheDocument()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Couldn't load team settings. Please try again.")).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Save season' })).not.toBeInTheDocument()
+  },
+}
+
 export const Unset: Story = {
   args: { season: {} },
   play: async ({ canvas }) => {

--- a/app/src/features/team-settings/ui/TeamSettingsView.tsx
+++ b/app/src/features/team-settings/ui/TeamSettingsView.tsx
@@ -6,8 +6,12 @@ import type { SeasonInput } from '@shared/api/season'
 import { isSeasonConfigured, seasonChanged, validateSeasonRange, type SeasonBounds } from '../lib/season'
 
 interface TeamSettingsViewProps {
-  /** The saved season (the baseline the draft is compared against). */
-  season: SeasonBounds
+  /** The saved season (the baseline the draft is compared against); defaults to an unset season. */
+  season?: SeasonBounds
+  /** The season query is in flight — render the loading shell instead of the form. */
+  isLoading?: boolean
+  /** The season query failed — render the error shell instead of the form. */
+  isError?: boolean
   isSaving?: boolean
   /** Backend error surfaced from the container (e.g. a rejected save), shown inline. */
   error?: string | null
@@ -15,12 +19,15 @@ interface TeamSettingsViewProps {
 }
 
 /**
- * Presentational Team Settings UI: the season start/end pickers. Owns only local draft state; the
- * query + mutation live in the TeamSettings container, so every state (unset / set / change-warning)
- * renders purely from props (see TeamSettingsView.stories.tsx). Editing an already-configured season
- * surfaces a non-blocking warning — changing the window never moves or deletes existing events.
+ * Presentational Team Settings UI — the complete section, heading and all: the season start/end
+ * pickers. Owns only local draft state; the query + mutation live in the TeamSettings container.
+ *
+ * The load/error/data shells are props-driven (isLoading / isError) rather than lived in the
+ * container, so every state — loading / error / unset / set / change-warning — renders purely from
+ * props as a story (see TeamSettingsView.stories.tsx), with no network. Editing an already-configured
+ * season surfaces a non-blocking warning — changing the window never moves or deletes existing events.
  */
-export function TeamSettingsView({ season, isSaving, error, onSave }: TeamSettingsViewProps) {
+export function TeamSettingsView({ season = {}, isLoading, isError, isSaving, error, onSave }: TeamSettingsViewProps) {
   const [start, setStart] = useState(season.start ?? '')
   const [end, setEnd] = useState(season.end ?? '')
 
@@ -44,50 +51,59 @@ export function TeamSettingsView({ season, isSaving, error, onSave }: TeamSettin
         </p>
       </div>
 
-      {!isSeasonConfigured(season) && !dirty && (
-        <p className="text-sm text-muted-foreground">No season set — events can be scheduled on any date.</p>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {isError && (
+        <p className="text-sm text-red-500">Couldn't load team settings. Please try again.</p>
       )}
 
-      <div className="flex flex-wrap gap-4">
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="season-start">Start date</Label>
-          <Input
-            id="season-start"
-            type="date"
-            value={start}
-            max={end || undefined}
-            onChange={(e) => setStart(e.target.value)}
-            className="w-48"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="season-end">End date</Label>
-          <Input
-            id="season-end"
-            type="date"
-            value={end}
-            min={start || undefined}
-            onChange={(e) => setEnd(e.target.value)}
-            className="w-48"
-          />
-        </div>
-      </div>
+      {!isLoading && !isError && (
+        <>
+          {!isSeasonConfigured(season) && !dirty && (
+            <p className="text-sm text-muted-foreground">No season set — events can be scheduled on any date.</p>
+          )}
 
-      {rangeError && <p className="text-sm text-red-500">{rangeError}</p>}
+          <div className="flex flex-wrap gap-4">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="season-start">Start date</Label>
+              <Input
+                id="season-start"
+                type="date"
+                value={start}
+                max={end || undefined}
+                onChange={(e) => setStart(e.target.value)}
+                className="w-48"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="season-end">End date</Label>
+              <Input
+                id="season-end"
+                type="date"
+                value={end}
+                min={start || undefined}
+                onChange={(e) => setEnd(e.target.value)}
+                className="w-48"
+              />
+            </div>
+          </div>
 
-      {showWarning && !rangeError && (
-        <p className="rounded-lg border border-gold/40 bg-gold/10 px-3 py-2 text-sm text-foreground" role="alert">
-          Changing the season won't move or delete existing events — some may now fall outside the new window.
-        </p>
+          {rangeError && <p className="text-sm text-red-500">{rangeError}</p>}
+
+          {showWarning && !rangeError && (
+            <p className="rounded-lg border border-gold/40 bg-gold/10 px-3 py-2 text-sm text-foreground" role="alert">
+              Changing the season won't move or delete existing events — some may now fall outside the new window.
+            </p>
+          )}
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <div>
+            <Button disabled={isSaving || !dirty || !!rangeError} onClick={handleSave}>
+              {isSaving ? 'Saving…' : 'Save season'}
+            </Button>
+          </div>
+        </>
       )}
-
-      {error && <p className="text-sm text-red-500">{error}</p>}
-
-      <div>
-        <Button disabled={isSaving || !dirty || !!rangeError} onClick={handleSave}>
-          {isSaving ? 'Saving…' : 'Save season'}
-        </Button>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What

Continues the **ADR-0017** frontend-testing rollout tracked in #133 — extending the manage-positions exemplar to four more features so more of the app is provable with **no network**. Renovate automerge is only as safe as the coverage that gates it; this widens that coverage.

Two kinds of change, both under `app/`:

### 1. Shells-down (Container/View)
Push the loading/error shells out of the container into the presentational `*View` as props-driven states (`isLoading` / `isError`), default the data prop to empty, move the section `<h2>` into the View, and reduce the container to pure wiring (covered by e2e). Each now gets **Loading** + **ErrorState** stories that render from props alone.

- `features/manage-members`: `MemberRoster` → `MemberRosterView` (`members` defaults to `[]`)
- `features/team-settings`: `TeamSettings` → `TeamSettingsView` (`season` prop now optional, defaulting to `{}`)

### 2. Prop-contract spies
`fn()` spies passed as callback props, asserted with `toHaveBeenCalledWith` in `play` — proving the wiring survives a dependency bump, not just the render.

- `MemberRosterView.stories.tsx`: `onRename`, `onToggleRole`, `onRemove`
- `GenerateInviteContent.stories.tsx`: `onRotate`, `onExpire`
- `RecurringEventsWizard.stories.tsx`: `onSubmit` (asserts `objectContaining` `eventTypeId` + `title` after walking Type → Next → Next → Create)

## Network line

Held — **no MSW in stories**; real API round-trips stay in the two e2e flows. Containers remain thin wiring exercised by e2e per ADR-0017.

## Testing

- `make test-app` green: **241 tests** pass (unit + Storybook browser projects), including all new stories.
- `tsc -b` typecheck + `eslint` clean.
- No new e2e: these changes introduce no new auth path, cross-tenant write, or external integration — the existing login/attendance flows already cover the seams. (The pre-commit hook's `make test-api` fails locally only because Docker/colima isn't running for Testcontainers; this diff is frontend-only.)

## Chromatic

The new stories (MemberRosterView Loading/ErrorState/RenameMember/ToggleRole/RemoveMember, TeamSettingsView Loading/ErrorState, GenerateInviteContent RotateLink/ExpireLink, RecurringEventsWizard CreateSeries) are new snapshots — Chromatic's **"UI Tests"** check will flag them as baselines needing a one-time accept.

Closes part of #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
