### PR TITLE
fix: always run the Chromatic gate on PRs so required checks never hang

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,10 +20,12 @@ on:
     paths:
       - 'app/**'
       - 'design-tokens/**'
+  # No paths filter on PRs — the workflow must always run so the required "UI Tests" /
+  # "chromatic" checks always report. A path-skipped workflow emits no check-run at all, which
+  # a required status check reads as "waiting" forever, blocking backend-only and Renovate PRs
+  # (the exact automerge case ADR-0017 targets). TurboSnap (onlyChanged) keeps a no-app-change
+  # run at 0 snapshots — free and auto-green — so always running costs nothing when nothing moved.
   pull_request:
-    paths:
-      - 'app/**'
-      - 'design-tokens/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Remove the `paths:` filter from the **`pull_request`** trigger in `.github/workflows/chromatic.yml`, so the visual-regression gate always runs on PRs. The `push: main` trigger keeps its `paths:` filter.

## Why

`chromatic` and `UI Tests` are **required** status checks on `main` (ADR-0017, added in #134). But the workflow's PR trigger was filtered to `app/**` / `design-tokens/**`. A PR that touches neither — a backend-only change, or a Renovate Gradle bump — never triggers the workflow, so those two required checks **emit no status at all**. GitHub reads a required context with no check-run as *"waiting"* indefinitely and blocks the PR forever.

That's the exact trap that blocked #135 before it was rebased, and it silently defeats #134's headline goal (*safe Renovate automerge*): backend dependency bumps could never automerge because the visual gate would never report.

## Why this is free / auto-green

The action already runs with `onlyChanged: true` (TurboSnap). When a PR changes nothing that reaches a story:

- TurboSnap captures **0 snapshots** → **$0** Chromatic cost.
- The repo is public → CI minutes are free.
- Chromatic posts **`UI Tests` = success automatically** (no human accept; a human is pulled in only on a real visual delta).

| PR type | Runs? | Snapshots | `UI Tests` |
|---|---|---|---|
| Touches a story | yes | changed stories only | green, or human on diff |
| App change, no visual effect | yes | ~0 | auto-green |
| Backend-only / Renovate | yes | 0 | auto-green |

## Why keep `paths:` on `push: main`

Backend-only commits to `main` don't need a Chromatic build — TurboSnap finds each PR's baseline from the last app-touching ancestor, so the baseline stays correct without a run on every backend commit.

## Note on required checks + path filters

GitHub rulesets can't express "require check X only for path Y" — required checks are per-branch. The conditionality has to live in the workflow, and a top-level `paths:` filter is the wrong lever for a *required* check because a path-skipped workflow produces no check-run (hangs) rather than a skipped-but-successful one. Always-run + TurboSnap is the correct shape.

No test added: this is a CI-trigger change with no app/backend code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)