### PR TITLE
feat(build): enforce hexagonal architecture with flock-detekt (walking skeleton, #18)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,3 +123,32 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   isn't load-bearing in the domain (per ADR-0001).
 - **Nevobo** — Dutch volleyball federation; source of external league standings
   (Competition context).
+
+### Architecture (hexagonal) ([ADR-0018](docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md))
+
+The backend is hexagonal (ports & adapters). These boundaries are enforced by the build
+(flock-detekt rulesets on `:api:detekt`), not just by convention. The four source layers under
+`com.github.zzave.teambalance.api` are **domain**, **application**, **infrastructure**, and
+**interfaces**.
+
+- **Domain** — Entities, value objects, and domain events. Framework-free: no Spring, JPA, or
+  other framework imports. The innermost layer; depends on nothing else here.
+- **Application** — Use cases (the `*Service` orchestrators) and the **port** interfaces they
+  need. Also framework-free (this is the stricter half of [ADR-0018](docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md)):
+  a service is a constructor-injected plain class, not a Spring `@Service`.
+- **Port** — An interface, owned by the domain/application side, describing something the
+  application needs from the outside world (`EventRepository`, `EmailSender`, `CurrentUserGateway`).
+  Named with a `Repository`, `Gateway`, `Port`, or `Client` suffix. The dependency-inversion seam:
+  the application depends on the port, never on the adapter. _Avoid_: interface, service interface.
+- **Adapter** — A concrete implementation of a **port** living in **infrastructure** (a JPA
+  repository, the Bunq client, an email sender). Named `*Adapter` or `*Impl`. Adapters talk to the
+  domain through ports, never directly to one another. _Avoid_: implementation, provider, gateway
+  (a gateway is the *port*, its adapter is the implementation).
+- **Value Object** — A domain type that replaces a raw primitive with a meaningful, type-safe one
+  — a Kotlin `@JvmInline value class` wrapping a single value (`EventId(UUID)`, `Email(String)`).
+  Converted to/from its primitive **only at the edges** (the JPA entity mapper and the Wirespec DTO
+  mapper); the Wirespec contract and DB schema are unchanged. _Avoid_: wrapper, id class.
+- **Composition Root** — The single Spring `@Configuration` in **infrastructure** that constructs
+  the framework-free application services from their ports. The **only** place autowiring happens
+  for those services; keeps the domain/application layers Spring-free. _Avoid_: DI config, wiring,
+  bean config (when specifically meaning this root).

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -7,6 +7,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 val wirespecVersion: String by project
 val testcontainersVersion: String by project
 val archunitVersion: String by project
+val flockDetektVersion: String by project
 
 plugins {
     kotlin("jvm")
@@ -81,6 +82,21 @@ dependencies {
     // Testing — ArchUnit
     testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
 
+    // Hexagonal-architecture rulesets for detekt (ADR-0018)
+    detektPlugins("community.flock:hexagonal-detekt-rules:$flockDetektVersion")
+}
+
+// detekt analyses sources with its OWN embedded Kotlin compiler and refuses to start on any
+// other version. io.spring.dependency-management force-aligns every kotlin-* artifact — including
+// the ones on detekt's isolated `detekt` configuration — to the project's Kotlin, so without this
+// the task dies with "detekt was compiled with Kotlin <x> but is currently running with <y>".
+// getSupportedKotlinVersion() is the engine's own answer, so this stays correct across upgrades.
+configurations.matching { it.name == "detekt" }.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin") {
+            useVersion(dev.detekt.gradle.plugin.getSupportedKotlinVersion())
+        }
+    }
 }
 
 java {
@@ -129,6 +145,9 @@ tasks.named<BootRun>("bootRun") {
 detekt {
     buildUponDefaultConfig = true
     config.setFrom(files("$projectDir/detekt.yml"))
+    // Hexagonal violations that predate ADR-0018, so the build stays green while the refactor
+    // sub-issues burn them down. New violations are not in here and still fail the build.
+    baseline = file("$projectDir/detekt-baseline.xml")
 }
 
 // Wirespec code generation

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>AdapterCannotDependOnAdapter:DemoDataSeeder.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
+    <ID>AdapterCannotDependOnAdapter:E2eEnvironmentInitializer.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.UserContext</ID>
+    <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTeamMemberRepository</ID>
+    <ID>AdapterCannotDependOnAdapter:UserContextCurrentTeamProvider.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext</ID>
+    <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
+    <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
+    <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>
+    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:AuthService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:AuthorizationService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
+    <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
+    <ID>DomainNoFrameworkImports:EventService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:EventService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:EventTypeService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.beans.factory.annotation.Value</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:MemberService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:PositionService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.stereotype.Service</ID>
+    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:EventReference.kt:EventReference$val title: String?</ID>
+    <ID>DomainNoPrimitiveObsession:EventReference.kt:EventReference$val url: String</ID>
+    <ID>DomainNoPrimitiveObsession:EventType.kt:EventType$val color: String?</ID>
+    <ID>DomainNoPrimitiveObsession:EventType.kt:EventType$val name: String</ID>
+    <ID>DomainNoPrimitiveObsession:Invitation.kt:Invitation$/** Salted SHA-256 of the invite token — never the plaintext (which is shown to the admin once). */ val tokenHash: String</ID>
+    <ID>DomainNoPrimitiveObsession:InvitationService.kt:GeneratedInvitation$val token: String</ID>
+    <ID>DomainNoPrimitiveObsession:MagicLinkToken.kt:MagicLinkToken$val email: String</ID>
+    <ID>DomainNoPrimitiveObsession:MagicLinkToken.kt:MagicLinkToken$val tokenHash: String</ID>
+    <ID>DomainNoPrimitiveObsession:Position.kt:Position$val label: String</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:PotentialEvent.kt:PotentialEvent$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val description: String?</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val location: String?</ID>
+    <ID>DomainNoPrimitiveObsession:SeriesModification.kt:EventEdit$val title: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val displayName: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val onboarded: Boolean</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val position: String?</ID>
+    <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val role: String</ID>
+    <ID>DomainNoPrimitiveObsession:User.kt:User$val displayName: String</ID>
+    <ID>DomainNoPrimitiveObsession:User.kt:User$val email: String</ID>
+    <ID>PortNamingConvention:EmailSender.kt:EmailSender</ID>
+    <ID>PortsInDomainOnly:SpringDataAttendanceRepository.kt:SpringDataAttendanceRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataEventRepository.kt:SpringDataEventRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataEventTypeRepository.kt:SpringDataEventTypeRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataInvitationRepository.kt:SpringDataInvitationRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataMagicLinkTokenRepository.kt:SpringDataMagicLinkTokenRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamMemberRepository.kt:SpringDataTeamMemberRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamPositionRepository.kt:SpringDataTeamPositionRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataTeamSettingsRepository.kt:SpringDataTeamSettingsRepository : JpaRepository</ID>
+    <ID>PortsInDomainOnly:SpringDataUserRepository.kt:SpringDataUserRepository : JpaRepository</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/api/detekt.yml
+++ b/api/detekt.yml
@@ -5,3 +5,88 @@ config:
 style:
   MaxLineLength:
     maxLineLength: 140
+
+# ─── Hexagonal rulesets (flock-detekt) — see ADR-0018 ────────────────────────
+# Every rule is inactive until switched on here, so the `active: true` lines are
+# activation, not configuration. Rule PROPERTIES are deliberately left out: flock's
+# defaults already describe this codebase (port packages, port suffixes, adapter
+# packages/patterns, forbidden framework imports, DTO/service suffixes).
+#
+# Two package tokens do need overriding, because flock matches package SEGMENTS and
+# our layers are not named the way its defaults assume:
+#
+#   domainPackages: our `application` layer must be as framework-free as `domain`,
+#                   and we have no `core` package.
+#   apiPackages:    our inbound layer is `interfaces`. The default token `api` is
+#                   actively harmful here — the root package is
+#                   com.github.zzave.teambalance.api, so `api` matches every file.
+
+hexagonal-domain:
+  active: true
+  excludes: ['**/src/test/**']
+  DomainNoPrimitiveObsession:
+    active: true
+    domainPackages: ['domain', 'application']
+  DomainNoFrameworkImports:
+    active: true
+    domainPackages: ['domain', 'application']
+  # Opt-in allow-list, stricter than DomainNoFrameworkImports' deny-list. Left off
+  # (flock's own default) — the deny-list is the line this epic enforces.
+  DomainModelMustBeStandalone:
+    active: false
+  DomainMustBeImmutable:
+    active: true
+    domainPackages: ['domain', 'application']
+  ValueClassMustHaveJvmInline:
+    active: true
+    domainPackages: ['domain', 'application']
+
+hexagonal-port:
+  active: true
+  excludes: ['**/src/test/**']
+  PortMustBeInterface:
+    active: true
+  PortNamingConvention:
+    active: true
+  PortsInDomainOnly:
+    active: true
+    domainPackages: ['domain', 'application']
+    apiPackages: ['interfaces']
+
+hexagonal-adapter:
+  active: true
+  excludes: ['**/src/test/**']
+  AdapterMustImplementPort:
+    active: true
+  AdapterNamingConvention:
+    active: true
+  AdapterCannotDependOnAdapter:
+    active: true
+
+hexagonal-dependency:
+  active: true
+  excludes: ['**/src/test/**']
+  DomainCannotDependOnAdapters:
+    active: true
+    domainPackages: ['domain', 'application']
+  DomainCannotDependOnApi:
+    active: true
+    domainPackages: ['domain', 'application']
+    apiPackages: ['interfaces']
+  ApiCannotDependOnAdapters:
+    active: true
+    apiPackages: ['interfaces']
+  ApiCannotDependOnPorts:
+    active: true
+    apiPackages: ['interfaces']
+
+hexagonal-layering:
+  active: true
+  excludes: ['**/src/test/**']
+  DtoOnlyInAdaptersOrApi:
+    active: true
+    domainPackages: ['domain', 'application']
+    apiPackages: ['interfaces']
+  NoServiceInApiOrAdapter:
+    active: true
+    apiPackages: ['interfaces']

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.springframework.boot") version "4.0.4" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("community.flock.wirespec.plugin.gradle") version "0.19.6" apply false
-    id("dev.detekt") version "2.0.0-alpha.2" apply false
+    id("dev.detekt") version "2.0.0-alpha.5" apply false
 }
 
 allprojects {

--- a/docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md
+++ b/docs/adr/0018-enforce-hexagonal-architecture-with-flock-detekt.md
@@ -1,0 +1,127 @@
+# ADR-0018: Enforce hexagonal architecture in the build with flock-detekt
+
+- Status: Accepted
+- Date: 2026-08-01
+
+## Context
+
+The frontend already fails the build on any cross-layer import (eslint-plugin-boundaries).
+The backend enforces only **dependency direction** between layers — a bytecode-based ArchUnit
+test (`ArchitectureTest.kt`) — and nothing **inside** each layer. The domain can drift into
+framework imports, model fields stay raw primitives, ports/adapters get named inconsistently,
+and business logic leaks across layers. Architecture depends on reviewer vigilance, not on the
+build.
+
+Worse, bytecode analysis has blind spots. `interfaces/AuthController` imports
+`infrastructure.identity.SessionKeys`, yet ArchUnit's "interfaces must not depend on
+infrastructure" rule stays green: `SessionKeys.USER_ID` is a `const val`, which the Kotlin
+compiler **inlines**, leaving no bytecode reference for ArchUnit to see. A source-based analyzer
+catches it.
+
+We want the build to be the source of architectural truth: domain **and** application genuinely
+framework-free, ports/adapters named consistently, identifiers and meaningful strings modeled as
+value objects — mapped to primitives only at the edges.
+
+## Decision
+
+### 1. Adopt flock-detekt's five hexagonal rulesets as build-breaking errors
+
+Add `community.flock:hexagonal-detekt-rules` as a `detektPlugins` dependency and switch on all five
+rulesets in `api/detekt.yml`:
+
+- **hexagonal-domain** — `DomainNoPrimitiveObsession`, `DomainNoFrameworkImports`,
+  `DomainMustBeImmutable`, `ValueClassMustHaveJvmInline` (+ opt-in `DomainModelMustBeStandalone`,
+  left off — `DomainNoFrameworkImports` already covers the deny side).
+- **hexagonal-port** — `PortMustBeInterface`, `PortNamingConvention`, `PortsInDomainOnly`.
+- **hexagonal-adapter** — `AdapterMustImplementPort`, `AdapterNamingConvention`,
+  `AdapterCannotDependOnAdapter`.
+- **hexagonal-dependency** — `DomainCannotDependOnAdapters`, `DomainCannotDependOnApi`,
+  `ApiCannotDependOnAdapters`, `ApiCannotDependOnPorts`.
+- **hexagonal-layering** — `DtoOnlyInAdaptersOrApi`, `NoServiceInApiOrAdapter`.
+
+The Arrow (typed-error) rulesets are **not** adopted; error handling stays exception-based
+(`TeambalanceException`).
+
+These rules report at severity `error` on their own, so a violation fails `:api:detekt` without
+setting `config.warningsAsErrors`. That flag is deliberately left at its existing value (`false`):
+flipping it would also promote detekt's *own* style warnings to build failures, which is a separate
+decision with nothing to do with hexagonal enforcement.
+
+The rules apply to production code only: each ruleset carries
+`excludes: ['**/src/test/**']`, mirroring ArchUnit's `DoNotIncludeTests()` — test code legitimately
+wires adapters across layers. Test sources stay covered by detekt's ordinary style rules, which is
+why the exclusion sits on the rulesets rather than on the `detekt` task's source set. Generated
+Wirespec sources live under `build/` and are outside detekt's source set already.
+
+### 2. Configuration is activation, not duplication
+
+Every flock rule is **inactive until switched on** — the rulesets ship default config as a jar
+resource, but detekt does not load it at runtime, so a ruleset that is not named in `detekt.yml`
+silently does nothing. The `active: true` lines are therefore load-bearing.
+
+Rule **properties** are a different matter: flock's built-in defaults already describe this codebase
+(port packages, port suffixes `Port`/`Repository`/`Gateway`/`Client`, adapter packages incl.
+`infrastructure`, adapter patterns, the forbidden-framework-import list, DTO and service suffixes),
+so `detekt.yml` does not restate them. Restating a default only creates a second copy to keep in
+sync with upstream. Exactly **two** package tokens are overridden, and only because our layer names
+differ from what flock's defaults assume — see §3.
+
+### 3. Package-token mapping (codebase-specific, and the subtle part)
+
+flock matches package **segments** (bounded by dots: `.token.`, `endsWith(.token)`, …). Every
+class here lives under `com.github.zzave.teambalance.api.*`, so the literal token **`api` matches
+every file** and must never appear in config. The mapping:
+
+| flock token     | our layer(s)                | overridden? | rationale                                       |
+|-----------------|-----------------------------|-------------|-------------------------------------------------|
+| `domain`        | `domain` **+ `application`** | yes         | both must be framework-free (this epic's core)  |
+| `api` (inbound) | **`interfaces`**             | yes         | controllers — the driving side; **not** `api`   |
+| `port`          | `domain.port`                | no          | default `['port', 'ports']` already matches     |
+| `adapter`       | `infrastructure`             | no          | default already includes `infrastructure`       |
+
+### 4. Engine compatibility
+
+detekt 2.0 is pre-release and breaks its rule-provider API between alphas, so each flock release
+only loads on the engines it was compiled against (flock 1.2.0 ↔ detekt 2.0.0-alpha.4–alpha.5).
+This repo therefore moves from detekt `2.0.0-alpha.2` to **`2.0.0-alpha.5`** alongside flock
+**1.2.0**. The engine analyses sources with its own embedded Kotlin (2.4.0); the project stays on
+Kotlin 2.3.
+
+One line of build glue is required, and it is a detekt-wide issue rather than a flock one:
+`io.spring.dependency-management` force-aligns every `kotlin-*` artifact to the project's Kotlin
+version, including on detekt's isolated `detekt` classpath, and the engine hard-refuses to start on
+a Kotlin version other than its own. `api/build.gradle.kts` pins that configuration back to
+`dev.detekt.gradle.plugin.getSupportedKotlinVersion()` — the engine's own answer, so it stays
+correct across upgrades. This is the workaround detekt documents at
+<https://detekt.dev/docs/gettingstarted/gradle#dependencies>.
+
+**Konsist was the pre-committed fallback** and was verified to compile and run under this repo's
+Kotlin / Java toolchain. It is **not** adopted: it is test-based (assertions in Kotest), with no
+detekt baseline, no `warningsAsErrors`, and no per-category rule config — so it does not fit the
+"exemptions-as-config, zero baseline" definition of done (see §5). flock keeps everything in one
+detekt pipeline.
+
+### 5. Existing violations baselined; exemptions belong in rule config, not the baseline
+
+A detekt baseline (`api/detekt-baseline.xml`, 59 entries) captures today's production violations so
+the build stays green while the refactor waves burn them down. **The baseline is temporary
+scaffolding, not the end state.** Deliberate, permanent exemptions live in **versioned rule config**,
+never a grandfathered baseline. This is proven reachable: `DomainNoPrimitiveObsession.allowedPrimitives`
+exempts a specific primitive (e.g. `String`: 24 → 1 findings) while the rule **stays active** and
+still catches other primitives. The final sub-issue of this epic deletes ArchUnit, removes the
+baseline entirely, and moves any surviving exemptions into rule config.
+
+## Consequences
+
+- **59 production violations** are baselined now, concentrated where the epic expects them:
+  `DomainNoPrimitiveObsession` (24), `DomainNoFrameworkImports` in `application` (16),
+  `PortsInDomainOnly` (9), `AdapterCannotDependOnAdapter` (6), and four singles — the framework-strip
+  and value-object waves erase these baseline entries.
+- **Source-based beats bytecode-based** for this: flock catches the `const val` inlining case above
+  that ArchUnit silently passes. ArchUnit is retired at the end of the epic so there is a single
+  source of truth.
+- **detekt is pinned to a pre-release engine.** Upgrading detekt now means checking flock's
+  compatibility matrix first; a mismatched pair fails loudly at task start
+  (`NoClassDefFoundError` / "compiled with Kotlin x but running with y"), not silently.
+- **New guardrail is live now**: a forbidden framework import added to a domain/application class
+  fails `:api:detekt` immediately (verified), independent of the baseline.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,6 @@ javaVersion=25
 wirespecVersion=0.19.6
 testcontainersVersion=1.21.4
 archunitVersion=1.3.0
+flockDetektVersion=1.2.0
 kotestVersion=5.9.1
 kotestSpringExtensionVersion=1.3.0


### PR DESCRIPTION
## #18 — Walking skeleton: flock-detekt hexagonal enforcement (tracer 1)

Part of #17. Replaces the closed #153 — that PR carried a temporary detekt-**alpha.1** bridge because flock 1.1.0 could not load on a modern engine. Upstream has since shipped **flock-detekt 1.2.0** (2026-08-01, built against detekt 2.0.0-alpha.5), so **the entire bridge is gone**. This PR also acts on the review comment on #153: *"can we rely on the defaults from flock-detekt rather than overriding everything here?"*

flock's five hexagonal rulesets now run as build-breaking checks on `:api:detekt`, with today's violations baselined so the build stays green. **No production refactor** — the refactor waves burn the baseline down; the finale retires ArchUnit and zeroes it.

### 🧭 Decisions for reviewer sign-off

**1. The alpha.1 bridge is deleted.** `api/build.gradle.kts` shrank from **+54 lines to +19**; `detekt.yml` from **+114 to +85**. What remains is one documented workaround, and it is a *detekt* issue rather than a flock one:

```kotlin
configurations.matching { it.name == "detekt" }.all {
    resolutionStrategy.eachDependency {
        if (requested.group == "org.jetbrains.kotlin") {
            useVersion(dev.detekt.gradle.plugin.getSupportedKotlinVersion())
        }
    }
}
```

`io.spring.dependency-management` force-aligns every `kotlin-*` artifact — including on detekt's isolated `detekt` configuration — to the project's Kotlin, and the engine hard-refuses to start on anything but its own. This is the fix detekt itself documents. Using `getSupportedKotlinVersion()` rather than a literal keeps it correct across upgrades. No `jvmTarget` cap, no version pinned backwards.

**Engine bump: detekt `2.0.0-alpha.2` → `2.0.0-alpha.5`**, matching flock 1.2.0's compatibility matrix. This is the same bump Renovate proposes on `renovate/dev.detekt-2.x`; that PR would break `main` on its own (the Kotlin clash above), and this PR carries the fix — worth merging this first and letting Renovate's close as superseded.

**2. Answering the review comment: yes, defaults carry almost everything.**

| What | Source |
|---|---|
| port packages, port suffixes (`Port`/`Repository`/`Gateway`/`Client`) | **flock default** |
| adapter packages (incl. `infrastructure`), adapter patterns | **flock default** |
| forbidden framework imports, DTO suffixes, service suffixes, `allowedPrimitives` | **flock default** |
| `domainPackages: ['domain', 'application']` | **overridden** — our `application` layer must be as framework-free as `domain`, and we have no `core` |
| `apiPackages: ['interfaces']` | **overridden** — our inbound layer is `interfaces`, and the default token `api` is *actively harmful* here: the root package is `com.github.zzave.teambalance.api`, so `api` matches every file |

Two overrides, both codebase-specific, both explained in-file. Everything else was deleted as a redundant copy of upstream.

**Evidence it's equivalent:** the defaults-based config finds the **exact same 59 violations with the identical per-rule distribution** as #153's fully-overridden config — `DomainNoPrimitiveObsession` 24, `DomainNoFrameworkImports` 16, `PortsInDomainOnly` 9, `AdapterCannotDependOnAdapter` 6, plus four singles.

The `active: true` lines are **not** removable: flock ships default config as a jar resource but detekt does not load it at runtime, so a ruleset not named in `detekt.yml` silently does nothing. Verified — a config with only rule-set-level `active: true` and no per-rule entries produced **0 findings**.

**3. ⚠️ Deviation from the sub-issue's acceptance text: `warningsAsErrors` left at `false`.**

The acceptance says "enabled as errors (`warningsAsErrors: true`)". The rules already report at `severity="error"` on their own and fail the build — verified: the negative test below fails `:api:detekt` with `warningsAsErrors: false`. Flipping the flag would additionally promote detekt's *own* style warnings to build failures, an unrelated policy change. **The intent (hexagonal violations break the build) is met without it.** Say the word and it's a one-line change.

**4. Test sources excluded at the ruleset, not the task.** Each ruleset carries `excludes: ['**/src/test/**']`, mirroring ArchUnit's `DoNotIncludeTests()`. #153 instead scoped the whole `detekt` task to `src/main/kotlin`, which silently *dropped detekt's ordinary style rules from test code*. Excluding at the ruleset keeps that coverage. (Generated Wirespec lives under `build/` and is outside detekt's source set already — confirmed: 167 files analysed = 119 main + 48 test, with the 68 generated files present on disk.)

**5. Approve ADR-0018 + the hexagonal glossary** added to `CONTEXT.md`.

### ✅ Acceptance checklist

- [x] flock rulesets resolve + run — natively on detekt 2.0.0-alpha.5, no bridge.
- [x] All 5 hexagonal rulesets enabled; Arrow rulesets absent. *(As errors by rule severity, not via `warningsAsErrors` — see deviation 3.)*
- [x] Baseline exists (`api/detekt-baseline.xml`, 59 entries); `./gradlew :api:detekt` green; `./gradlew build -x test` green.
- [x] **Negative test**: a new `org.springframework.stereotype.Component` import in `domain/model/Event.kt` fails `:api:detekt` via `DomainNoFrameworkImports` — not masked by the baseline — then reverted.
- [x] **Per-category config proven**: `DomainNoPrimitiveObsession.allowedPrimitives: ['String']` takes that rule 24 → 1 findings while it stays active and still flags other primitives — the exemptions-as-config mechanism the finale depends on.
- [x] ADR + glossary at the next free number (0018).

### Bonus: why source-based (flock) beats bytecode-based (ArchUnit)

`interfaces/AuthController` imports `infrastructure.identity.SessionKeys`, yet ArchUnit's "interfaces !→ infrastructure" rule stays green — `SessionKeys.USER_ID` is a `const val` that Kotlin **inlines**, leaving no bytecode reference. flock catches it. Reinforces retiring ArchUnit at the end of the epic.

### Verification

Full pre-commit gate (`make format test e2e`) ran on **both** commits, no `--no-verify`: detekt ✅, `:api:test` ✅ (Testcontainers), `test-app` ✅ (47 files / 255 tests), real full-stack Playwright ✅ (7 passed). Plus `./gradlew build -x test` ✅.

<sub>Note: `./gradlew build` also runs `:installGitHooks`, which fails inside a **git worktree** because `.git` is a file there rather than a directory. Pre-existing and unrelated — `build.gradle.kts` is untouched apart from the detekt version line.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
