### PR TITLE
chore: tighten Renovate config for gated automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": ["config:recommended"],
   "minimumReleaseAge": "14 days",
   "platformAutomerge": true,
+  "dependencyDashboard": true,
+  "semanticCommits": "enabled",
+  "schedule": ["before 9am on wednesday"],
   "packageRules": [
     {
       "description": "Automerge non-major updates. The full CI build + the required Chromatic 'UI Tests' status check are the gate: patch/minor bumps land unattended only when the app still builds, behaves, and looks pixel-identical. See ADR-0017.",
@@ -14,5 +17,9 @@
       "matchUpdateTypes": ["major"],
       "automerge": false
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "description": "CVE fixes bypass the 14-day age gate and the Wednesday schedule (both Renovate defaults for security updates) and are raised immediately, still gated by the CI build + Chromatic 'UI Tests' check. Automerge follows the same update-type policy as everything else: patch/minor land unattended; a security *major* still lands by hand via the major rule above. Requires GitHub 'Dependabot alerts' enabled on the repo, otherwise no security updates are detected.",
+    "automerge": true
+  }
 }


### PR DESCRIPTION
Tightens `renovate.json` on top of the ADR-0017 gated-automerge policy, without loosening the gate. See [ADR-0017](docs/adr/0017-visual-regression-gate-and-gated-renovate-automerge.md).

## Changes
- **`schedule: ["before 9am on wednesday"]`** — batch the merge train into one weekly window, concentrating CI + Chromatic snapshot usage. Bumps already wait out the 14-day age gate, so weekly batching costs no meaningful freshness; GitHub native auto-merge still merges any green PR the moment its checks pass, independent of this window.
- **`semanticCommits: "enabled"`** — pin the `chore(deps):` style the repo already uses (was relying on auto-detection).
- **`dependencyDashboard: true`** — already implicit via `config:recommended`; made explicit in a security-sensitive config.
- **`vulnerabilityAlerts.automerge: true`** — CVE fixes bypass the 14-day age gate and the weekly schedule (both Renovate defaults for security updates) and are raised immediately, still gated by the CI `build` + Chromatic `UI Tests` checks. Patch/minor security fixes automerge; a security **major** still lands by hand via the major rule.

**Automerge policy is unchanged:** patch / minor / pin / digest automerge behind the green gate; **majors always by hand**.

## Requires (out of this PR, admin toggles)
1. **The gate is currently broken** and must be fixed for *any* automerge to work: the `UI Tests` required check is pinned to the Chromatic **GitHub App** (id 47100, already installed), but Chromatic posts the status via its **OAuth** connection (as user `ZzAve`) → GitHub rejects it with *"Required status check UI Tests was not set by the expected GitHub app."* **Fix in Chromatic → project → Manage → GitHub: switch the repo link from the personal OAuth account to the Chromatic GitHub App.** No ruleset change needed after that.
2. **`vulnerabilityAlerts` is inert until GitHub "Dependabot alerts" is enabled** (Settings → Code security) — currently off.

Config validated with `renovate-config-validator` (✅ validated successfully).