### PR TITLE
refactor(api): reclassify the identity providers as domain gateways (#19)

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -7,7 +7,7 @@
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.UserContext</ID>
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTeamMemberRepository</ID>
-    <ID>AdapterCannotDependOnAdapter:UserContextCurrentTeamProvider.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext</ID>
+    <ID>AdapterCannotDependOnAdapter:UserContextCurrentTeamAdapter.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext</ID>
     <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
     <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>

--- a/api/detekt.yml
+++ b/api/detekt.yml
@@ -79,6 +79,12 @@ hexagonal-dependency:
   ApiCannotDependOnPorts:
     active: true
     apiPackages: ['interfaces']
+    # The two identity gateways answer "who is calling, and for which team" — request context the
+    # inbound adapter owns, not data the application reaches out for. Controllers read them and pass
+    # the ids in as explicit arguments, which is what keeps the services pure functions of their
+    # parameters (see #19 / ADR-0018). Exempted by exact type name, so no other port slips through;
+    # AuthController's TeamMemberRepository dependency is a real breach and stays baselined.
+    allowedPortTypes: ['CurrentUserGateway', 'CurrentTeamGateway']
 
 hexagonal-layering:
   active: true

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
@@ -1,8 +1,8 @@
-package com.github.zzave.teambalance.api.application
+package com.github.zzave.teambalance.api.domain.port
 
 import java.util.UUID
 
-interface CurrentTeamProvider {
+interface CurrentTeamGateway {
     /** The team resolved for the current request, or throws if the caller has no active team. */
     fun requireCurrentTeamId(): UUID
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentUserGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentUserGateway.kt
@@ -1,8 +1,8 @@
-package com.github.zzave.teambalance.api.application
+package com.github.zzave.teambalance.api.domain.port
 
 import java.util.UUID
 
-interface CurrentUserProvider {
+interface CurrentUserGateway {
     fun getCurrentUserId(): UUID?
     fun requireCurrentUserId(): UUID
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentTeamAdapter.kt
@@ -1,7 +1,7 @@
 package com.github.zzave.teambalance.api.infrastructure.identity
 
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
 import com.github.zzave.teambalance.api.domain.exception.NoTeamMembershipException
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.CurrentTeamContext
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -12,7 +12,7 @@ import java.util.UUID
  * agree, with no second round-trip.
  */
 @Component
-class UserContextCurrentTeamProvider : CurrentTeamProvider {
+class UserContextCurrentTeamAdapter : CurrentTeamGateway {
     override fun requireCurrentTeamId(): UUID =
         CurrentTeamContext.get() ?: throw NoTeamMembershipException(UserContext.require())
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentUserAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/UserContextCurrentUserAdapter.kt
@@ -1,11 +1,11 @@
 package com.github.zzave.teambalance.api.infrastructure.identity
 
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
-class UserContextCurrentUserProvider : CurrentUserProvider {
+class UserContextCurrentUserAdapter : CurrentUserGateway {
     override fun getCurrentUserId(): UUID? = UserContext.get()
     override fun requireCurrentUserId(): UUID = UserContext.require()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
@@ -1,10 +1,10 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
 import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.SetAttendance
 import com.github.zzave.teambalance.api.interfaces.generated.model.Attendance
 import org.springframework.web.bind.annotation.RestController
@@ -13,12 +13,12 @@ import java.util.UUID
 @RestController
 class AttendanceController(
     private val attendanceService: AttendanceService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : SetAttendance.Handler {
 
     override suspend fun setAttendance(request: SetAttendance.Request): SetAttendance.Response<*> {
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         val eventId = UUID.fromString(request.path.eventId)
         val userId = UUID.fromString(request.path.userId)
         val state = AttendanceState.valueOf(request.body.state)
@@ -28,7 +28,7 @@ class AttendanceController(
             eventId = eventId,
             userId = userId,
             state = state,
-            changedBy = currentUserProvider.requireCurrentUserId(),
+            changedBy = currentUserGateway.requireCurrentUserId(),
         ) ?: return SetAttendance.Response404(Unit)
 
         val member = attendanceService.findMember(userId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -1,8 +1,6 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.application.PotentialEvent
 import com.github.zzave.teambalance.api.domain.model.AttendanceState as DomainAttendanceState
@@ -11,6 +9,8 @@ import com.github.zzave.teambalance.api.domain.model.EventReference as DomainEve
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope as DomainEventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.MemberAttendance
 import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.model.EventSeriesScope as GeneratedEventSeriesScope
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateEvent
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.DeleteEvent
@@ -35,8 +35,8 @@ import java.util.UUID
 class EventController(
     private val eventService: EventService,
     private val attendanceService: AttendanceService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : ListEvents.Handler,
     CreateEvent.Handler,
     GetEvent.Handler,
@@ -44,7 +44,7 @@ class EventController(
     DeleteEvent.Handler {
 
     override suspend fun listEvents(request: ListEvents.Request): ListEvents.Response<*> {
-        val members = attendanceService.teamMembers(currentTeamProvider.requireCurrentTeamId())
+        val members = attendanceService.teamMembers(currentTeamGateway.requireCurrentTeamId())
         val events = if (request.queries.includepast) eventService.getAllEvents() else eventService.getUpcomingEvents()
         val attendance = attendanceService.attendanceForAll(events.map { it.id }, members)
         return ListEvents.Response200(
@@ -53,8 +53,8 @@ class EventController(
     }
 
     override suspend fun createEvent(request: CreateEvent.Request): CreateEvent.Response<*> {
-        val teamId = currentTeamProvider.requireCurrentTeamId()
-        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
         val event = eventService.createEvent(
             callerId = userId,
             teamId = teamId,
@@ -70,7 +70,7 @@ class EventController(
         val event = eventService.getEvent(id)
             ?: return GetEvent.Response404(Unit)
 
-        val members = attendanceService.teamMembers(currentTeamProvider.requireCurrentTeamId())
+        val members = attendanceService.teamMembers(currentTeamGateway.requireCurrentTeamId())
         val attendance = attendanceService.attendanceFor(id, members)
 
         return GetEvent.Response200(
@@ -93,8 +93,8 @@ class EventController(
     // Scoped edit (ADR-0014, Phase 3): a bulk scope touches many rows, so the success type is an
     // EventList of the affected occurrences. The scope query param defaults to THIS when absent.
     override suspend fun updateEvent(request: UpdateEvent.Request): UpdateEvent.Response<*> {
-        val teamId = currentTeamProvider.requireCurrentTeamId()
-        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
         val id = UUID.fromString(request.path.id)
         val req = request.body
         val events = eventService.updateEvent(
@@ -117,8 +117,8 @@ class EventController(
     }
 
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
-        val teamId = currentTeamProvider.requireCurrentTeamId()
-        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
         val id = UUID.fromString(request.path.id)
         return if (eventService.deleteEvent(callerId = userId, teamId = teamId, id = id, scope = request.queries.scope.consume())) {
             DeleteEvent.Response204(Unit)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -1,8 +1,8 @@
 package com.github.zzave.teambalance.api.interfaces
 
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.InvitationService
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireInvitations
@@ -14,16 +14,16 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class InvitationController(
     private val invitationService: InvitationService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : CreateInvitation.Handler,
     AcceptInvitation.Handler,
     ExpireInvitations.Handler,
     RotateInvitation.Handler {
 
     override suspend fun createInvitation(request: CreateInvitation.Request): CreateInvitation.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
 
         val invitation = invitationService.generateInviteLink(callerId = userId, teamId = teamId)
         return CreateInvitation.Response201(
@@ -35,23 +35,23 @@ class InvitationController(
     }
 
     override suspend fun acceptInvitation(request: AcceptInvitation.Request): AcceptInvitation.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
+        val userId = currentUserGateway.requireCurrentUserId()
         val teamId = invitationService.acceptInvitation(request.path.token, userId)
             ?: return AcceptInvitation.Response404(Unit)
         return AcceptInvitation.Response200(AcceptedInvitation(teamId = teamId.toString()))
     }
 
     override suspend fun expireInvitations(request: ExpireInvitations.Request): ExpireInvitations.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
 
         invitationService.expireActiveInvitations(callerId = userId, teamId = teamId)
         return ExpireInvitations.Response204(Unit)
     }
 
     override suspend fun rotateInvitation(request: RotateInvitation.Request): RotateInvitation.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
 
         val invitation = invitationService.rotateInviteLink(callerId = userId, teamId = teamId)
         return RotateInvitation.Response201(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/MemberController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/MemberController.kt
@@ -1,11 +1,11 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AuthorizationService
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.MemberService
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CompleteOnboarding
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetCurrentMember
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ListMembers
@@ -20,8 +20,8 @@ import java.util.UUID
 @RestController
 class MemberController(
     private val memberService: MemberService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
     private val authorizationService: AuthorizationService,
 ) : GetCurrentMember.Handler,
     ListMembers.Handler,
@@ -30,21 +30,21 @@ class MemberController(
     RemoveMember.Handler {
 
     override suspend fun getCurrentMember(request: GetCurrentMember.Request): GetCurrentMember.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         return GetCurrentMember.Response200(memberService.getMember(teamId, userId).toDto())
     }
 
     override suspend fun listMembers(request: ListMembers.Request): ListMembers.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         authorizationService.requireAdmin(caller, teamId)
         return ListMembers.Response200(MemberList(memberService.listMembers(teamId).map { it.toDto() }))
     }
 
     override suspend fun updateMember(request: UpdateMember.Request): UpdateMember.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         // Admin-vs-self and role guards are enforced in the service, not here.
         val updated = memberService.updateMember(
             callerId = caller,
@@ -58,8 +58,8 @@ class MemberController(
     }
 
     override suspend fun completeOnboarding(request: CompleteOnboarding.Request): CompleteOnboarding.Response<*> {
-        val userId = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         // Onboarding is self-only and never changes role — the request's role field is ignored.
         val updated = memberService.completeOnboarding(
             userId = userId,
@@ -71,8 +71,8 @@ class MemberController(
     }
 
     override suspend fun removeMember(request: RemoveMember.Request): RemoveMember.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         memberService.removeMember(caller, teamId, UUID.fromString(request.path.userId))
         return RemoveMember.Response204(Unit)
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/PositionController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/PositionController.kt
@@ -1,9 +1,9 @@
 package com.github.zzave.teambalance.api.interfaces
 
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.PositionService
 import com.github.zzave.teambalance.api.domain.model.Position
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreatePosition
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.DeletePosition
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ListPositions
@@ -16,8 +16,8 @@ import com.github.zzave.teambalance.api.interfaces.generated.model.Position as P
 @RestController
 class PositionController(
     private val positionService: PositionService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : ListPositions.Handler,
     CreatePosition.Handler,
     RenamePosition.Handler,
@@ -25,21 +25,21 @@ class PositionController(
 
     override suspend fun listPositions(request: ListPositions.Request): ListPositions.Response<*> {
         // Any authenticated member may read the vocabulary; requireCurrentUserId fails closed with 401.
-        currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         return ListPositions.Response200(PositionList(positionService.listPositions(teamId).map { it.toDto() }))
     }
 
     override suspend fun createPosition(request: CreatePosition.Request): CreatePosition.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         val created = positionService.createPosition(caller, teamId, request.body.label)
         return CreatePosition.Response201(created.toDto())
     }
 
     override suspend fun renamePosition(request: RenamePosition.Request): RenamePosition.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         val renamed = positionService.renamePosition(
             callerId = caller,
             teamId = teamId,
@@ -50,8 +50,8 @@ class PositionController(
     }
 
     override suspend fun deletePosition(request: DeletePosition.Request): DeletePosition.Response<*> {
-        val caller = currentUserProvider.requireCurrentUserId()
-        val teamId = currentTeamProvider.requireCurrentTeamId()
+        val caller = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
         positionService.deletePosition(caller, teamId, UUID.fromString(request.path.id))
         return DeletePosition.Response204(Unit)
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventController.kt
@@ -1,11 +1,11 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AttendanceService
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.domain.model.Recurrence
 import com.github.zzave.teambalance.api.domain.model.RecurrenceFrequency as DomainRecurrenceFrequency
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateRecurringEvents
 import com.github.zzave.teambalance.api.interfaces.generated.model.RecurrenceFrequency
 import com.github.zzave.teambalance.api.interfaces.generated.model.RecurringEventSeries
@@ -20,15 +20,15 @@ import java.util.UUID
 class RecurringEventController(
     private val eventService: EventService,
     private val attendanceService: AttendanceService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : CreateRecurringEvents.Handler {
 
     // Admin-only, mirroring single-event create — enforced in EventService.createRecurringEvents.
     // Season/cap/empty violations surface as 422 via the GlobalExceptionHandler; a non-admin as 403.
     override suspend fun createRecurringEvents(request: CreateRecurringEvents.Request): CreateRecurringEvents.Response<*> {
-        val teamId = currentTeamProvider.requireCurrentTeamId()
-        val userId = currentUserProvider.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+        val userId = currentUserGateway.requireCurrentUserId()
 
         val body = request.body
         val series = eventService.createRecurringEvents(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonController.kt
@@ -1,9 +1,9 @@
 package com.github.zzave.teambalance.api.interfaces
 
-import com.github.zzave.teambalance.api.application.CurrentTeamProvider
-import com.github.zzave.teambalance.api.application.CurrentUserProvider
 import com.github.zzave.teambalance.api.application.SeasonService
 import com.github.zzave.teambalance.api.domain.model.Season as DomainSeason
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetSeason
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.SetSeason
 import com.github.zzave.teambalance.api.interfaces.generated.model.Season
@@ -14,8 +14,8 @@ import java.time.LocalDate
 @RestController
 class SeasonController(
     private val seasonService: SeasonService,
-    private val currentUserProvider: CurrentUserProvider,
-    private val currentTeamProvider: CurrentTeamProvider,
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : GetSeason.Handler,
     SetSeason.Handler {
 
@@ -26,8 +26,8 @@ class SeasonController(
     // Admin-only (enforced in SeasonService.setSeason); a non-admin surfaces as 403 via the handler.
     override suspend fun setSeason(request: SetSeason.Request): SetSeason.Response<*> {
         val season = seasonService.setSeason(
-            callerId = currentUserProvider.requireCurrentUserId(),
-            teamId = currentTeamProvider.requireCurrentTeamId(),
+            callerId = currentUserGateway.requireCurrentUserId(),
+            teamId = currentTeamGateway.requireCurrentTeamId(),
             start = request.body.start?.toLocalDate(),
             end = request.body.end?.toLocalDate(),
         )


### PR DESCRIPTION
Closes #19. Wave 3 of the flock-detekt hexagonal-enforcement epic (#17), first mechanical rollout.

`CurrentUserProvider` and `CurrentTeamProvider` were application-layer interfaces whose only implementations live in `infrastructure/identity` — driven ports in everything but name and location. They now live in `domain/port` as `CurrentUserGateway` / `CurrentTeamGateway`, and their adapters are `UserContextCurrentUserAdapter` / `UserContextCurrentTeamAdapter`.

The adapter rename is required, not cosmetic: once the interface carries a flock port suffix, `AdapterNamingConvention` demands its implementor in an adapter package match `.*Adapter`/`.*Impl`/`.*Client`/`Mock.*`.

## ⚠️ The ticket's premise was stale — please read before reviewing the config change

The acceptance criterion "remove the baseline entries for these ports" is **vacuous: there were none.**

flock recognises a port by **suffix** (`Port`/`Repository`/`Gateway`/`Client`). `…Provider` was invisible to the port and dependency rulesets, so `PortsInDomainOnly` and `PortNamingConvention` never fired on these two. The baseline before *and* after holds exactly `PortNamingConvention:EmailSender.kt` plus nine `PortsInDomainOnly:SpringData*Repository` entries.

So this ticket does not remove suppression — **it turns enforcement on.** Renaming into a port suffix *creates* findings. Worth carrying forward to any future `*→Gateway`/`*→Port` rename.

## The 14 findings that appeared, and how they're resolved

Naming them ports makes flock see them as ports, which surfaced 14 `ApiCannotDependOnPorts` violations (7 controllers × 2): every controller reads the caller and team id from these gateways.

Resolved as **exemption-as-config** — the mechanism this epic's DoD calls for (#24) — rather than a baseline:

```yaml
ApiCannotDependOnPorts:
  active: true
  apiPackages: ['interfaces']
  allowedPortTypes: ['CurrentUserGateway', 'CurrentTeamGateway']
```

**Why this dependency is deliberate.** These two answer *"who is calling, and for which team"* — request context the **inbound adapter** owns, not data the application reaches out for. Controllers read them and pass the ids in as explicit arguments, and that explicitness is exactly what keeps the application services pure functions of their parameters (their unit tests need no request-context fake) — the property #20 established and #21/#80 depend on.

**Proven precise, not a rule kill.** Adding `SeasonRepository` to `SeasonController` still fails `:api:detekt` with `ApiCannotDependOnPorts` (run, observed, reverted). `AuthController`'s `TeamMemberRepository` dependency — a genuine layering breach — stays baselined and untouched.

**Baseline net change: zero removals, zero additions.** One entry's *filename* follows the adapter rename (`AdapterCannotDependOnAdapter:UserContextCurrentTeamAdapter.kt`) — a pre-existing `infrastructure.identity → infrastructure.multitenancy` import, out of scope here.

### Alternatives I rejected — happy to be overruled

| | Approach | Why not |
|---|---|---|
| (a) | Push gateway consumption down into the 9 application services so each self-resolves the caller | Satisfies the rule organically, but makes every service request-scope-dependent, changes most service signatures, and collides head-on with #21/#80, which are rewriting those same services |
| (b) | An application-layer pass-through facade wrapping both gateways (`interfaces → application → ports`) | Satisfies the rule with no exemption, but is a class with zero behaviour added only to placate a linter |
| (c) | Baseline the 14 | Contradicts #24's zero-baseline definition of done |

**For #24:** the exemption ledger is now three entries, all due for sign-off at the finale — `DomainModelMustBeStandalone active:false` (flock's own default), `config.warningsAsErrors:false` (#18's declared deviation), and this one.

## Acceptance

- [x] Both ports live in the domain port package with `Gateway` names.
- [x] Adapters + all call sites updated; app boots and behaves identically.
- [x] Baseline entries for these ports removed; `:api:detekt` stays green. *(Green — but see above: there were no such entries to remove.)*
- [x] `TeamBalanceIT` + existing tests pass.

## Verification

- `./gradlew :api:detekt` green — and red in exactly the expected 14 places before the exemption.
- `:api:test` **293/293**, counted from the JUnit XML rather than trusting `BUILD SUCCESSFUL` — same count as `main`. Every `@SpringBootTest` IT boots, which is what proves the renamed `@Component` adapters are still discovered and injected into the controllers.
- `test-app` 47 files / 255 tests.
- Real full-stack Playwright (`./scripts/e2e.sh`): **7/7 passed** — login, attendance toggle, onboarding, auth guard, logout. Precisely the caller-identity paths this change touches.
- ArchUnit: all 6 rules green (`interfaces → domain.port` is an allowed direction).
- Pre-commit hook ran with no `--no-verify`.

#20's read-boundary lesson does **not** apply here: no service lost a `@Transactional` and no adapter read path changed, so there's no detached-entity hazard. (It still applies in full to #21/#80.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
