### PR TITLE
chore: adopt config:best-practices (minus npm 3-day preset) + pin app deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    ":configMigration",
+    ":pinAllExceptPeerDependencies",
+    "abandonments:recommended",
+    ":maintainLockFilesWeekly"
+  ],
   "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
   "platformAutomerge": true,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "schedule": ["before 9am on wednesday"],
   "packageRules": [
     {
-      "description": "Automerge non-major updates. The full CI build + the required Chromatic 'UI Tests' status check are the gate: patch/minor bumps land unattended only when the app still builds, behaves, and looks pixel-identical. See ADR-0017.",
+      "description": "Automerge non-major updates. The full CI build + the required Chromatic 'UI Tests' status check are the gate: patch/minor bumps (and the digest/pin bumps that pinning generates) land unattended only when the app still builds, behaves, and looks pixel-identical. See ADR-0017.",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },


### PR DESCRIPTION
Follow-up to #138. Adopts the substance of `config:best-practices` and pins app dependencies, with **one deliberate omission** for supply-chain safety.

## Why not extend `config:best-practices` directly
The umbrella preset bundles **`security:minimumReleaseAgeNpm`**, which injects:
```json
{ "matchDatasources": ["npm"], "minimumReleaseAge": "3 days", "internalChecksFilter": "strict" }
```
Because packageRules apply *after* the top-level setting, that would **override our ADR-0017 14-day gate down to 3 days for npm** — the ecosystem where the supply-chain window matters most. So we extend the individual best-practice presets and drop that one, keeping **14 days uniform**.

## What's added
- `docker:pinDigests` + `helpers:pinGitHubActionDigests` — pin base images (`postgres:17`, api Dockerfile) and `actions/*` refs to digests. Supply-chain hardening; the resulting pin/digest bumps automerge behind the green gate.
- `:pinAllExceptPeerDependencies` — pin all app dependency versions (prod + dev). These modules are **applications, not published libraries**, so pinning is correct. (Superset of the requested `:pinDependencies`; the canonical app preset, cleaner than stacking two pin presets.)
- `:configMigration`, `abandonments:recommended`, `:maintainLockFilesWeekly` — config-migration PRs, abandoned-package flagging, weekly lockfile refresh. **Lockfile maintenance stays manual-merge** (it bypasses the age gate, so a human reviews it).
- `internalChecksFilter: "strict"` — don't raise a PR / burn CI until the 14-day age has actually passed (the *useful* half of the dropped security preset, applied uniformly).

## Behaviour notes
- **First run** will open a batch of pin/digest PRs (rewriting `package.json`s, workflows, Dockerfile with `# vX`-annotated SHAs) — expected, one-time.
- Automerge policy unchanged: patch/minor/pin/digest automerge behind CI `build` + Chromatic `UI Tests`; **majors always by hand**.

Validated with `renovate-config-validator` ✅.