### PR TITLE
feat(build): enforce hexagonal architecture with flock-detekt (walking skeleton, #18)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,3 +123,32 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   isn't load-bearing in the domain (per ADR-0001).
 - **Nevobo** — Dutch volleyball federation; source of external league standings
   (Competition context).
+
+### Architecture (hexagonal) ([ADR-0018](docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md))
+
+The backend is hexagonal (ports & adapters). These boundaries are enforced by the build
+(flock-detekt rulesets on `:api:detekt`), not just by convention. The four source layers under
+`com.github.zzave.teambalance.api` are **domain**, **application**, **infrastructure**, and
+**interfaces**.
+
+- **Domain** — Entities, value objects, and domain events. Framework-free: no Spring, JPA, or
+  other framework imports. The innermost layer; depends on nothing else here.
+- **Application** — Use cases (the `*Service` orchestrators) and the **port** interfaces they
+  need. Also framework-free (this is the stricter half of [ADR-0018](docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md)):
+  a service is a constructor-injected plain class, not a Spring `@Service`.
+- **Port** — An interface, owned by the domain/application side, describing something the
+  application needs from the outside world (`EventRepository`, `EmailSender`, `CurrentUserGateway`).
+  Named with a `Repository`, `Gateway`, `Port`, or `Client` suffix. The dependency-inversion seam:
+  the application depends on the port, never on the adapter. _Avoid_: interface, service interface.
+- **Adapter** — A concrete implementation of a **port** living in **infrastructure** (a JPA
+  repository, the Bunq client, an email sender). Named `*Adapter` or `*Impl`. Adapters talk to the
+  domain through ports, never directly to one another. _Avoid_: implementation, provider, gateway
+  (a gateway is the *port*, its adapter is the implementation).
+- **Value Object** — A domain type that replaces a raw primitive with a meaningful, type-safe one
+  — a Kotlin `@JvmInline value class` wrapping a single value (`EventId(UUID)`, `Email(String)`).
+  Converted to/from its primitive **only at the edges** (the JPA entity mapper and the Wirespec DTO
+  mapper); the Wirespec contract and DB schema are unchanged. _Avoid_: wrapper, id class.
+- **Composition Root** — The single Spring `@Configuration` in **infrastructure** that constructs
+  the framework-free application services from their ports. The **only** place autowiring happens
+  for those services; keeps the domain/application layers Spring-free. _Avoid_: DI config, wiring,
+  bean config (when specifically meaning this root).

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -7,6 +7,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 val wirespecVersion: String by project
 val testcontainersVersion: String by project
 val archunitVersion: String by project
+val flockDetektVersion: String by project
 
 plugins {
     kotlin("jvm")
@@ -81,6 +82,44 @@ dependencies {
     // Testing — ArchUnit
     testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
 
+    // flock-detekt hexagonal-architecture rulesets (issue #18)
+    detektPlugins("community.flock:hexagonal-detekt-rules:$flockDetektVersion")
+}
+
+// ┌───────────────────────────────────────────────────────────────────────────┐
+// │ TEMPORARY alpha.1 bridge — remove as a unit when flock-detekt ships a build │
+// │ compiled against detekt 2.0.0-alpha.2+. See ADR-0018.                       │
+// │                                                                             │
+// │ flock-detekt 1.1.0 is compiled against detekt 2.0.0-alpha.1 and references  │
+// │ dev.detekt.api.RuleSet$Id, which alpha.2 removed — so on alpha.2 its rules  │
+// │ fail to load (NoClassDefFoundError). We therefore pin the detekt PLUGIN to  │
+// │ alpha.1 (root build.gradle.kts) and bridge the two resulting frictions:     │
+// │                                                                             │
+// │ 1. io.spring.dependency-management force-aligns every kotlin-* artifact —    │
+// │    including kotlin-compiler-embeddable on detekt's own isolated runtime     │
+// │    classpath — to the project's Kotlin 2.3.0, so detekt aborts with          │
+// │    "compiled with Kotlin 2.2.20 but currently running with 2.3.0". Pin       │
+// │    detekt's OWN classpath back to detekt's supported Kotlin; the project     │
+// │    itself stays on 2.3.0. (https://detekt.dev/docs/gettingstarted/gradle)    │
+// │ 2. detekt's pinned 2.2.20 compiler only accepts JVM targets up to 24, but    │
+// │    this module's toolchain is Java 25. detekt only parses sources, so cap    │
+// │    the analysis JVM target at the highest value it accepts.                  │
+// │                                                                             │
+// │ To migrate: bump the plugin to alpha.2 + flockDetektVersion to the new       │
+// │ release, then delete this whole block. detekt.yml stays unchanged.          │
+// └───────────────────────────────────────────────────────────────────────────┘
+configurations.matching { it.name == "detekt" }.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin") {
+            useVersion(dev.detekt.gradle.plugin.getSupportedKotlinVersion())
+        }
+    }
+}
+tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
+    jvmTarget = "24"
+}
+tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
+    jvmTarget = "24"
 }
 
 java {
@@ -129,6 +168,21 @@ tasks.named<BootRun>("bootRun") {
 detekt {
     buildUponDefaultConfig = true
     config.setFrom(files("$projectDir/detekt.yml"))
+    // Existing hexagonal-rule violations are captured here so the build stays green while
+    // the refactor sub-issues (#19-#23) burn them down. New violations still fail the build.
+    baseline = file("$projectDir/detekt-baseline.xml")
+}
+
+// Enforce the hexagonal rules on production sources only. Test code legitimately wires
+// adapters across layers (this mirrors ArchUnit's DoNotIncludeTests), and the generated
+// Wirespec sources under build/ are contract code we never hand-edit — analysing either
+// would only produce noise. Applied to both the check and the baseline-creation tasks so
+// their file sets stay identical.
+tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
+    setSource(files("src/main/kotlin"))
+}
+tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
+    setSource(files("src/main/kotlin"))
 }
 
 // Wirespec code generation

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>AdapterCannotDependOnAdapter:DemoDataSeeder.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
+    <ID>AdapterCannotDependOnAdapter:E2eEnvironmentInitializer.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.UserContext</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTeamMemberRepository</ID>
+    <ID>AdapterCannotDependOnAdapter:UserContextCurrentTeamProvider.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext</ID>
+    <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
+    <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
+    <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>
+    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:AuthService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:AuthorizationService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
+    <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
+    <ID>DomainNoFrameworkImports:EventService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:EventService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:EventTypeService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.beans.factory.annotation.Value</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:MemberService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:PositionService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:EventReference.kt:EventReference$val title: String?</ID>
+    <ID>DomainNoPrimitiveObsession:EventReference.kt:EventReference$val url: String</ID>
+    <ID>DomainNoPrimitiveObsession:EventType.kt:EventType$val color: String?</ID>
+    <ID>DomainNoPrimitiveObsession:EventType.kt:EventType$val name: String</ID>
+    <ID>DomainNoPrimitiveObsession:Invitation.kt:Invitation$/** Salted SHA-256 of the invite token — never the plaintext (which is shown to the admin once). */ val tokenHash: String</ID>
+    <ID>DomainNoPrimitiveObsession:InvitationService.kt:GeneratedInvitation$val token: String</ID>
+    <ID>DomainNoPrimitiveObsession:MagicLinkToken.kt:MagicLinkToken$val email: String</ID>
+    <ID>DomainNoPrimitiveObsession:MagicLinkToken.kt:MagicLinkToken$val tokenHash: String</ID>
+    <ID>DomainNoPrimitiveObsession:Position.kt:Position$val label: String</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val displayName: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val onboarded: Boolean</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val position: String?</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val role: String</ID>
+    <ID>DomainNoPrimitiveObsession:User.kt:User$val displayName: String</ID>
+    <ID>DomainNoPrimitiveObsession:User.kt:User$val email: String</ID>
+    <ID>PortNamingConvention:EmailSender.kt:EmailSender</ID>
+    <ID>PortsInDomainOnly:SpringDataAttendanceRepository.kt:SpringDataAttendanceRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataEventRepository.kt:SpringDataEventRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataEventTypeRepository.kt:SpringDataEventTypeRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataInvitationRepository.kt:SpringDataInvitationRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataMagicLinkTokenRepository.kt:SpringDataMagicLinkTokenRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamMemberRepository.kt:SpringDataTeamMemberRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamPositionRepository.kt:SpringDataTeamPositionRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamSettingsRepository.kt:SpringDataTeamSettingsRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataUserRepository.kt:SpringDataUserRepository : JpaRepository</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/api/detekt.yml
+++ b/api/detekt.yml
@@ -1,7 +1,119 @@
 config:
   validation: true
-  warningsAsErrors: false
+  # flock hexagonal rules are enforced as build-breaking errors (ADR-0018).
+  warningsAsErrors: true
 
 style:
   MaxLineLength:
     maxLineLength: 140
+
+# ─── flock-detekt hexagonal rulesets (ADR-0018) ──────────────────────────────
+# Package-token mapping for this codebase. flock matches package *segments*
+# (bounded by dots), and everything here lives under
+# com.github.zzave.teambalance.api.*, so:
+#
+#   flock token   ->  our layer(s)
+#   ───────────       ──────────────────────────────────────────────
+#   domain        ->  domain + application  (both must be framework-free)
+#   port          ->  domain.port
+#   adapter       ->  infrastructure
+#   api (inbound) ->  interfaces
+#
+# CRITICAL: never use the literal token 'api' — our root package is
+# ...teambalance.api, so 'api' matches every file. The inbound layer is 'interfaces'.
+
+hexagonal-domain:
+  active: true
+  DomainNoPrimitiveObsession:
+    active: true
+    domainPackages: ['domain', 'application']
+    allowedPrimitives: []
+  DomainNoFrameworkImports:
+    active: true
+    domainPackages: ['domain', 'application']
+    forbiddenImports:
+      - 'org.springframework'
+      - 'io.ktor'
+      - 'jakarta'
+      - 'javax.servlet'
+      - 'io.micronaut'
+      - 'io.quarkus'
+      - 'org.hibernate'
+      - 'org.jooq'
+  # Opt-in strict allow-list; DomainNoFrameworkImports already covers the deny side.
+  DomainModelMustBeStandalone:
+    active: false
+    domainPackages: ['domain', 'application']
+  DomainMustBeImmutable:
+    active: true
+    domainPackages: ['domain', 'application']
+  ValueClassMustHaveJvmInline:
+    active: true
+    domainPackages: ['domain', 'application']
+    checkOnlyInDomain: false
+
+hexagonal-port:
+  active: true
+  PortMustBeInterface:
+    active: true
+    portPackages: ['port']
+    portSuffixes: ['Port', 'Repository', 'Gateway', 'Client']
+  PortNamingConvention:
+    active: true
+    portPackages: ['port']
+    allowedSuffixes: ['Port', 'Repository', 'Gateway', 'Client']
+  PortsInDomainOnly:
+    active: true
+    domainPackages: ['domain', 'application']
+    adapterPackages: ['infrastructure']
+    apiPackages: ['interfaces']
+    portSuffixes: ['Port', 'Repository', 'Gateway', 'Client']
+
+hexagonal-adapter:
+  active: true
+  AdapterMustImplementPort:
+    active: true
+    adapterPackages: ['infrastructure']
+    adapterPatterns: ['.*Adapter', '.*Impl']
+  AdapterNamingConvention:
+    active: true
+    adapterPackages: ['infrastructure']
+    allowedPatterns: ['.*Adapter', '.*Impl']
+    portSuffixes: ['Port', 'Repository', 'Gateway', 'Client']
+  AdapterCannotDependOnAdapter:
+    active: true
+    adapterPackages: ['infrastructure']
+
+hexagonal-dependency:
+  active: true
+  DomainCannotDependOnAdapters:
+    active: true
+    domainPackages: ['domain', 'application']
+    adapterPackages: ['infrastructure']
+  DomainCannotDependOnApi:
+    active: true
+    domainPackages: ['domain', 'application']
+    apiPackages: ['interfaces']
+  ApiCannotDependOnAdapters:
+    active: true
+    apiPackages: ['interfaces']
+    adapterPackages: ['infrastructure']
+  ApiCannotDependOnPorts:
+    active: true
+    apiPackages: ['interfaces']
+    portSuffixes: ['Port', 'Repository', 'Gateway', 'Client']
+    allowedPortTypes: []
+
+hexagonal-layering:
+  active: true
+  DtoOnlyInAdaptersOrApi:
+    active: true
+    domainPackages: ['domain', 'application']
+    adapterPackages: ['infrastructure']
+    apiPackages: ['interfaces']
+    dtoSuffixes: ['Dto', 'Request', 'Response']
+  NoServiceInApiOrAdapter:
+    active: true
+    apiPackages: ['interfaces']
+    adapterPackages: ['infrastructure']
+    serviceSuffixes: ['Service']

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
     id("org.springframework.boot") version "4.0.4" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("community.flock.wirespec.plugin.gradle") version "0.19.6" apply false
-    id("dev.detekt") version "2.0.0-alpha.2" apply false
+    // TEMPORARY: pinned to alpha.1 to load flock-detekt 1.1.0 (built against alpha.1).
+    // Bump back to 2.0.0-alpha.2 when flock ships an alpha.2 build. See ADR-0018 and the
+    // "TEMPORARY alpha.1 bridge" block in api/build.gradle.kts.
+    id("dev.detekt") version "2.0.0-alpha.1" apply false
 }
 
 allprojects {

--- a/docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md
+++ b/docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md
@@ -1,0 +1,118 @@
+# ADR-0018: Enforce hexagonal architecture in the build with flock-detekt
+
+- Status: Accepted
+- Date: 2026-07-31
+
+## Context
+
+The frontend already fails the build on any cross-layer import (eslint-plugin-boundaries).
+The backend enforces only **dependency direction** between layers — a bytecode-based ArchUnit
+test (`ArchitectureTest.kt`) — and nothing **inside** each layer. The domain can drift into
+framework imports, model fields stay raw primitives, ports/adapters get named inconsistently,
+and business logic leaks across layers. Architecture depends on reviewer vigilance, not on the
+build.
+
+Worse, bytecode analysis has blind spots. `interfaces/AuthController` imports
+`infrastructure.identity.SessionKeys`, yet ArchUnit's "interfaces must not depend on
+infrastructure" rule stays green: `SessionKeys.USER_ID` is a `const val`, which the Kotlin
+compiler **inlines**, leaving no bytecode reference for ArchUnit to see. A source-based analyzer
+catches it.
+
+We want the build to be the source of architectural truth: domain **and** application genuinely
+framework-free, ports/adapters named consistently, identifiers and meaningful strings modeled as
+value objects — mapped to primitives only at the edges.
+
+## Decision
+
+### 1. Adopt flock-detekt's five hexagonal rulesets as build-breaking errors
+
+Add `community.flock:hexagonal-detekt-rules` as a `detektPlugins` dependency and enable all five
+rulesets in `api/detekt.yml` with `config.warningsAsErrors: true`:
+
+- **hexagonal-domain** — `DomainNoPrimitiveObsession`, `DomainNoFrameworkImports`,
+  `DomainMustBeImmutable`, `ValueClassMustHaveJvmInline` (+ opt-in `DomainModelMustBeStandalone`,
+  left off — `DomainNoFrameworkImports` already covers the deny side).
+- **hexagonal-port** — `PortMustBeInterface`, `PortNamingConvention`, `PortsInDomainOnly`.
+- **hexagonal-adapter** — `AdapterMustImplementPort`, `AdapterNamingConvention`,
+  `AdapterCannotDependOnAdapter`.
+- **hexagonal-dependency** — `DomainCannotDependOnAdapters`, `DomainCannotDependOnApi`,
+  `ApiCannotDependOnAdapters`, `ApiCannotDependOnPorts`.
+- **hexagonal-layering** — `DtoOnlyInAdaptersOrApi`, `NoServiceInApiOrAdapter`.
+
+The Arrow (typed-error) rulesets are **not** adopted; error handling stays exception-based
+(`TeambalanceException`).
+
+Analysis runs on **production sources only** (`src/main/kotlin`) — test code legitimately wires
+adapters across layers (this mirrors ArchUnit's `DoNotIncludeTests()`), and the generated Wirespec
+sources under `build/` are contract code we never hand-edit.
+
+### 2. Package-token mapping (codebase-specific, and the subtle part)
+
+flock matches package **segments** (bounded by dots: `.token.`, `endsWith(.token)`, …). Every
+class here lives under `com.github.zzave.teambalance.api.*`, so the literal token **`api` matches
+every file** and must never appear in config. The mapping:
+
+| flock token     | our layer(s)              | rationale                                        |
+|-----------------|---------------------------|--------------------------------------------------|
+| `domain`        | `domain` **+ `application`** | both must be framework-free (this epic's core) |
+| `port`          | `domain.port`             | ports are interfaces owned by the domain         |
+| `adapter`       | `infrastructure`          | JPA/Bunq/email/identity adapters                 |
+| `api` (inbound) | **`interfaces`**          | controllers — the driving side; **not** `api`    |
+
+Port suffixes accept `Repository` and `Gateway` (our ports are `*Repository`; #19 introduces
+`*Gateway`). Adapter patterns are `.*Adapter` / `.*Impl` (a `*Repository` is a *port*, not an
+adapter, so it is deliberately excluded from the adapter patterns).
+
+### 3. Temporary alpha.1 compatibility bridge
+
+flock-detekt 1.1.0 is compiled against detekt **2.0.0-alpha.1** and references
+`dev.detekt.api.RuleSet$Id`, a class **removed in alpha.2** (which this repo runs). A compatibility
+spike settled the go/no-go:
+
+| Attempt                                   | Result                                                              |
+|-------------------------------------------|--------------------------------------------------------------------|
+| flock on detekt **alpha.2** (repo default) | ❌ `NoClassDefFoundError: dev.detekt.api.RuleSet$Id` — rules won't load |
+| Pin detekt down to **alpha.1**            | ❌ `detekt was compiled with Kotlin 2.2.20 but running with 2.3.0`  |
+| alpha.1 **+ detekt-runtime Kotlin pin + jvmTarget=24** | ✅ rules resolve, load, run, and fire            |
+
+The bridge (all isolated to detekt's own tooling — the app stays on Kotlin 2.3):
+
+1. Pin the **detekt plugin** to `2.0.0-alpha.1` (matches flock's binary API).
+2. Pin `kotlin-compiler-embeddable` **on detekt's isolated `detekt` classpath** back to detekt's
+   supported version, so `io.spring.dependency-management` can't force it to 2.3.0
+   (per <https://detekt.dev/docs/gettingstarted/gradle#dependencies>).
+3. Cap the Detekt tasks' `jvmTarget` at `24` (detekt's pinned compiler's max; it only parses).
+
+**Migration:** when flock ships a build compiled against detekt 2.0.0-alpha.2+, bump the plugin to
+alpha.2 and `flockDetektVersion` to the new release, then delete the bridge block. `detekt.yml` is
+unchanged. (The alpha.2-compatible flock build is being requested upstream.) flock is a
+single-maintainer repo; if the upstream bump stalls, the fallback is to vendor flock's rule sources
+recompiled against alpha.2.
+
+**Konsist was the pre-committed fallback** and was verified to compile and run under this repo's
+Kotlin 2.3 / Java 25 toolchain. It is **not** adopted: it is test-based (assertions in Kotest), with
+no detekt baseline, no `warningsAsErrors`, and no per-category rule config — so it does not fit the
+"exemptions-as-config, zero baseline" definition of done (see §4 and #24). flock keeps everything in
+one detekt pipeline.
+
+### 4. Existing violations baselined; exemptions belong in rule config, not the baseline
+
+A detekt baseline (`api/detekt-baseline.xml`, 59 entries) captures today's production violations so
+the build stays green while the refactor waves (#19–#23) burn them down. **The baseline is temporary
+scaffolding, not the end state.** Deliberate, permanent exemptions live in **versioned rule config**,
+never a grandfathered baseline. This is proven reachable: `DomainNoPrimitiveObsession.allowedPrimitives`
+exempts a specific primitive (e.g. `String`: 24 → 1 findings) while the rule **stays active** and
+still catches other primitives (`Boolean`, …). #24 deletes ArchUnit, removes the baseline entirely,
+and moves any surviving exemptions into rule config.
+
+## Consequences
+
+- **59 production violations** are baselined now, concentrated where the epic expects them:
+  `DomainNoPrimitiveObsession` (24) and `DomainNoFrameworkImports` in `application` (16) —
+  the framework-strip (#20/#21/#80) and value-object (#22/#23) waves erase these baseline entries.
+- **Source-based beats bytecode-based** for this: flock catches the `const val` inlining case above
+  that ArchUnit silently passes. #24 retires ArchUnit so there is a single source of truth.
+- The alpha.1 pin is **detekt-tooling-only and temporary**; production code, tests, and runtime stay
+  on Kotlin 2.3 / detekt-free.
+- **New guardrail is live now**: a forbidden framework import added to a domain/application class
+  fails `:api:detekt` immediately (verified), independent of the baseline.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,6 @@ javaVersion=25
 wirespecVersion=0.19.6
 testcontainersVersion=1.20.4
 archunitVersion=1.3.0
+flockDetektVersion=1.1.0
 kotestVersion=5.9.1
 kotestSpringExtensionVersion=1.3.0


### PR DESCRIPTION
## #18 — Walking skeleton: flock-detekt hexagonal enforcement (tracer 1)

Closes part of #17. flock-detekt's five hexagonal rulesets now run as **build-breaking checks on `:api:detekt`**, with existing violations baselined so the build stays green. **No production refactor** — the refactor waves (#19–#23) burn the baseline down; #24 retires ArchUnit and zeroes it.

### 🧭 Decisions for reviewer sign-off (this is a tracer decision-gate PR)

**1. GO with flock (not the Konsist fallback), via a TEMPORARY detekt-alpha.1 bridge.**

The compatibility spike (go/no-go):

| Attempt | Result |
|---|---|
| flock 1.1.0 on detekt **2.0.0-alpha.2** (repo default) | ❌ `NoClassDefFoundError: dev.detekt.api.RuleSet$Id` — removed alpha.1→alpha.2 |
| Pin detekt down to **alpha.1** alone | ❌ `detekt was compiled with Kotlin 2.2.20 but running with 2.3.0` |
| alpha.1 **+ detekt-runtime Kotlin pin + jvmTarget=24** | ✅ rules resolve, load, run, fire |
| Konsist fallback | ✅ compiles/runs under Kotlin 2.3, but test-based (no baseline / warningsAsErrors / per-category config) → fails the exemptions-as-config DoD. **Rejected.** |

The bridge is **isolated to detekt's own tooling — the app stays on Kotlin 2.3** — and is a single, clearly-marked, removable block. **Migration:** when flock ships an alpha.2-compatible build (being requested upstream), bump the plugin to alpha.2 + `flockDetektVersion`, delete the bridge block; `detekt.yml` is unchanged. If upstream stalls, the fallback is vendoring flock's rules recompiled against alpha.2.

**2. Approve ADR-0018 + the hexagonal glossary** added to `CONTEXT.md`.

### ✅ Acceptance checklist

- [x] flock rulesets resolve + run (documented under the alpha.1 bridge in ADR-0018).
- [x] All 5 hexagonal rulesets enabled as **errors** (`warningsAsErrors: true`); Arrow rulesets absent.
- [x] Baseline exists (`api/detekt-baseline.xml`, 59 prod violations); `./gradlew :api:detekt` + `:api:compileKotlin` green; full `:api:test` green (45s, Testcontainers).
- [x] **Negative test**: a new `org.springframework` import in `domain/model/Event.kt` fails `:api:detekt` via `DomainNoFrameworkImports` (not masked by the baseline), then reverted.
- [x] **Per-category config proven**: `DomainNoPrimitiveObsession.allowedPrimitives` exempts `String` (24→1 findings) while the rule stays active and still flags `Boolean` etc. — the exemptions-as-config mechanism #24 depends on.
- [x] ADR + glossary written at the next free ADR number (0018).

### Package-token mapping (codebase-specific — the subtle bit)

flock matches package **segments**, and everything lives under `com.github.zzave.teambalance.api.*`, so the literal token **`api` matches every file and is never used**. Mapping:

| flock token | our layer(s) |
|---|---|
| `domain` | `domain` + `application` (both framework-free) |
| `port` | `domain.port` |
| `adapter` | `infrastructure` |
| `api` (inbound) | `interfaces` |

Analysis is scoped to `src/main/kotlin` only (mirrors ArchUnit's `DoNotIncludeTests`; drops generated Wirespec under `build/`).

### Bonus: why source-based (flock) beats bytecode-based (ArchUnit)

`interfaces/AuthController` imports `infrastructure.identity.SessionKeys`, yet ArchUnit's "interfaces !→ infrastructure" stays green — `SessionKeys.USER_ID` is a `const val` that Kotlin **inlines**, leaving no bytecode reference. flock (source-based) catches it. Reinforces #24 (retire ArchUnit; flock as the single source of truth).

### ⚠️ CI / hook note

Backend gates are green locally: `:api:detekt` ✅ and full `:api:test` ✅ (via the pre-commit hook, Testcontainers). The pre-commit `test-app`/`e2e` steps could not complete in the dev sandbox due to a **pre-existing frontend env breakage** (`rolldown` linux-arm64 native binding missing) — unrelated to this backend-only diff. Commit was made with `--no-verify` (author-authorized); PR CI runs the real gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
