### PR TITLE
test: prop-contract spies for SeriesScopeField + ReferenceRowsEditor; finish the audit (#133)

### DIFF
--- a/app/src/entities/event/ui/ReferenceRowsEditor.stories.tsx
+++ b/app/src/entities/event/ui/ReferenceRowsEditor.stories.tsx
@@ -1,18 +1,36 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect } from 'storybook/test'
+import { expect, fn } from 'storybook/test'
 import type { ReferenceRow } from '../lib/references'
 import { ReferenceRowsEditor } from './ReferenceRowsEditor'
 
 // Stateful wrapper — the editor is controlled, so the story owns the rows to exercise add/remove.
-function Harness({ initial = [] as ReferenceRow[] }) {
+// `onChange` (default fn() spy from meta) is forwarded before the local state update so a story can
+// assert the prop-contract — that an edit reports the next rows array up — while the controlled
+// editor still re-renders from the updated state.
+function Harness({
+  initial = [] as ReferenceRow[],
+  onChange,
+}: {
+  initial?: ReferenceRow[]
+  onChange?: (rows: ReferenceRow[]) => void
+}) {
   const [rows, setRows] = useState<ReferenceRow[]>(initial)
-  return <ReferenceRowsEditor rows={rows} onChange={setRows} />
+  return (
+    <ReferenceRowsEditor
+      rows={rows}
+      onChange={(next) => {
+        onChange?.(next)
+        setRows(next)
+      }}
+    />
+  )
 }
 
 const meta = {
   title: 'entities/event/ReferenceRowsEditor',
   component: Harness,
+  args: { onChange: fn() },
 } satisfies Meta<typeof Harness>
 
 export default meta
@@ -40,5 +58,18 @@ export const Prefilled: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByLabelText('Link 1 label')).toHaveValue('Nevobo')
     await expect(canvas.getByLabelText('Link 1 URL')).toHaveValue('https://nevobo.nl')
+  },
+}
+
+// Prop-contract: adding a row and typing into it each report the next rows array up via onChange.
+// The stateful stories above assert the resulting DOM; this asserts the wiring — that the add and
+// update paths call onChange with the expected array, which a getByLabelText check can't prove.
+export const ReportsEdits: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /Add link/ }))
+    await expect(args.onChange).toHaveBeenCalledWith([{ title: '', url: '' }])
+
+    await userEvent.type(canvas.getByLabelText('Link 1 URL'), 'https://nevobo.nl')
+    await expect(args.onChange).toHaveBeenLastCalledWith([{ title: '', url: 'https://nevobo.nl' }])
   },
 }

--- a/app/src/features/edit-event/ui/SeriesScopeField.stories.tsx
+++ b/app/src/features/edit-event/ui/SeriesScopeField.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect } from 'storybook/test'
+import { expect, fn } from 'storybook/test'
 import type { Event, EventSeriesScope } from '@shared/api/events'
 import { makeEvent } from '@shared/testing/event-fixtures'
 import { SeriesScopeField } from './SeriesScopeField'
@@ -15,11 +15,31 @@ const SIBLINGS: Event[] = [
 
 // Stateful harness: `scope` is owned by the parent dialog in production, so the story holds it to
 // make the segmented control interactive. The story's args drive the variant + starting scope.
-function Harness({ variant, initialScope }: { variant: 'edit' | 'delete'; initialScope: EventSeriesScope }) {
+// `onScopeChange` (default fn() spy from meta) is forwarded before the local state update so a story
+// can assert the prop-contract — that a scope button fires onScopeChange with the picked value —
+// while the live preview still reacts to the click.
+function Harness({
+  variant,
+  initialScope,
+  onScopeChange,
+}: {
+  variant: 'edit' | 'delete'
+  initialScope: EventSeriesScope
+  onScopeChange?: (scope: EventSeriesScope) => void
+}) {
   const [scope, setScope] = useState<EventSeriesScope>(initialScope)
   return (
     <div className="max-w-md">
-      <SeriesScopeField siblings={SIBLINGS} currentId="b" scope={scope} onScopeChange={setScope} variant={variant} />
+      <SeriesScopeField
+        siblings={SIBLINGS}
+        currentId="b"
+        scope={scope}
+        onScopeChange={(next) => {
+          onScopeChange?.(next)
+          setScope(next)
+        }}
+        variant={variant}
+      />
     </div>
   )
 }
@@ -27,6 +47,7 @@ function Harness({ variant, initialScope }: { variant: 'edit' | 'delete'; initia
 const meta = {
   title: 'features/edit-event/SeriesScopeField',
   component: Harness,
+  args: { onScopeChange: fn() },
 } satisfies Meta<typeof Harness>
 
 export default meta
@@ -46,8 +67,10 @@ export const EditThis: Story = {
 
 export const EditThisAndFollowing: Story = {
   args: { variant: 'edit', initialScope: 'THIS' },
-  play: async ({ canvas, userEvent }) => {
+  play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'This & following' }))
+    // Prop-contract: picking a scope reports it up (the dialog persists it as the chosen scope).
+    await expect(args.onScopeChange).toHaveBeenCalledWith('THIS_AND_FOLLOWING')
     await expect(canvas.getByText('Affects 3 of 4 events')).toBeInTheDocument()
     await expect(canvas.getByRole('button', { name: 'This & following' })).toHaveAttribute('aria-pressed', 'true')
     await expect(canvas.getByText(/Splits the series in two/)).toBeInTheDocument()
@@ -78,8 +101,10 @@ export const DeleteThis: Story = {
 
 export const DeleteThisAndFollowing: Story = {
   args: { variant: 'delete', initialScope: 'THIS' },
-  play: async ({ canvas, userEvent }) => {
+  play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'This & following' }))
+    // Same scope-report contract holds for the delete variant.
+    await expect(args.onScopeChange).toHaveBeenCalledWith('THIS_AND_FOLLOWING')
     await expect(canvas.getByText('Removes 3 of 4 events')).toBeInTheDocument()
     await expect(canvas.getByText(/every later one/)).toBeInTheDocument()
   },


### PR DESCRIPTION
Closes the prop-contract-spy rollout for ADR-0017 / #133: the last two interactive stories that asserted render-only now assert the callback contract, and the audit sweep is complete.

## What changed

Both are controlled components rendered through a stateful `Harness` (the parent owns the value in production). Rather than break that, the fn() spy is threaded through the harness **as the component's real callback prop**, so the interaction still drives the live re-render *and* the spy captures the call. A severed button→prop wiring (the exact class a Radix/Tailwind bump can introduce) fails the `toHaveBeenCalledWith` assertion — not just the DOM check.

- **`features/edit-event/ui/SeriesScopeField.stories.tsx`** — `onScopeChange` is now asserted in both the edit (`EditThisAndFollowing`) and delete (`DeleteThisAndFollowing`) variants: clicking a scope button reports the picked `EventSeriesScope` up. Existing render-only states (EditThis/EditAll/DeleteThis/DeleteAll) kept.
- **`entities/event/ui/ReferenceRowsEditor.stories.tsx`** — new `ReportsEdits` story proves both the **add** path (`onChange([{ title: '', url: '' }])`) and the **update** path (typing a URL → `onChange` last called with `[{ title: '', url: 'https://nevobo.nl' }]`). The existing stateful `AddAndRemove` / `Prefilled` stories stay — they assert the resulting DOM; this one asserts the wiring.

**Network line held** — no MSW; the spies prove the component called its prop, not that a request reached the server. Real round-trips stay in the two e2e flows.

## Audit sweep — "audit the rest"

Read every interactive story. The five flagged as possibly-incomplete already assert **all** their callbacks, so no change was needed:

| Story | Callback prop(s) | Already asserted? |
|-------|------------------|-------------------|
| `AttendanceToggle` | `onToggle` | ✅ `NotResponded` → `'ATTENDING'` |
| `EditProfileForm` | `onSubmit` (only) | ✅ `SavedSuccess` / `PositionRequired` / `PositionPreselected` |
| `CreateEventForm` | `onSubmit` (only) | ✅ `DerivesEndTimeFromDuration` |
| `PositionPicker` | `onChange` (only) | ✅ `HasPositions` → `'p2'`, `WithUnassigned` → `null` |
| `CreateEntryChooser` | `onSingle`, `onRecurring` | ✅ both in `Default` |

Remaining interactive stories (`RecurringEventsWizard` → `onSubmit`, `TeamSettingsView` → `onSave`, plus the #137 exemplars `ManagePositionsView` / `MemberRosterView` / `GenerateInviteContent`) already assert every callback.

**Skipped as display/navigation-only (no callback props):** `EventCard` and `BottomNav` navigate via TanStack Router `<Link>` (no callback prop to spy); `EventListView`, `EventTypeBadge`, `EventTypeIcon`, `ReferenceChips`, `RoleBreakdown`, `SeriesPeek`, `MonthCalendarPreview`, `ColdStartSplash` expose no callbacks. Nothing to assert.

## Verification

- `make test-app` → **242 passed** (44 files); the two changed stories run green in headless chromium (9 story tests across them).
- `npm run typecheck` clean, `npm run lint` clean.
- Full pre-commit gate passed locally, including `:api:test` (Testcontainers) and the real e2e Playwright suite (7 passed).

## Chromatic note

`ReferenceRowsEditor`'s new `ReportsEdits` story is a **new snapshot** — Chromatic's **UI Tests** check will flag it for a one-time baseline accept. The SeriesScopeField changes only added `play` assertions to existing stories, so they produce no new snapshot.

## No new e2e

Per the PR gate: this change adds no new seam (no new auth path, cross-tenant write, or external integration) — it strengthens existing story assertions. The login + attendance flows already cover the runtime seams. No e2e added.
