### PR TITLE
feat(api): startup tenant-migration runner (Slice 1, #154)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -1,0 +1,10 @@
+package com.github.zzave.teambalance.api.domain.port
+
+/**
+ * Read-side access to platform-level teams. Minimal by design: Slice 1 only needs the tenant schema
+ * names to keep every team's schema migrated at boot; the full Team aggregate arrives with create-team.
+ */
+interface TeamRepository {
+    /** Schema names of all teams — the source of truth for which tenant schemas must exist. */
+    fun findAllSchemaNames(): List<String>
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunner.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunner.kt
@@ -1,0 +1,19 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import org.springframework.stereotype.Component
+
+/**
+ * Brings every team's tenant schema up to head, so no schema drifts behind (retires the manual
+ * docker-Flyway step for existing teams). Provisioning is idempotent, so running it repeatedly — or
+ * against schemas that are already current — is safe.
+ */
+@Component
+class StartupTenantMigrationRunner(
+    private val teamRepository: TeamRepository,
+    private val tenantSchemaManager: TenantSchemaManager,
+) {
+    fun migrateAllTenantSchemas() {
+        teamRepository.findAllSchemaNames().forEach(tenantSchemaManager::provisionTenantSchema)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunner.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunner.kt
@@ -1,18 +1,28 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.context.annotation.DependsOn
 import org.springframework.stereotype.Component
 
 /**
- * Brings every team's tenant schema up to head, so no schema drifts behind (retires the manual
- * docker-Flyway step for existing teams). Provisioning is idempotent, so running it repeatedly — or
- * against schemas that are already current — is safe.
+ * Brings every team's tenant schema up to head at startup, so no schema drifts behind (retires the
+ * manual docker-Flyway step for existing teams). Provisioning is idempotent, so running it repeatedly
+ * — or against schemas that are already current — is safe.
+ *
+ * Runs during context refresh as an [InitializingBean] (mirroring [PlatformSchemaInitializer]) so it
+ * completes before boot is "done", closing the startup race. `@DependsOn` orders it after
+ * [PlatformSchemaInitializer], which creates `public.teams` — the source of truth this reads.
  */
 @Component
+@DependsOn("platformSchemaInitializer")
 class StartupTenantMigrationRunner(
     private val teamRepository: TeamRepository,
     private val tenantSchemaManager: TenantSchemaManager,
-) {
+) : InitializingBean {
+
+    override fun afterPropertiesSet() = migrateAllTenantSchemas()
+
     fun migrateAllTenantSchemas() {
         teamRepository.findAllSchemaNames().forEach(tenantSchemaManager::provisionTenantSchema)
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -1,0 +1,20 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+/**
+ * Reads `public.teams` over the raw datasource (via [JdbcTemplate]), not Hibernate. The startup
+ * runner queries this with no tenant resolved, when the tenant-routed JPA path fails closed; the
+ * explicit `public.` qualification keeps the read reachable regardless of the connection's search_path
+ * — the same approach the sibling platform-boot code (TenantSchemaManager) uses.
+ */
+@Repository
+class JdbcTeamRepositoryAdapter(
+    private val jdbcTemplate: JdbcTemplate,
+) : TeamRepository {
+    override fun findAllSchemaNames(): List<String> =
+        // schema_name is NOT NULL; filterNotNull only satisfies queryForList's nullable element type.
+        jdbcTemplate.queryForList("SELECT schema_name FROM public.teams", String::class.java).filterNotNull()
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
@@ -1,0 +1,76 @@
+package com.github.zzave.teambalance.api.infrastructure.multitenancy
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.UUID
+
+/**
+ * Slice 1 — the startup tenant-migration runner iterates `public.teams` and migrates every tenant
+ * schema to head on boot, so no team schema drifts behind (retires the manual docker-Flyway step).
+ *
+ * This test owns only the runner's unique behavior: that it reaches into `public.teams` and brings
+ * *each* team's schema to head. The "a provisioned schema has all the right tables" contract is owned
+ * one layer down by [TenantSchemaManagerTest] (the runner delegates to the same provisioning path),
+ * so we don't re-assert table structure here.
+ *
+ * Driven through the runner's public entry point (not full boot) so the same harness carries the
+ * isolate-and-continue / fail-fast cases; provisioning is idempotent so re-invoking is safe.
+ */
+class StartupTenantMigrationRunnerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var runner: StartupTenantMigrationRunner
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    init {
+        test("migrates every tenant schema listed in public.teams to head") {
+            val schemas = listOf(seedTeam(), seedTeam())
+
+            runner.migrateAllTenantSchemas()
+
+            val head = tenantMigrationsOnClasspath()
+            for (schema in schemas) {
+                appliedTenantMigrations(schema) shouldBe head
+            }
+        }
+    }
+
+    /** Inserts a memberless team with a fresh, unique schema name and returns that schema name. */
+    private fun seedTeam(): String {
+        val token = UUID.randomUUID().toString().replace("-", "").take(12)
+        val schema = "team_s1_$token"
+        jdbcTemplate.update(
+            "INSERT INTO public.teams (name, slug, sport, schema_name) VALUES (?, ?, ?, ?)",
+            "Slice1 $token",
+            "slice1-$token",
+            "Volleyball",
+            schema,
+        )
+        return schema
+    }
+
+    /**
+     * Number of versioned migrations successfully applied in [schema] (baseline excluded). Throws if
+     * the schema was never provisioned — a runner that skips a team therefore fails this test loudly.
+     */
+    private fun appliedTenantMigrations(schema: String): Int = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM \"$schema\".flyway_tenant_schema_history " +
+            "WHERE success = true AND version IS NOT NULL AND \"type\" <> 'BASELINE'",
+        Int::class.java,
+    ) ?: 0
+
+    /**
+     * Parity source of truth: the versioned migrations the runner actually points at
+     * (`classpath:db/tenant-migration`). Derived from the folder so adding a migration keeps this
+     * test honest without editing a magic number.
+     */
+    private fun tenantMigrationsOnClasspath(): Int =
+        PathMatchingResourcePatternResolver()
+            .getResources("classpath*:db/tenant-migration/V*__*.sql")
+            .size
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
@@ -1,8 +1,12 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
 import com.github.zzave.teambalance.api.TeamBalanceIT
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import org.springframework.jdbc.core.JdbcTemplate
 import java.util.UUID
@@ -16,8 +20,9 @@ import java.util.UUID
  * one layer down by [TenantSchemaManagerTest] (the runner delegates to the same provisioning path),
  * so we don't re-assert table structure here.
  *
- * Driven through the runner's public entry point (not full boot) so the same harness carries the
- * isolate-and-continue / fail-fast cases; provisioning is idempotent so re-invoking is safe.
+ * The behavior is driven through the runner's public entry point (not full boot) so the same harness
+ * carries the isolate-and-continue / fail-fast cases; provisioning is idempotent so re-invoking is
+ * safe. A separate case asserts the boot wiring: that the runner actually ran during context refresh.
  */
 class StartupTenantMigrationRunnerIT : TeamBalanceIT() {
 
@@ -26,6 +31,9 @@ class StartupTenantMigrationRunnerIT : TeamBalanceIT() {
 
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var applicationContext: ConfigurableApplicationContext
 
     init {
         test("migrates every tenant schema listed in public.teams to head") {
@@ -37,6 +45,19 @@ class StartupTenantMigrationRunnerIT : TeamBalanceIT() {
             for (schema in schemas) {
                 appliedTenantMigrations(schema) shouldBe head
             }
+        }
+
+        test("is wired to run at startup, after the platform schema is provisioned") {
+            // The runner closes the boot-time migration race, so it must run during context refresh
+            // (InitializingBean) and only after PlatformSchemaInitializer has created public.teams.
+            // We assert the wiring, not a DB side effect: the happy-path test above already invokes
+            // migrateAllTenantSchemas() manually and provisions every team, so any schema-state signal
+            // here would pass with or without the boot hook. The wiring is the only honest signal.
+            runner.shouldBeInstanceOf<InitializingBean>()
+
+            applicationContext.beanFactory
+                .getBeanDefinition("startupTenantMigrationRunner")
+                .dependsOn.orEmpty().toList() shouldContain "platformSchemaInitializer"
         }
     }
 


### PR DESCRIPTION
Part of #154 (self-service team onboarding). **Slice 1 — startup tenant-migration runner**, tracer bullets 1 & 2. Built TDD (red → green at each step).

## What this does

On startup, the app now migrates **every** team's tenant schema to head automatically, so no team schema drifts behind and the manual docker-CLI Flyway step for existing teams is retired.

- `StartupTenantMigrationRunner` reads all schema names from `public.teams` and provisions each via the existing idempotent `TenantSchemaManager.provisionTenantSchema`.
- It runs during context refresh (`InitializingBean`), `@DependsOn("platformSchemaInitializer")` so it fires only after the platform schema (`public.teams`, its source of truth) exists — closing the boot-time migration race.
- New read-side `TeamRepository.findAllSchemaNames()` port (Slice 2 reuses it), implemented by `JdbcTeamRepositoryAdapter`.

## Design notes

- **Reads via `JdbcTemplate` against an explicit `public.teams`, not JPA.** The runner runs with no tenant context, where the tenant-routed Hibernate path fails closed (`TenantIdentifierResolver` → `__no_tenant__`). This mirrors the sibling platform-boot code (`TenantSchemaManager`, `PlatformSchemaInitializer`) using the raw datasource.
- **Per-tenant failure handling (isolate-and-continue) and the fail-fast config flag are intentionally *not* here yet** — they're the next tracer bullets (PRD Slice 1 tests (b)/(c)), which also provide the behavioral boot-failure proofs.

## Tests (lowest layer that proves it)

Testcontainers IT (`StartupTenantMigrationRunnerIT`):
- **Happy path** — two teams seeded into `public.teams`, both schemas migrated to head. The expected migration count is derived from the `db/tenant-migration` folder (no magic number); table-structure coverage stays owned by `TenantSchemaManagerTest`.
- **Boot wiring** — asserts the lifecycle contract (`InitializingBean` + `dependsOn` platform initializer), *not* a DB side effect: the happy-path test invokes `migrateAllTenantSchemas()` manually and provisions every team, so any schema-state signal would pass with or without the hook in the shared DB. The wiring is the only honest signal.

**No new e2e:** this introduces no new stack seam (the create-team seam arrives in Slice 3). Full `:api:test` (291) and the existing real e2e suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)