### PR TITLE
test: shells-down for edit/delete-event dialogs + create-event sheet (#133)

### DIFF
--- a/app/src/features/edit-event/ui/DeleteEventDialog.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialog.tsx
@@ -5,13 +5,12 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@shared/ui/dialog'
 import { Button } from '@shared/ui/button'
-import { useDeleteEvent, type Event, type EventSeriesScope } from '@shared/api/events'
-import { SeriesScopeField } from './SeriesScopeField'
+import { useDeleteEvent, type Event } from '@shared/api/events'
+import { DeleteEventDialogView } from './DeleteEventDialogView'
 
 interface DeleteEventDialogProps {
   eventId: string
@@ -21,10 +20,11 @@ interface DeleteEventDialogProps {
 }
 
 /**
- * Delete one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no
- * siblings) deletes itself with the default THIS scope and no prompt. For a series, the
- * SeriesScopeField drives which occurrences go — and a delete **never splits** (survivors keep
- * their group). On success it navigates back to the event list, since the detail route may be gone.
+ * Container for deleting an event: wires the DeleteEvent mutation and the post-delete navigation to
+ * the presentational DeleteEventDialogView, and owns the dialog open/close state. Pure wiring — the
+ * scope state and the pending/error shells live in the View (props-driven), so this seam is covered
+ * by e2e, not a story. On success it navigates back to the event list, since the detail route may be
+ * gone. The dialog chrome (title + description) stays here, so the View is Radix-free. See ADR-0017.
  */
 export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEventDialogProps) {
   const [open, setOpen] = useState(false)
@@ -32,13 +32,6 @@ export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEvent
   const deleteEvent = useDeleteEvent()
 
   const isSeries = siblings.length > 1
-  const [scope, setScope] = useState<EventSeriesScope>('THIS')
-
-  const handleDelete = () => {
-    deleteEvent.mutate({ id: eventId, scope }, { onSuccess: () => navigate({ to: '/' }) })
-  }
-
-  const confirmLabel = deleteEvent.isPending ? 'Deleting…' : isSeries && scope !== 'THIS' ? 'Delete events' : 'Delete event'
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -57,28 +50,14 @@ export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEvent
             {title} will be removed for everyone, along with its attendance.
           </DialogDescription>
         </DialogHeader>
-        {isSeries && (
-          <SeriesScopeField
-            siblings={siblings}
-            currentId={eventId}
-            scope={scope}
-            onScopeChange={setScope}
-            variant="delete"
-          />
-        )}
-        {deleteEvent.isError && (
-          <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
-            Could not delete the event. Please try again.
-          </p>
-        )}
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)} disabled={deleteEvent.isPending}>
-            Cancel
-          </Button>
-          <Button variant="destructive" onClick={handleDelete} disabled={deleteEvent.isPending}>
-            {confirmLabel}
-          </Button>
-        </DialogFooter>
+        <DeleteEventDialogView
+          eventId={eventId}
+          siblings={siblings}
+          isPending={deleteEvent.isPending}
+          isError={deleteEvent.isError}
+          onDelete={(scope) => deleteEvent.mutate({ id: eventId, scope }, { onSuccess: () => navigate({ to: '/' }) })}
+          onCancel={() => setOpen(false)}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/app/src/features/edit-event/ui/DeleteEventDialogView.stories.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialogView.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import type { Event } from '@shared/api/events'
+import { makeEvent } from '@shared/testing/event-fixtures'
+import { DeleteEventDialogView } from './DeleteEventDialogView'
+
+// DeleteEventDialogView is the presentational body behind the DeleteEventDialog container. It owns
+// the local scope state and hands the chosen scope up via onDelete; the mutation + navigation stay
+// in the container, so every state renders purely from props (ADR-0017). The pending/error shells
+// that used to live in the container are now the isPending/isError args, and the confirm stories
+// prove the wiring with a prop-contract spy.
+
+// A three-occurrence series; the middle one ('evt-1') is the one being deleted.
+const SIBLINGS: Event[] = [
+  makeEvent({ id: 'evt-0', startTime: '2026-08-25T18:30:00+02:00', recurringGroup: 'g1' }),
+  makeEvent({ id: 'evt-1', startTime: '2026-09-01T18:30:00+02:00', recurringGroup: 'g1' }),
+  makeEvent({ id: 'evt-2', startTime: '2026-09-08T18:30:00+02:00', recurringGroup: 'g1' }),
+]
+
+const meta = {
+  title: 'features/edit-event/DeleteEventDialogView',
+  component: DeleteEventDialogView,
+  args: { eventId: 'evt-1', onDelete: fn(), onCancel: fn() },
+} satisfies Meta<typeof DeleteEventDialogView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// A standalone event (no siblings) shows no scope prompt and confirms with the default THIS scope.
+export const Standalone: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.queryByRole('group', { name: 'Scope' })).not.toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete event' }))
+    await expect(args.onDelete).toHaveBeenCalledWith('THIS')
+  },
+}
+
+export const Cancel: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Cancel' }))
+    await expect(args.onCancel).toHaveBeenCalled()
+  },
+}
+
+// A series occurrence surfaces the scope selector; picking a bulk scope both relabels the confirm
+// button and hands the chosen scope up.
+export const Series: Story = {
+  args: { siblings: SIBLINGS },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByRole('group', { name: 'Scope' })).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Delete event' })).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'All events' }))
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete events' }))
+    await expect(args.onDelete).toHaveBeenCalledWith('ALL')
+  },
+}
+
+export const Deleting: Story = {
+  args: { isPending: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Deleting…' })).toBeDisabled()
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Could not delete the event. Please try again.')).toBeInTheDocument()
+  },
+}

--- a/app/src/features/edit-event/ui/DeleteEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialogView.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { DialogFooter } from '@shared/ui/dialog'
+import { Button } from '@shared/ui/button'
+import { type Event, type EventSeriesScope } from '@shared/api/events'
+import { SeriesScopeField } from './SeriesScopeField'
+
+interface DeleteEventDialogViewProps {
+  eventId: string
+  /** Every occurrence sharing this event's recurring group. A single-element (or empty) list is standalone. */
+  siblings?: Event[]
+  /** The delete mutation is in flight — the buttons disable and the confirm shows "Deleting…". */
+  isPending?: boolean
+  /** The delete mutation failed — render the inline error shell. */
+  isError?: boolean
+  onDelete: (scope: EventSeriesScope) => void
+  onCancel: () => void
+}
+
+/**
+ * Presentational body of the delete-event dialog. Owns the local scope state and hands the chosen
+ * scope up via onDelete; the mutation, the post-delete navigation, and the dialog open/close state
+ * live in the DeleteEventDialog container.
+ *
+ * The pending/error shells are props-driven (isPending / isError) rather than lived in the container,
+ * so every state — standalone / series / deleting / error — renders purely from props as a story,
+ * with no network. See ADR-0017.
+ *
+ * Delete one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no
+ * siblings) deletes itself with the default THIS scope and no prompt. For a series, the
+ * SeriesScopeField drives which occurrences go — and a delete never splits (survivors keep their
+ * group). The dialog chrome (title + description) stays in the container, so this stays Radix-free.
+ */
+export function DeleteEventDialogView({
+  eventId,
+  siblings = [],
+  isPending,
+  isError,
+  onDelete,
+  onCancel,
+}: DeleteEventDialogViewProps) {
+  const isSeries = siblings.length > 1
+  const [scope, setScope] = useState<EventSeriesScope>('THIS')
+
+  const confirmLabel = isPending ? 'Deleting…' : isSeries && scope !== 'THIS' ? 'Delete events' : 'Delete event'
+
+  return (
+    <>
+      {isSeries && (
+        <SeriesScopeField
+          siblings={siblings}
+          currentId={eventId}
+          scope={scope}
+          onScopeChange={setScope}
+          variant="delete"
+        />
+      )}
+      {isError && (
+        <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+          Could not delete the event. Please try again.
+        </p>
+      )}
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button variant="destructive" onClick={() => onDelete(scope)} disabled={isPending}>
+          {confirmLabel}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/app/src/features/edit-event/ui/EditEventDialog.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialog.tsx
@@ -2,14 +2,9 @@ import { useState } from 'react'
 import { Pencil } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@shared/ui/dialog'
 import { Button } from '@shared/ui/button'
-import { Input } from '@shared/ui/input'
-import { Label } from '@shared/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shared/ui/select'
-import { useUpdateEvent, type Event, type EventDetail, type EventSeriesScope } from '@shared/api/events'
+import { useUpdateEvent, type Event, type EventDetail } from '@shared/api/events'
 import { useEventTypes } from '@shared/api/event-types'
-import { ReferenceRowsEditor } from '@entities/event/ui/ReferenceRowsEditor'
-import { cleanReferences, toReferenceRows, type ReferenceRow } from '@entities/event/lib/references'
-import { SeriesScopeField } from './SeriesScopeField'
+import { EditEventDialogView } from './EditEventDialogView'
 
 interface EditEventDialogProps {
   event: EventDetail
@@ -17,61 +12,17 @@ interface EditEventDialogProps {
   siblings?: Event[]
 }
 
-// ISO instant → the value a <input type="datetime-local"> expects ('YYYY-MM-DDTHH:mm' in local time).
-function toLocalInput(iso: string): string {
-  const d = new Date(iso)
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-// Swap the time-of-day into a 'YYYY-MM-DDTHH:mm' local string, keeping its date.
-function withTime(local: string, time: string): string {
-  return `${local.slice(0, 10)}T${time}`
-}
-
 /**
- * Edit one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no siblings)
- * edits itself exactly as before — the scope prompt is hidden and the request carries the default
- * THIS. For a series, the SeriesScopeField drives the scope; bulk scopes lock the per-occurrence
- * date (only the time-of-day propagates), so the date input is swapped for a time-only input.
+ * Container for editing an event: wires the event-types query and the UpdateEvent mutation to the
+ * presentational EditEventDialogView, and owns the dialog open/close state. Pure wiring — the form
+ * state and the pending/error shells live in the View (props-driven), so this seam is covered by
+ * e2e, not a story. The dialog chrome (trigger + header) stays here, so the View is Radix-free.
+ * See ADR-0017.
  */
 export function EditEventDialog({ event, siblings = [] }: EditEventDialogProps) {
   const [open, setOpen] = useState(false)
   const { data: eventTypes } = useEventTypes()
   const updateEvent = useUpdateEvent()
-
-  const isSeries = siblings.length > 1
-  const [scope, setScope] = useState<EventSeriesScope>('THIS')
-  const dateLocked = isSeries && scope !== 'THIS'
-
-  const [typeId, setTypeId] = useState(event.eventType.id)
-  const [title, setTitle] = useState(event.title)
-  const [start, setStart] = useState(toLocalInput(event.startTime))
-  const [end, setEnd] = useState(toLocalInput(event.endTime))
-  // Seed the editor from the event's existing links — updateEvent has replace-semantics, so the
-  // full set must be sent back on every save or the links would be wiped.
-  const [references, setReferences] = useState<ReferenceRow[]>(toReferenceRows(event.references))
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const form = new FormData(e.currentTarget)
-    updateEvent.mutate(
-      {
-        id: event.id,
-        scope,
-        eventTypeId: typeId,
-        title,
-        description: (form.get('description') as string) || undefined,
-        // For a bulk scope the date is locked to the occurrence's own date; only the time-of-day
-        // (and duration) matters — the backend re-anchors each occurrence to its own date.
-        startTime: new Date(start).toISOString(),
-        endTime: new Date(end).toISOString(),
-        location: (form.get('location') as string) || undefined,
-        references: cleanReferences(references),
-      },
-      { onSuccess: () => setOpen(false) },
-    )
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -85,103 +36,14 @@ export function EditEventDialog({ event, siblings = [] }: EditEventDialogProps) 
         <DialogHeader>
           <DialogTitle>Edit event</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {isSeries && (
-            <SeriesScopeField
-              siblings={siblings}
-              currentId={event.id}
-              scope={scope}
-              onScopeChange={setScope}
-              variant="edit"
-            />
-          )}
-          <div>
-            <Label htmlFor="edit-type">Type</Label>
-            <Select value={typeId} onValueChange={setTypeId}>
-              <SelectTrigger id="edit-type">
-                <SelectValue placeholder="Select type" />
-              </SelectTrigger>
-              <SelectContent>
-                {(eventTypes ?? []).map((t) => (
-                  <SelectItem key={t.id} value={t.id}>
-                    <div className="flex items-center gap-2">
-                      <span className="inline-block h-3 w-3 rounded-full" style={{ backgroundColor: t.color ?? '#888' }} />
-                      {t.name}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label htmlFor="edit-title">Title</Label>
-            <Input id="edit-title" required value={title} onChange={(e) => setTitle(e.target.value)} />
-          </div>
-          {dateLocked ? (
-            <>
-              <div>
-                <Label htmlFor="edit-start-time">Start time</Label>
-                <Input
-                  id="edit-start-time"
-                  type="time"
-                  required
-                  value={start.slice(11, 16)}
-                  onChange={(e) => setStart((s) => withTime(s, e.target.value))}
-                />
-              </div>
-              <div>
-                <Label htmlFor="edit-end-time">End time</Label>
-                <Input
-                  id="edit-end-time"
-                  type="time"
-                  required
-                  value={end.slice(11, 16)}
-                  onChange={(e) => setEnd((s) => withTime(s, e.target.value))}
-                />
-              </div>
-            </>
-          ) : (
-            <>
-              <div>
-                <Label htmlFor="edit-start">Start time</Label>
-                <Input
-                  id="edit-start"
-                  type="datetime-local"
-                  required
-                  value={start}
-                  onChange={(e) => setStart(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label htmlFor="edit-end">End time</Label>
-                <Input
-                  id="edit-end"
-                  type="datetime-local"
-                  required
-                  value={end}
-                  onChange={(e) => setEnd(e.target.value)}
-                />
-              </div>
-            </>
-          )}
-          <div>
-            <Label htmlFor="edit-location">Location (optional)</Label>
-            <Input id="edit-location" name="location" defaultValue={event.location ?? ''} />
-          </div>
-          <div>
-            <Label htmlFor="edit-description">Description (optional)</Label>
-            <Input id="edit-description" name="description" defaultValue={event.description ?? ''} />
-          </div>
-          <ReferenceRowsEditor rows={references} onChange={setReferences} />
-          {updateEvent.isError && (
-            <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
-              Could not save changes. Please try again.
-            </p>
-          )}
-          <Button type="submit" disabled={updateEvent.isPending}>
-            {updateEvent.isPending ? 'Saving…' : 'Save changes'}
-          </Button>
-        </form>
+        <EditEventDialogView
+          event={event}
+          siblings={siblings}
+          eventTypes={eventTypes}
+          isPending={updateEvent.isPending}
+          isError={updateEvent.isError}
+          onSubmit={(request) => updateEvent.mutate(request, { onSuccess: () => setOpen(false) })}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import type { Event, EventDetail } from '@shared/api/events'
+import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEvent } from '@shared/testing/event-fixtures'
+import { EditEventDialogView } from './EditEventDialogView'
+
+// EditEventDialogView is the presentational edit-event form behind the EditEventDialog container.
+// It owns all local form state and hands a fully-assembled update request up via onSubmit; the query
+// + mutation stay in the container, so every state renders purely from props (ADR-0017): the
+// pending/error shells that used to live in the container are now the isPending/isError args, and
+// the submit story proves the wiring with a prop-contract spy.
+const EVENT_TYPES: EventTypeItem[] = [
+  { id: 'et-1', name: 'Training', color: '#22c55e' },
+  { id: 'et-2', name: 'Match', color: '#3b82f6' },
+]
+
+const EVENT: EventDetail = {
+  id: 'evt-1',
+  eventType: { id: 'et-1', name: 'Training', color: '#22c55e' },
+  title: 'Tuesday Training',
+  description: undefined,
+  startTime: '2026-09-01T18:30:00+02:00',
+  endTime: '2026-09-01T20:00:00+02:00',
+  location: undefined,
+  references: [],
+  recurringGroup: undefined,
+  attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
+  attendances: [],
+}
+
+// A three-occurrence series; the middle one ('evt-1') is the one being edited.
+const SIBLINGS: Event[] = [
+  makeEvent({ id: 'evt-0', startTime: '2026-08-25T18:30:00+02:00', recurringGroup: 'g1' }),
+  makeEvent({ id: 'evt-1', startTime: '2026-09-01T18:30:00+02:00', recurringGroup: 'g1' }),
+  makeEvent({ id: 'evt-2', startTime: '2026-09-08T18:30:00+02:00', recurringGroup: 'g1' }),
+]
+
+const meta = {
+  title: 'features/edit-event/EditEventDialogView',
+  component: EditEventDialogView,
+  args: { event: EVENT, eventTypes: EVENT_TYPES, onSubmit: fn() },
+} satisfies Meta<typeof EditEventDialogView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// A standalone event (no siblings) shows no scope prompt and submits with the default THIS scope.
+export const Standalone: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByLabelText('Title')).toHaveValue('Tuesday Training')
+    await expect(canvas.queryByRole('group', { name: 'Scope' })).not.toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Save changes' }))
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'evt-1', scope: 'THIS', eventTypeId: 'et-1', title: 'Tuesday Training' }),
+    )
+  },
+}
+
+// A series occurrence surfaces the scope selector so the admin can choose how far the edit reaches.
+export const Series: Story = {
+  args: { siblings: SIBLINGS },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('group', { name: 'Scope' })).toBeInTheDocument()
+    await expect(canvas.getByText('Affects 1 of 3 events')).toBeInTheDocument()
+  },
+}
+
+export const Saving: Story = {
+  args: { isPending: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Saving…' })).toBeDisabled()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Could not save changes. Please try again.')).toBeInTheDocument()
+  },
+}

--- a/app/src/features/edit-event/ui/EditEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shared/ui/select'
+import type { Event, EventDetail, EventInput, EventSeriesScope } from '@shared/api/events'
+import type { EventTypeItem } from '@shared/api/event-types'
+import { ReferenceRowsEditor } from '@entities/event/ui/ReferenceRowsEditor'
+import { cleanReferences, toReferenceRows, type ReferenceRow } from '@entities/event/lib/references'
+import { SeriesScopeField } from './SeriesScopeField'
+
+export type UpdateEventRequest = EventInput & { id: string; scope: EventSeriesScope }
+
+interface EditEventDialogViewProps {
+  event: EventDetail
+  /** Every occurrence sharing this event's recurring group. A single-element (or empty) list is standalone. */
+  siblings?: Event[]
+  /** Event types for the picker; defaults to an empty list while the container's query is in flight. */
+  eventTypes?: EventTypeItem[]
+  /** The update mutation is in flight — the submit button shows "Saving…" and is disabled. */
+  isPending?: boolean
+  /** The update mutation failed — render the inline error shell. */
+  isError?: boolean
+  onSubmit: (request: UpdateEventRequest) => void
+}
+
+// ISO instant → the value a <input type="datetime-local"> expects ('YYYY-MM-DDTHH:mm' in local time).
+function toLocalInput(iso: string): string {
+  const d = new Date(iso)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Swap the time-of-day into a 'YYYY-MM-DDTHH:mm' local string, keeping its date.
+function withTime(local: string, time: string): string {
+  return `${local.slice(0, 10)}T${time}`
+}
+
+/**
+ * Presentational edit-event form. Owns all local form state (scope, type, title, times, links) and
+ * hands a fully-assembled update request up via onSubmit; the query, the mutation, and the dialog
+ * open/close state live in the EditEventDialog container.
+ *
+ * The pending/error shells are props-driven (isPending / isError) rather than lived in the container,
+ * so every state — standalone / series / saving / error — renders purely from props as a story, with
+ * no network. See ADR-0017.
+ *
+ * Edit one occurrence of a series with a scope (ADR-0014, Phase 3). A standalone event (no siblings)
+ * edits itself with the default THIS scope and no prompt. For a series, the SeriesScopeField drives
+ * the scope; bulk scopes lock the per-occurrence date (only the time-of-day propagates), so the date
+ * input is swapped for a time-only input.
+ */
+export function EditEventDialogView({
+  event,
+  siblings = [],
+  eventTypes = [],
+  isPending,
+  isError,
+  onSubmit,
+}: EditEventDialogViewProps) {
+  const isSeries = siblings.length > 1
+  const [scope, setScope] = useState<EventSeriesScope>('THIS')
+  const dateLocked = isSeries && scope !== 'THIS'
+
+  const [typeId, setTypeId] = useState(event.eventType.id)
+  const [title, setTitle] = useState(event.title)
+  const [start, setStart] = useState(toLocalInput(event.startTime))
+  const [end, setEnd] = useState(toLocalInput(event.endTime))
+  // Seed the editor from the event's existing links — the update has replace-semantics, so the full
+  // set must be sent back on every save or the links would be wiped.
+  const [references, setReferences] = useState<ReferenceRow[]>(toReferenceRows(event.references))
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const form = new FormData(e.currentTarget)
+    onSubmit({
+      id: event.id,
+      scope,
+      eventTypeId: typeId,
+      title,
+      description: (form.get('description') as string) || undefined,
+      // For a bulk scope the date is locked to the occurrence's own date; only the time-of-day
+      // (and duration) matters — the backend re-anchors each occurrence to its own date.
+      startTime: new Date(start).toISOString(),
+      endTime: new Date(end).toISOString(),
+      location: (form.get('location') as string) || undefined,
+      references: cleanReferences(references),
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {isSeries && (
+        <SeriesScopeField
+          siblings={siblings}
+          currentId={event.id}
+          scope={scope}
+          onScopeChange={setScope}
+          variant="edit"
+        />
+      )}
+      <div>
+        <Label htmlFor="edit-type">Type</Label>
+        <Select value={typeId} onValueChange={setTypeId}>
+          <SelectTrigger id="edit-type">
+            <SelectValue placeholder="Select type" />
+          </SelectTrigger>
+          <SelectContent>
+            {eventTypes.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                <div className="flex items-center gap-2">
+                  <span className="inline-block h-3 w-3 rounded-full" style={{ backgroundColor: t.color ?? '#888' }} />
+                  {t.name}
+                </div>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div>
+        <Label htmlFor="edit-title">Title</Label>
+        <Input id="edit-title" required value={title} onChange={(e) => setTitle(e.target.value)} />
+      </div>
+      {dateLocked ? (
+        <>
+          <div>
+            <Label htmlFor="edit-start-time">Start time</Label>
+            <Input
+              id="edit-start-time"
+              type="time"
+              required
+              value={start.slice(11, 16)}
+              onChange={(e) => setStart((s) => withTime(s, e.target.value))}
+            />
+          </div>
+          <div>
+            <Label htmlFor="edit-end-time">End time</Label>
+            <Input
+              id="edit-end-time"
+              type="time"
+              required
+              value={end.slice(11, 16)}
+              onChange={(e) => setEnd((s) => withTime(s, e.target.value))}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div>
+            <Label htmlFor="edit-start">Start time</Label>
+            <Input
+              id="edit-start"
+              type="datetime-local"
+              required
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="edit-end">End time</Label>
+            <Input
+              id="edit-end"
+              type="datetime-local"
+              required
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+            />
+          </div>
+        </>
+      )}
+      <div>
+        <Label htmlFor="edit-location">Location (optional)</Label>
+        <Input id="edit-location" name="location" defaultValue={event.location ?? ''} />
+      </div>
+      <div>
+        <Label htmlFor="edit-description">Description (optional)</Label>
+        <Input id="edit-description" name="description" defaultValue={event.description ?? ''} />
+      </div>
+      <ReferenceRowsEditor rows={references} onChange={setReferences} />
+      {isError && (
+        <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+          Could not save changes. Please try again.
+        </p>
+      )}
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Saving…' : 'Save changes'}
+      </Button>
+    </form>
+  )
+}

--- a/app/src/widgets/create-event/ui/CreateEventSheet.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheet.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { ArrowLeft, Plus } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { Button } from '@shared/ui/button'
-import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from '@shared/ui/sheet'
+import { Sheet, SheetContent, SheetTrigger } from '@shared/ui/sheet'
 import { useEventTypes } from '@shared/api/event-types'
 import { useSeason } from '@shared/api/season'
 import { useCreateEvent, type EventInput } from '@shared/api/events'
@@ -10,28 +10,17 @@ import {
   useCreateRecurringEvents,
   type CreateRecurringEventsRequest,
 } from '@shared/api/recurring-events'
-import { CreateEventForm } from '@features/create-event/ui/CreateEventForm'
-import { RecurringEventsWizard } from '@features/create-recurring-events/ui/RecurringEventsWizard'
-import { CreateEntryChooser } from './CreateEntryChooser'
+import { CreateEventSheetView, type CreateEventMode } from './CreateEventSheetView'
 
-type Mode = 'closed' | 'chooser' | 'single' | 'recurring'
-
-const TITLES: Record<Exclude<Mode, 'closed'>, string> = {
-  chooser: 'Create event',
-  single: 'New event',
-  recurring: 'New recurring series',
-}
-const DESCRIPTIONS: Record<Exclude<Mode, 'closed'>, string> = {
-  chooser: 'Choose how you want to add events',
-  single: 'A one-off training, match, or other event',
-  recurring: 'A weekly or bi-weekly series across the season',
-}
+type Mode = 'closed' | CreateEventMode
 
 /**
  * The admin's single entry point for adding events, presented as a bottom sheet (prototype A):
- * "New Event" opens a Single / Recurring chooser, and the chosen flow (the presentational
- * CreateEventForm or RecurringEventsWizard) renders in the same sheet with a back step. A widget,
- * since it composes two feature slices; data + both mutations live here.
+ * "New Event" opens a Single / Recurring chooser, and the chosen flow renders in the same sheet with
+ * a back step. A widget, since it composes two feature slices; data + both mutations live here and
+ * are wired to the presentational CreateEventSheetView. Pure wiring — the mode-dependent body and
+ * its states live in the View (props-driven), so this seam is covered by e2e, not a story. The sheet
+ * chrome (trigger + open/close) stays here. See ADR-0017.
  */
 export function CreateEventSheet() {
   const [mode, setMode] = useState<Mode>('closed')
@@ -62,8 +51,6 @@ export function CreateEventSheet() {
         }[createSeries.error.reason]
       : 'Could not create the series. Please try again.'
 
-  const isForm = mode === 'single' || mode === 'recurring'
-
   return (
     <Sheet open={mode !== 'closed'} onOpenChange={(open) => (open ? setMode('chooser') : close())}>
       <SheetTrigger asChild>
@@ -73,40 +60,21 @@ export function CreateEventSheet() {
         </Button>
       </SheetTrigger>
       <SheetContent>
-        <div className="relative mb-1 flex items-center justify-center">
-          {isForm && (
-            <button
-              type="button"
-              onClick={() => setMode('chooser')}
-              aria-label="Back to event type"
-              className="absolute left-0 flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted"
-            >
-              <ArrowLeft size={18} />
-            </button>
-          )}
-          {mode !== 'closed' && <SheetTitle>{TITLES[mode]}</SheetTitle>}
-        </div>
-        {mode !== 'closed' && <SheetDescription className="mb-4">{DESCRIPTIONS[mode]}</SheetDescription>}
-
-        {mode === 'chooser' && (
-          <CreateEntryChooser onSingle={() => setMode('single')} onRecurring={() => setMode('recurring')} />
-        )}
-        {mode === 'single' && (
-          <CreateEventForm
-            eventTypes={eventTypes ?? []}
-            isPending={createEvent.isPending}
-            onSubmit={handleSingle}
-            error={createEvent.isError ? 'Could not create the event. Please try again.' : null}
-          />
-        )}
-        {mode === 'recurring' && (
-          <RecurringEventsWizard
-            eventTypes={eventTypes ?? []}
+        {mode !== 'closed' && (
+          <CreateEventSheetView
+            mode={mode}
+            eventTypes={eventTypes}
             season={season}
-            isPending={createSeries.isPending}
-            errorMessage={seriesError}
             today={today}
-            onSubmit={handleRecurring}
+            isCreatingSingle={createEvent.isPending}
+            isCreatingRecurring={createSeries.isPending}
+            singleError={createEvent.isError ? 'Could not create the event. Please try again.' : null}
+            recurringError={seriesError}
+            onBack={() => setMode('chooser')}
+            onChooseSingle={() => setMode('single')}
+            onChooseRecurring={() => setMode('recurring')}
+            onSubmitSingle={handleSingle}
+            onSubmitRecurring={handleRecurring}
           />
         )}
       </SheetContent>

--- a/app/src/widgets/create-event/ui/CreateEventSheetView.stories.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheetView.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { Sheet } from '@shared/ui/sheet'
+import type { EventTypeItem } from '@shared/api/event-types'
+import { CreateEventSheetView } from './CreateEventSheetView'
+
+// CreateEventSheetView is the presentational body of the create-event sheet behind the
+// CreateEventSheet widget. The mode navigation, data queries, and mutations stay in the widget, so
+// each mode renders purely from props (ADR-0017). SheetTitle/SheetDescription are Radix Dialog
+// primitives, so the stories mount the View under a controlled <Sheet open> to give them their
+// context — no portal, no network. The child features (chooser/form/wizard) own their own state
+// stories; here we cover the sheet's own header + navigation wiring with prop-contract spies.
+const EVENT_TYPES: EventTypeItem[] = [
+  { id: 'et-1', name: 'Training', color: '#22c55e' },
+  { id: 'et-2', name: 'Match', color: '#3b82f6' },
+]
+
+const meta = {
+  title: 'widgets/create-event/CreateEventSheetView',
+  component: CreateEventSheetView,
+  args: {
+    eventTypes: EVENT_TYPES,
+    today: '2026-09-01',
+    onBack: fn(),
+    onChooseSingle: fn(),
+    onChooseRecurring: fn(),
+    onSubmitSingle: fn(),
+    onSubmitRecurring: fn(),
+  },
+  decorators: [(Story) => <Sheet open>{Story()}</Sheet>],
+} satisfies Meta<typeof CreateEventSheetView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// The first thing the sheet shows: pick single vs recurring. No back step yet.
+export const Chooser: Story = {
+  args: { mode: 'chooser' },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText('Create event')).toBeInTheDocument()
+    await expect(canvas.getByText('Choose how you want to add events')).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Back to event type' })).not.toBeInTheDocument()
+    await userEvent.click(canvas.getByText('Single event'))
+    await expect(args.onChooseSingle).toHaveBeenCalled()
+    await userEvent.click(canvas.getByText('Recurring series'))
+    await expect(args.onChooseRecurring).toHaveBeenCalled()
+  },
+}
+
+// The single-event form, with a back step to the chooser.
+export const SingleForm: Story = {
+  args: { mode: 'single' },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText('New event')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Create Event' })).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Back to event type' }))
+    await expect(args.onBack).toHaveBeenCalled()
+  },
+}
+
+// A failed single-create surfaces inline in the form.
+export const SingleError: Story = {
+  args: { mode: 'single', singleError: 'Could not create the event. Please try again.' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Could not create the event. Please try again.')).toBeInTheDocument()
+  },
+}
+
+// The recurring-series wizard opens on its first step, with a back step to the chooser.
+export const Recurring: Story = {
+  args: { mode: 'recurring' },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText('New recurring series')).toBeInTheDocument()
+    await expect(canvas.getByText('What are you scheduling?')).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Back to event type' }))
+    await expect(args.onBack).toHaveBeenCalled()
+  },
+}

--- a/app/src/widgets/create-event/ui/CreateEventSheetView.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheetView.tsx
@@ -1,0 +1,107 @@
+import { ArrowLeft } from 'lucide-react'
+import { SheetDescription, SheetTitle } from '@shared/ui/sheet'
+import type { EventInput } from '@shared/api/events'
+import type { EventTypeItem } from '@shared/api/event-types'
+import type { Season } from '@shared/api/season'
+import type { CreateRecurringEventsRequest } from '@shared/api/recurring-events'
+import { CreateEventForm } from '@features/create-event/ui/CreateEventForm'
+import { RecurringEventsWizard } from '@features/create-recurring-events/ui/RecurringEventsWizard'
+import { CreateEntryChooser } from './CreateEntryChooser'
+
+// The sheet is only mounted while open, so its body is always in one of these three modes.
+export type CreateEventMode = 'chooser' | 'single' | 'recurring'
+
+const TITLES: Record<CreateEventMode, string> = {
+  chooser: 'Create event',
+  single: 'New event',
+  recurring: 'New recurring series',
+}
+const DESCRIPTIONS: Record<CreateEventMode, string> = {
+  chooser: 'Choose how you want to add events',
+  single: 'A one-off training, match, or other event',
+  recurring: 'A weekly or bi-weekly series across the season',
+}
+
+interface CreateEventSheetViewProps {
+  mode: CreateEventMode
+  /** Event types for the pickers; defaults to an empty list while the container's query is in flight. */
+  eventTypes?: EventTypeItem[]
+  season?: Season
+  today: string
+  isCreatingSingle?: boolean
+  isCreatingRecurring?: boolean
+  /** Message when the last single-create attempt failed; null hides the alert. */
+  singleError?: string | null
+  /** Message when the last recurring-create attempt failed; undefined hides the alert. */
+  recurringError?: string
+  onBack: () => void
+  onChooseSingle: () => void
+  onChooseRecurring: () => void
+  onSubmitSingle: (values: EventInput) => void
+  onSubmitRecurring: (body: CreateRecurringEventsRequest) => void
+}
+
+/**
+ * Presentational body of the create-event sheet: the mode-dependent header (back step + title +
+ * description) and the chooser / single-form / recurring-wizard switch. The mode navigation state,
+ * the data queries, and both mutations live in the CreateEventSheet widget — so each mode renders
+ * purely from props as a story, with no network. Composes already-presentational child features
+ * (CreateEntryChooser, CreateEventForm, RecurringEventsWizard), each of which owns its own states;
+ * this View covers only the sheet's own navigation + wiring seam. See ADR-0017.
+ */
+export function CreateEventSheetView({
+  mode,
+  eventTypes = [],
+  season,
+  today,
+  isCreatingSingle,
+  isCreatingRecurring,
+  singleError,
+  recurringError,
+  onBack,
+  onChooseSingle,
+  onChooseRecurring,
+  onSubmitSingle,
+  onSubmitRecurring,
+}: CreateEventSheetViewProps) {
+  const isForm = mode === 'single' || mode === 'recurring'
+
+  return (
+    <>
+      <div className="relative mb-1 flex items-center justify-center">
+        {isForm && (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to event type"
+            className="absolute left-0 flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted"
+          >
+            <ArrowLeft size={18} />
+          </button>
+        )}
+        <SheetTitle>{TITLES[mode]}</SheetTitle>
+      </div>
+      <SheetDescription className="mb-4">{DESCRIPTIONS[mode]}</SheetDescription>
+
+      {mode === 'chooser' && <CreateEntryChooser onSingle={onChooseSingle} onRecurring={onChooseRecurring} />}
+      {mode === 'single' && (
+        <CreateEventForm
+          eventTypes={eventTypes}
+          isPending={!!isCreatingSingle}
+          onSubmit={onSubmitSingle}
+          error={singleError}
+        />
+      )}
+      {mode === 'recurring' && (
+        <RecurringEventsWizard
+          eventTypes={eventTypes}
+          season={season}
+          isPending={!!isCreatingRecurring}
+          errorMessage={recurringError}
+          today={today}
+          onSubmit={onSubmitRecurring}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
Continues the ADR-0017 shells-down rollout (#133): pushes the loading/error shells out of the last four dialog/sheet containers into prop-only `*View`s, so every data state renders as a **no-network story**. Container public APIs are unchanged — consumers still render `<EditEventDialog/>`, `<DeleteEventDialog/>`, `<CreateEventSheet/>`.

## The move

Per ADR-0017 / `docs/testing.md`: the `*View` is presentational and prop-only and **gets the story**; the container is thin wiring **covered by e2e**. Radix chrome (Dialog/Sheet title + header) stays in the container, keeping each View free of Radix context — following the existing `GenerateInviteDialog` → `GenerateInviteContent` precedent.

| Container | New View | States now story-able |
|---|---|---|
| `EditEventDialog` | `EditEventDialogView` | Standalone / Series / Saving / ErrorState (+ submit prop-contract spy) |
| `DeleteEventDialog` | `DeleteEventDialogView` | Standalone / Cancel / Series / Deleting / ErrorState (onDelete/onCancel spies) |
| `CreateEventSheet` | `CreateEventSheetView` | Chooser / SingleForm / SingleError / Recurring (navigation spies) |

- **EditEventDialog** — all form state (scope, type, title, times, links) + the pending/error shells move into `EditEventDialogView`; the container keeps the event-types query, the `UpdateEvent` mutation, and the dialog open/close. The View builds the update request and hands it up via `onSubmit`.
- **DeleteEventDialog** — the scope state + pending/error shells move into `DeleteEventDialogView`; the container keeps the dynamic title/description chrome, the `DeleteEvent` mutation, and the post-delete navigation. The View hands the chosen scope up via `onDelete(scope)`.
- **CreateEventSheet** — the mode-dependent header (back step + title + description) and the chooser/form/wizard switch move into `CreateEventSheetView`; the container keeps the Sheet chrome, the event-types/season queries, and both mutations. Stories mount the View under a controlled `<Sheet open>` so `SheetTitle`/`SheetDescription` get their Radix Root context — no portal, no network. The composed child features (`CreateEntryChooser`, `CreateEventForm`, `RecurringEventsWizard`) already own their own state stories; this View covers only the sheet's own header + navigation seam.
- **GenerateInviteDialog** — already shells-down: `GenerateInviteContent` owns the `isPending`/`isError` states and has Pending/Error/Idle/Generated stories; the `DialogTitle` stays in the container as chrome. **No code change — ticked as done.**

Existing shell copy is reused verbatim ("Could not save changes. Please try again.", "Could not delete the event. Please try again.", "Saving…", "Deleting…", the create-event error strings) — no user-visible wording change.

## No new e2e

No new seam is introduced — the edit/delete/create flows run through the same authed API round-trips the attendance + login e2e flows already exercise. The container wiring stays covered by e2e; the new coverage is purely at the story layer. **Held the network line — no MSW in any story.**

## Verification

- `make test-app` green — **254 tests / 47 files**, including the **13 new story tests** (browser project, headless chromium).
- `npm --prefix app run typecheck` clean.
- `npm --prefix app run lint` clean.
- Pre-commit gate also ran detekt + `:api:test` + the real Playwright e2e suite (7 passed).

> **Chromatic:** the new `*View` stories are fresh snapshots — the **"UI Tests"** check will flag them as baselines needing a one-time accept.

Closes the shells-down section of #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)