### PR TITLE
refactor(api): thread an EventId value object through every layer (tracer 3, #22)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.application
 import com.github.zzave.teambalance.api.domain.model.Attendance
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
 import com.github.zzave.teambalance.api.domain.model.EventAttendance
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.domain.port.EventRepository
@@ -30,7 +31,7 @@ class AttendanceService(
      */
     fun setAttendance(
         teamId: UUID,
-        eventId: UUID,
+        eventId: EventId,
         userId: UUID,
         state: AttendanceState,
         changedBy: UUID,
@@ -66,14 +67,14 @@ class AttendanceService(
     // that rule; `members` is passed in so a listing resolves the roster once.
 
     /** The resolved attendance picture for one event — its response rows fetched once. */
-    fun attendanceFor(eventId: UUID, members: List<TeamMember>): EventAttendance =
+    fun attendanceFor(eventId: EventId, members: List<TeamMember>): EventAttendance =
         EventAttendance.resolve(members, attendanceRepository.findByEventId(eventId))
 
     /**
      * The resolved picture for many events, keyed by event id, from a single response-row query —
      * kills the per-event N+1 when producing a listing.
      */
-    fun attendanceForAll(eventIds: List<UUID>, members: List<TeamMember>): Map<UUID, EventAttendance> {
+    fun attendanceForAll(eventIds: List<EventId>, members: List<TeamMember>): Map<EventId, EventAttendance> {
         val responsesByEvent = attendanceRepository.findByEventIds(eventIds).groupBy { it.eventId }
         return eventIds.associateWith { EventAttendance.resolve(members, responsesByEvent[it] ?: emptyList()) }
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -5,6 +5,7 @@ import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundExcept
 import com.github.zzave.teambalance.api.domain.exception.RecurrenceExceedsCapException
 import com.github.zzave.teambalance.api.domain.model.Event
 import com.github.zzave.teambalance.api.domain.model.EventEdit
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.OccurrenceSchedule
@@ -55,7 +56,7 @@ class EventService(
 
     fun getAllEvents(): List<Event> = eventRepository.findAll()
 
-    fun getEvent(id: UUID): Event? = eventRepository.findById(id)
+    fun getEvent(id: EventId): Event? = eventRepository.findById(id)
 
     // No attendance rows are seeded here: the summary and roster are derived from current team
     // membership at read time (see AttendanceService), so a member's absence of a row simply reads
@@ -72,7 +73,7 @@ class EventService(
 
         return eventRepository.save(
             Event(
-                id = UUID.randomUUID(),
+                id = EventId(UUID.randomUUID()),
                 eventType = eventType,
                 title = potential.title,
                 description = potential.description,
@@ -132,7 +133,7 @@ class EventService(
             dates.map { date ->
                 val startTime = OccurrenceSchedule.startInstant(date, timeOfDay, clock.zone)
                 Event(
-                    id = UUID.randomUUID(),
+                    id = EventId(UUID.randomUUID()),
                     eventType = eventType,
                     title = title,
                     description = description,
@@ -179,7 +180,7 @@ class EventService(
     fun updateEvent(
         callerId: UUID,
         teamId: UUID,
-        id: UUID,
+        id: EventId,
         scope: EventSeriesScope,
         eventTypeId: UUID,
         title: String,
@@ -227,7 +228,7 @@ class EventService(
      *
      * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
      */
-    fun deleteEvent(callerId: UUID, teamId: UUID, id: UUID, scope: EventSeriesScope): Boolean {
+    fun deleteEvent(callerId: UUID, teamId: UUID, id: EventId, scope: EventSeriesScope): Boolean {
         authorizationService.requireAdmin(callerId, teamId)
         val target = eventRepository.findById(id) ?: return false
         eventRepository.deleteAllById(SeriesModification.planDelete(seriesOf(target), id, scope))

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -73,7 +73,7 @@ class EventService(
 
         return eventRepository.save(
             Event(
-                id = EventId(UUID.randomUUID()),
+                id = EventId.random(),
                 eventType = eventType,
                 title = potential.title,
                 description = potential.description,
@@ -133,7 +133,7 @@ class EventService(
             dates.map { date ->
                 val startTime = OccurrenceSchedule.startInstant(date, timeOfDay, clock.zone)
                 Event(
-                    id = EventId(UUID.randomUUID()),
+                    id = EventId.random(),
                     eventType = eventType,
                     title = title,
                     description = description,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -1,16 +1,17 @@
 package com.github.zzave.teambalance.api.domain.exception
 
+import com.github.zzave.teambalance.api.domain.model.EventId
 import java.util.UUID
 
 sealed class TeambalanceException(message: String) : RuntimeException(message)
 
 sealed class NotFoundException(message: String) : TeambalanceException(message)
 
-class EventNotFoundException(id: UUID) : NotFoundException("Event not found: $id")
+class EventNotFoundException(id: EventId) : NotFoundException("Event not found: $id")
 
 class EventTypeNotFoundException(id: UUID) : NotFoundException("EventType not found: $id")
 
-class AttendanceNotFoundException(eventId: UUID, userId: UUID) :
+class AttendanceNotFoundException(eventId: EventId, userId: UUID) :
     NotFoundException("Attendance not found for event $eventId and user $userId")
 
 class MemberNotFoundException(userId: UUID) : NotFoundException("Member not found: $userId")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Attendance.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Attendance.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 data class Attendance(
     val id: UUID,
-    val eventId: UUID,
+    val eventId: EventId,
     val userId: UUID,
     val state: AttendanceState,
     val updatedAt: Instant,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Event.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Event.kt
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.util.UUID
 
 data class Event(
-    val id: UUID,
+    val id: EventId,
     val eventType: EventType,
     val title: String,
     val description: String?,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventId.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventId.kt
@@ -1,0 +1,19 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.util.UUID
+
+/**
+ * The identity of an [Event] (ADR-0018). A `@JvmInline` value class, so it costs nothing at runtime —
+ * the compiler erases it back to the `UUID` it wraps — while the type system stops a `UUID` that
+ * means something else (a user, a team, an event *type*) being passed where an event is expected.
+ *
+ * It is the internal representation only: the wire contract and the database column are both still a
+ * UUID, and neither changes. Conversion therefore happens **only at the edges** — the JPA mapper
+ * ([com.github.zzave.teambalance.api.infrastructure.persistence.mapper] `internalize`/`externalize`)
+ * and the Wirespec mapper (`consume`/`produce` in the controllers). Everything between those two
+ * edges — domain model, ports, application services — speaks [EventId] and never unwraps it.
+ */
+@JvmInline
+value class EventId(val value: UUID) {
+    override fun toString(): String = value.toString()
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventId.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventId.kt
@@ -16,4 +16,13 @@ import java.util.UUID
 @JvmInline
 value class EventId(val value: UUID) {
     override fun toString(): String = value.toString()
+
+    companion object {
+        /**
+         * Mints an identity for an event that does not exist yet. The domain names its own events —
+         * the id is chosen before anything is persisted, so nothing downstream has to wait for a
+         * database-generated key.
+         */
+        fun random(): EventId = EventId(UUID.randomUUID())
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicy.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicy.kt
@@ -4,7 +4,6 @@ import com.github.zzave.teambalance.api.domain.exception.EventOutsideSeasonExcep
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.util.UUID
 
 /**
  * Owns "what to check, and when" for the season bound (ADR-0014): every event write whose start
@@ -42,7 +41,7 @@ class SeasonPolicy(
      * pre-edit value in [originalStarts] are checked. An unchanged start is grandfathered (a row
      * absent from [originalStarts] counts as moved and is checked).
      */
-    fun requireEditable(plan: SeriesEditPlan, originalStarts: Map<UUID, Instant>) =
+    fun requireEditable(plan: SeriesEditPlan, originalStarts: Map<EventId, Instant>) =
         plan.toPersist
             .filter { it.startTime != originalStarts[it.id] }
             .forEach { requireWithinSeason(it.startTime.toSeasonDate()) }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
@@ -58,7 +58,7 @@ object SeriesModification {
      */
     fun planEdit(
         series: List<Event>,
-        targetId: UUID,
+        targetId: EventId,
         scope: EventSeriesScope,
         edit: EventEdit,
         newTailGroup: UUID,
@@ -103,9 +103,9 @@ object SeriesModification {
      */
     fun planDelete(
         series: List<Event>,
-        targetId: UUID,
+        targetId: EventId,
         scope: EventSeriesScope,
-    ): List<UUID> {
+    ): List<EventId> {
         val ordered = series.sortedBy { it.startTime }
         val idx = ordered.indexOfFirst { it.id == targetId }
         require(idx >= 0) { "target $targetId is not part of the series" }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/AttendanceRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/AttendanceRepository.kt
@@ -1,14 +1,15 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Attendance
+import com.github.zzave.teambalance.api.domain.model.EventId
 import java.util.UUID
 
 interface AttendanceRepository {
-    fun findByEventId(eventId: UUID): List<Attendance>
+    fun findByEventId(eventId: EventId): List<Attendance>
 
     /** Response rows for many events in one query — lets a listing avoid a per-event fetch. */
-    fun findByEventIds(eventIds: List<UUID>): List<Attendance>
-    fun findByEventIdAndUserId(eventId: UUID, userId: UUID): Attendance?
+    fun findByEventIds(eventIds: List<EventId>): List<Attendance>
+    fun findByEventIdAndUserId(eventId: EventId, userId: UUID): Attendance?
     fun save(attendance: Attendance): Attendance
     fun saveAll(attendances: List<Attendance>): List<Attendance>
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventId
 import java.time.Instant
 import java.util.UUID
 
@@ -11,12 +12,12 @@ import java.util.UUID
  * transaction — it expresses "these rows go together" by handing them over in one call.
  */
 interface EventRepository {
-    fun findById(id: UUID): Event?
+    fun findById(id: EventId): Event?
     fun findUpcoming(since: Instant): List<Event>
     fun findAll(): List<Event>
     fun findByRecurringGroup(group: UUID): List<Event>
     fun save(event: Event): Event
     fun saveAll(events: List<Event>): List<Event>
-    fun deleteById(id: UUID)
-    fun deleteAllById(ids: List<UUID>)
+    fun deleteById(id: EventId)
+    fun deleteAllById(ids: List<EventId>)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.domain.exception.EventNotFoundException
 import com.github.zzave.teambalance.api.domain.model.Attendance
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
@@ -14,18 +15,18 @@ class JpaAttendanceRepositoryAdapter(
     private val eventJpaRepository: SpringDataEventRepository,
 ) : AttendanceRepository {
 
-    override fun findByEventId(eventId: UUID): List<Attendance> =
-        jpaRepository.findByEventUuid(eventId).map { it.internalize() }
+    override fun findByEventId(eventId: EventId): List<Attendance> =
+        jpaRepository.findByEventUuid(eventId.value).map { it.internalize() }
 
-    override fun findByEventIds(eventIds: List<UUID>): List<Attendance> =
+    override fun findByEventIds(eventIds: List<EventId>): List<Attendance> =
         if (eventIds.isEmpty()) emptyList()
-        else jpaRepository.findByEventUuidIn(eventIds).map { it.internalize() }
+        else jpaRepository.findByEventUuidIn(eventIds.map { it.value }).map { it.internalize() }
 
-    override fun findByEventIdAndUserId(eventId: UUID, userId: UUID): Attendance? =
-        jpaRepository.findByEventUuidAndUserId(eventId, userId)?.internalize()
+    override fun findByEventIdAndUserId(eventId: EventId, userId: UUID): Attendance? =
+        jpaRepository.findByEventUuidAndUserId(eventId.value, userId)?.internalize()
 
     override fun save(attendance: Attendance): Attendance {
-        val eventEntity = eventJpaRepository.findByUuid(attendance.eventId)
+        val eventEntity = eventJpaRepository.findByUuid(attendance.eventId.value)
             ?: throw EventNotFoundException(attendance.eventId)
         // Carry the DB identity over when the row already exists: a fresh entity (id=0) makes
         // Hibernate INSERT — violating the uuid unique constraint — instead of updating in place.
@@ -35,7 +36,7 @@ class JpaAttendanceRepositoryAdapter(
 
     override fun saveAll(attendances: List<Attendance>): List<Attendance> {
         if (attendances.isEmpty()) return emptyList()
-        val eventEntity = eventJpaRepository.findByUuid(attendances.first().eventId)
+        val eventEntity = eventJpaRepository.findByUuid(attendances.first().eventId.value)
             ?: throw EventNotFoundException(attendances.first().eventId)
         return jpaRepository.saveAll(attendances.map { it.externalize(eventEntity) }).map { it.internalize() }
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 import com.github.zzave.teambalance.api.domain.exception.EventNotFoundException
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
@@ -34,8 +35,8 @@ class JpaEventRepositoryAdapter(
 ) : EventRepository {
 
     @Transactional(readOnly = true)
-    override fun findById(id: UUID): Event? =
-        jpaRepository.findByUuid(id)?.internalize()
+    override fun findById(id: EventId): Event? =
+        jpaRepository.findByUuid(id.value)?.internalize()
 
     @Transactional(readOnly = true)
     override fun findUpcoming(since: Instant): List<Event> =
@@ -56,20 +57,20 @@ class JpaEventRepositoryAdapter(
     override fun saveAll(events: List<Event>): List<Event> = events.map { persist(it) }
 
     @Transactional
-    override fun deleteById(id: UUID) = remove(id)
+    override fun deleteById(id: EventId) = remove(id)
 
     @Transactional
-    override fun deleteAllById(ids: List<UUID>) = ids.forEach { remove(it) }
+    override fun deleteAllById(ids: List<EventId>) = ids.forEach { remove(it) }
 
     private fun persist(event: Event): Event {
         val eventTypeEntity = eventTypeJpaRepository.findByUuid(event.eventType.id)
             ?: throw EventTypeNotFoundException(event.eventType.id)
-        val technicalId = jpaRepository.findByUuid(event.id)?.id ?: 0
+        val technicalId = jpaRepository.findByUuid(event.id.value)?.id ?: 0
         return jpaRepository.save(event.externalize(eventTypeEntity, technicalId)).internalize()
     }
 
-    private fun remove(id: UUID) {
-        val entity = jpaRepository.findByUuid(id)
+    private fun remove(id: EventId) {
+        val entity = jpaRepository.findByUuid(id.value)
             ?: throw EventNotFoundException(id)
         jpaRepository.delete(entity)
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/AttendanceMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/AttendanceMapper.kt
@@ -2,12 +2,13 @@ package com.github.zzave.teambalance.api.infrastructure.persistence.mapper
 
 import com.github.zzave.teambalance.api.domain.model.Attendance
 import com.github.zzave.teambalance.api.domain.model.AttendanceState
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.AttendanceJpaEntity
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
 
 fun AttendanceJpaEntity.internalize() = Attendance(
     id = uuid,
-    eventId = event.uuid,
+    eventId = EventId(event.uuid),
     userId = userId,
     state = AttendanceState.valueOf(state),
     updatedAt = updatedAt,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
@@ -1,13 +1,14 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence.mapper
 
 import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventReferenceEmbeddable
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
 
 fun EventJpaEntity.internalize() = Event(
-    id = uuid,
+    id = EventId(uuid),
     eventType = eventType.internalize(),
     title = title,
     description = description,
@@ -22,7 +23,7 @@ fun EventJpaEntity.internalize() = Event(
 
 fun Event.externalize(eventTypeEntity: EventTypeJpaEntity, technicalId: Long = 0) = EventJpaEntity(
     id = technicalId,
-    uuid = id,
+    uuid = id.value,
     eventType = eventTypeEntity,
     title = title,
     description = description,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
@@ -19,7 +19,7 @@ class AttendanceController(
 
     override suspend fun setAttendance(request: SetAttendance.Request): SetAttendance.Response<*> {
         val teamId = currentTeamGateway.requireCurrentTeamId()
-        val eventId = UUID.fromString(request.path.eventId)
+        val eventId = request.path.eventId.consumeEventId()
         val userId = UUID.fromString(request.path.userId)
         val state = AttendanceState.valueOf(request.body.state)
 
@@ -36,7 +36,7 @@ class AttendanceController(
         return SetAttendance.Response200(
             Attendance(
                 id = attendance.id.toString(),
-                eventId = attendance.eventId.toString(),
+                eventId = attendance.eventId.produce(),
                 userId = attendance.userId.toString(),
                 displayName = member?.displayName ?: "Unknown",
                 role = member?.position ?: UNASSIGNED,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -6,6 +6,7 @@ import com.github.zzave.teambalance.api.application.PotentialEvent
 import com.github.zzave.teambalance.api.domain.model.AttendanceState as DomainAttendanceState
 import com.github.zzave.teambalance.api.domain.model.EventAttendance
 import com.github.zzave.teambalance.api.domain.model.EventReference as DomainEventReference
+import com.github.zzave.teambalance.api.domain.model.EventId
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope as DomainEventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.MemberAttendance
 import com.github.zzave.teambalance.api.domain.model.UNASSIGNED
@@ -66,7 +67,7 @@ class EventController(
     }
 
     override suspend fun getEvent(request: GetEvent.Request): GetEvent.Response<*> {
-        val id = UUID.fromString(request.path.id)
+        val id = request.path.id.consumeEventId()
         val event = eventService.getEvent(id)
             ?: return GetEvent.Response404(Unit)
 
@@ -75,7 +76,7 @@ class EventController(
 
         return GetEvent.Response200(
             EventDetail(
-                id = event.id.toString(),
+                id = event.id.produce(),
                 eventType = event.eventType.produce(),
                 title = event.title,
                 description = event.description,
@@ -95,7 +96,7 @@ class EventController(
     override suspend fun updateEvent(request: UpdateEvent.Request): UpdateEvent.Response<*> {
         val teamId = currentTeamGateway.requireCurrentTeamId()
         val userId = currentUserGateway.requireCurrentUserId()
-        val id = UUID.fromString(request.path.id)
+        val id = request.path.id.consumeEventId()
         val req = request.body
         val events = eventService.updateEvent(
             callerId = userId,
@@ -119,7 +120,7 @@ class EventController(
     override suspend fun deleteEvent(request: DeleteEvent.Request): DeleteEvent.Response<*> {
         val teamId = currentTeamGateway.requireCurrentTeamId()
         val userId = currentUserGateway.requireCurrentUserId()
-        val id = UUID.fromString(request.path.id)
+        val id = request.path.id.consumeEventId()
         return if (eventService.deleteEvent(callerId = userId, teamId = teamId, id = id, scope = request.queries.scope.consume())) {
             DeleteEvent.Response204(Unit)
         } else {
@@ -127,6 +128,14 @@ class EventController(
         }
     }
 }
+
+// The Wirespec edge for an event's identity. The contract carries an opaque UUID string and is
+// unchanged by EventId (ADR-0018) — these two functions are the only place in the inbound adapter
+// that wraps or unwraps it, so nothing between here and the JPA edge handles a bare UUID.
+// internal so AttendanceController and RecurringEventController convert the same way.
+internal fun String.consumeEventId(): EventId = EventId(UUID.fromString(this))
+
+internal fun EventId.produce(): String = value.toString()
 
 // A missing scope query param defaults to THIS (ADR-0014); otherwise it maps 1:1 to the domain enum.
 private fun GeneratedEventSeriesScope?.consume(): DomainEventSeriesScope = when (this) {
@@ -160,7 +169,7 @@ private fun List<DomainEventReference>.externalize(): List<EventReference> =
 // Takes the already-resolved projection so mapping stays free of data access (no per-event N+1).
 internal fun com.github.zzave.teambalance.api.domain.model.Event.produce(attendance: EventAttendance): Event =
     Event(
-        id = id.toString(),
+        id = id.produce(),
         eventType = eventType.produce(),
         title = title,
         description = description,

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -20,20 +20,21 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
+import com.github.zzave.teambalance.api.domain.model.EventId
 import java.util.UUID
 
 // The write use cases are admin-guarded in the service now (uniform write-authorization seam), so a
 // non-admin caller must be rejected *before* any repository work — these fakes therefore fail loudly
 // if touched, proving the guard short-circuits rather than the call merely erroring downstream.
 private class ExplodingEventRepo : EventRepository {
-    override fun findById(id: UUID): Event? = error("repository must not be reached for an unauthorized caller")
+    override fun findById(id: EventId): Event? = error("repository must not be reached for an unauthorized caller")
     override fun findUpcoming(since: Instant): List<Event> = error("unused")
     override fun findAll(): List<Event> = error("unused")
     override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
     override fun save(event: Event): Event = error("unused")
     override fun saveAll(events: List<Event>): List<Event> = error("unused")
-    override fun deleteById(id: UUID) = error("unused")
-    override fun deleteAllById(ids: List<UUID>) = error("unused")
+    override fun deleteById(id: EventId) = error("unused")
+    override fun deleteAllById(ids: List<EventId>) = error("unused")
 }
 
 private class ExplodingEventTypeRepo : EventTypeRepository {
@@ -92,7 +93,7 @@ class EventServiceTest : FunSpec() {
                 service.updateEvent(
                     callerId = nonAdmin,
                     teamId = teamId,
-                    id = UUID.randomUUID(),
+                    id = EventId(UUID.randomUUID()),
                     scope = EventSeriesScope.THIS,
                     eventTypeId = UUID.randomUUID(),
                     title = "x",
@@ -106,7 +107,7 @@ class EventServiceTest : FunSpec() {
 
         test("deleteEvent by a non-admin is rejected before any repository access") {
             shouldThrow<NotTeamAdminException> {
-                service.deleteEvent(nonAdmin, teamId, UUID.randomUUID(), EventSeriesScope.THIS)
+                service.deleteEvent(nonAdmin, teamId, EventId(UUID.randomUUID()), EventSeriesScope.THIS)
             }
         }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendanceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendanceTest.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  */
 class EventAttendanceTest : FunSpec({
 
-    val eventId = UUID.randomUUID()
+    val eventId = EventId(UUID.randomUUID())
 
     fun member(name: String, position: String? = null) = TeamMember(
         userId = UUID.randomUUID(),

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
@@ -1,0 +1,41 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.util.UUID
+
+/**
+ * The value-object edge contract (ADR-0018), pinned at the lowest layer that proves it. [EventId] is
+ * an internal representation only: the wire contract and the database column are both still a UUID,
+ * so the two edges (JPA mapper, Wirespec mapper) must be able to wrap and unwrap it losslessly, and
+ * an unwrapped id must be byte-for-byte the UUID that went in. The end-to-end round trip through the
+ * REST + persistence edges is covered by the existing event ITs, which this change leaves untouched.
+ */
+class EventIdTest : FunSpec({
+
+    test("wrapping and unwrapping is lossless — the edges can convert either way") {
+        val raw = UUID.randomUUID()
+
+        EventId(raw).value shouldBe raw
+    }
+
+    test("equality is the wrapped UUID's, so an EventId works as a map key across a round trip") {
+        val raw = UUID.randomUUID()
+
+        EventId(raw) shouldBe EventId(raw)
+        EventId(raw) shouldNotBe EventId(UUID.randomUUID())
+        mapOf(EventId(raw) to "x").getValue(EventId(raw)) shouldBe "x"
+    }
+
+    /**
+     * The wire edge converts explicitly (`value.toString()`), so this override is for diagnostics
+     * only — an interpolated id in an exception message must read as a bare UUID rather than
+     * Kotlin's default `EventId(value=…)`.
+     */
+    test("toString is the bare UUID, so interpolated messages stay readable") {
+        val raw = UUID.randomUUID()
+
+        "$raw" shouldBe EventId(raw).toString()
+    }
+})

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
@@ -28,6 +28,10 @@ class EventIdTest : FunSpec({
         mapOf(EventId(raw) to "x").getValue(EventId(raw)) shouldBe "x"
     }
 
+    test("random mints a fresh identity, so an event that has no row yet can name itself") {
+        EventId.random() shouldNotBe EventId.random()
+    }
+
     /**
      * The wire edge converts explicitly (`value.toString()`), so this override is for diagnostics
      * only — an interpolated id in an exception message must read as a bare UUID rather than

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
@@ -50,9 +50,9 @@ class RecurrenceContractTest : FunSpec({
             val scope = EventSeriesScope.valueOf(case["scope"].asText())
             // The fixture keys occurrences by stable string ids; map them to UUIDs deterministically
             // so the backend Event model can carry them, then translate results back for comparison.
-            val idByUuid = case["series"].associate { uuidOf(it["id"].asText()) to it["id"].asText() }
+            val idByUuid = case["series"].associate { eventIdOf(it["id"].asText()) to it["id"].asText() }
             val series = case["series"].map { event(it["id"].asText(), Instant.parse(it["startTime"].asText())) }
-            val currentId = uuidOf(case["currentId"].asText())
+            val currentId = eventIdOf(case["currentId"].asText())
             val expected = case["affectedIds"].map { it.asText() }
 
             // A scoped DELETE's affected set is exactly the ids it removes.
@@ -84,10 +84,10 @@ private val EDIT = EventEdit(
     endTime = Instant.parse("2026-01-01T19:30:00Z"),
 )
 
-private fun uuidOf(id: String): UUID = UUID.nameUUIDFromBytes(id.toByteArray())
+private fun eventIdOf(id: String): EventId = EventId(UUID.nameUUIDFromBytes(id.toByteArray()))
 
 private fun event(id: String, startTime: Instant): Event = Event(
-    id = uuidOf(id),
+    id = eventIdOf(id),
     eventType = EVENT_TYPE,
     title = "Training",
     description = null,

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicyTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeasonPolicyTest.kt
@@ -32,7 +32,7 @@ class SeasonPolicyTest : FunSpec({
     fun startOn(date: String): Instant =
         LocalDate.parse(date).atTime(LocalTime.of(20, 30)).atZone(zone).toInstant()
 
-    fun event(id: UUID, start: Instant, group: UUID? = null): Event =
+    fun event(id: EventId, start: Instant, group: UUID? = null): Event =
         Event(
             id = id,
             eventType = training,
@@ -80,8 +80,8 @@ class SeasonPolicyTest : FunSpec({
 
     test("requireEditable grandfathers an ALL title-only edit: no start moves, so nothing is checked") {
         // A whole series sitting OUTSIDE a shrunk window, edited without moving any start.
-        val out1 = event(UUID.randomUUID(), startOn("2026-10-06"))
-        val out2 = event(UUID.randomUUID(), startOn("2026-10-13"))
+        val out1 = event(EventId(UUID.randomUUID()), startOn("2026-10-06"))
+        val out2 = event(EventId(UUID.randomUUID()), startOn("2026-10-13"))
         val originalStarts = mapOf(out1.id to out1.startTime, out2.id to out2.startTime)
         // toPersist carries the same starts (only the title changed upstream) — grandfathered.
         val plan = SeriesEditPlan(edited = listOf(out1, out2), regrouped = emptyList())
@@ -90,7 +90,7 @@ class SeasonPolicyTest : FunSpec({
     }
 
     test("requireEditable rejects an occurrence whose start MOVED outside the window") {
-        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val original = event(EventId(UUID.randomUUID()), startOn("2026-09-15"))
         val originalStarts = mapOf(original.id to original.startTime)
         // The edit moved this occurrence's start out of the window.
         val moved = original.copy(startTime = startOn("2026-10-15"))
@@ -102,8 +102,8 @@ class SeasonPolicyTest : FunSpec({
 
     test("requireEditable checks moved starts but grandfathers unchanged ones in the same plan") {
         // One occurrence keeps its (out-of-window) start; another moves, but moves to INSIDE the window.
-        val kept = event(UUID.randomUUID(), startOn("2026-10-06"))
-        val original = event(UUID.randomUUID(), startOn("2026-09-01"))
+        val kept = event(EventId(UUID.randomUUID()), startOn("2026-10-06"))
+        val original = event(EventId(UUID.randomUUID()), startOn("2026-09-01"))
         val originalStarts = mapOf(kept.id to kept.startTime, original.id to original.startTime)
         val moved = original.copy(startTime = startOn("2026-09-20"))
         val plan = SeriesEditPlan(edited = listOf(kept, moved), regrouped = emptyList())
@@ -114,7 +114,7 @@ class SeasonPolicyTest : FunSpec({
 
     test("requireEditable checks the regrouped tail's moved starts too, not just edited ones") {
         // A regrouped tail row that was somehow moved out of window is still validated.
-        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val original = event(EventId(UUID.randomUUID()), startOn("2026-09-15"))
         val originalStarts = mapOf(original.id to original.startTime)
         val movedTail = original.copy(startTime = startOn("2026-10-20"), recurringGroup = UUID.randomUUID())
         val plan = SeriesEditPlan(edited = emptyList(), regrouped = listOf(movedTail))
@@ -127,7 +127,7 @@ class SeasonPolicyTest : FunSpec({
 
     test("an unconfigured season allows every create, batch, and moved edit") {
         val unset = SeasonPolicy(Season.UNSET, zone)
-        val original = event(UUID.randomUUID(), startOn("2026-09-15"))
+        val original = event(EventId(UUID.randomUUID()), startOn("2026-09-15"))
         val moved = original.copy(startTime = startOn("1999-01-01"))
 
         shouldNotThrowAny {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
@@ -31,7 +31,7 @@ class SeriesModificationTest : FunSpec({
     fun occurrence(date: String, group: UUID? = originalGroup): Event {
         val start = LocalDate.parse(date).atTime(LocalTime.of(20, 30)).atZone(zone).toInstant()
         return Event(
-            id = UUID.nameUUIDFromBytes(date.toByteArray()),
+            id = EventId(UUID.nameUUIDFromBytes(date.toByteArray())),
             eventType = training,
             title = "Weekly Training",
             description = "old",
@@ -195,10 +195,10 @@ class SeriesModificationTest : FunSpec({
 
     test("an unknown target id is rejected") {
         shouldThrow<IllegalArgumentException> {
-            SeriesModification.planEdit(series, UUID.randomUUID(), EventSeriesScope.THIS, editOn(), tailGroup, zone)
+            SeriesModification.planEdit(series, EventId(UUID.randomUUID()), EventSeriesScope.THIS, editOn(), tailGroup, zone)
         }
         shouldThrow<IllegalArgumentException> {
-            SeriesModification.planDelete(series, UUID.randomUUID(), EventSeriesScope.ALL)
+            SeriesModification.planDelete(series, EventId(UUID.randomUUID()), EventSeriesScope.ALL)
         }
     }
 })


### PR DESCRIPTION
Closes #22 (tracer 3). **Draft — this sub-issue carries an in-flight `hitl:"decision"` gate.** The VO threading pattern must be signed off before #23 replicates it across seven more identifiers and two semantic strings.

## What landed

`EventId` — a `@JvmInline value class` over the UUID that already identified an `Event` — threaded through domain model, ports, application services, and both edge mappers. Conversion happens **only at the edges**; nothing between them handles a bare UUID.

| Layer | Change |
|---|---|
| Domain | `Event.id`, `Attendance.eventId`, `SeriesModification.planEdit/planDelete`, `SeasonPolicy.requireEditable`, `EventNotFoundException` |
| Ports | `EventRepository.findById/deleteById/deleteAllById`, `AttendanceRepository.findByEventId/findByEventIds/findByEventIdAndUserId` |
| Application | `EventService.getEvent/updateEvent/deleteEvent`, `AttendanceService.setAttendance/attendanceFor/attendanceForAll` |
| JPA edge | `EventMapper` / `AttendanceMapper` `internalize`/`externalize`; the `Jpa*Adapter`s unwrap `.value` at the Spring Data call |
| Wirespec edge | `String.consumeEventId()` / `EventId.produce()` in `EventController` (internal, shared with `AttendanceController`) |

**No contract or schema change.** The wire still carries an opaque UUID string; the column is still a UUID. Wirespec files untouched, no migration.

## ⚠️ The acceptance criterion's premise is stale — the #19 lesson, repeated

> "Event-aggregate primitive-obsession baseline entries removed; :api:detekt stays green."

**There were none to remove, and threading `EventId` removes zero.** Verified against the flock 1.2.0 rule bytecode and empirically:

- `DomainNoPrimitiveObsession` flags **only** `String` + the Kotlin numeric/`Boolean`/`Char` primitives. `UUID` is not a primitive to flock, so `Event.id: UUID` was **never flagged** and never baselined.
- Emptying the baseline gives **24 `DomainNoPrimitiveObsession` violations before and 24 after** this change. Net baseline change: **zero**.
- The Event aggregate's actual baselined entries are all **display strings** (`Event`/`PotentialEvent`/`EventEdit` `.title/.description/.location`, `EventReference.title/url`, `EventType.name/color`) — which PRD decision 5 puts explicitly **out of scope** and #24 will exempt as config.

So #22 does not *remove suppression*; like #19 it makes a latent concept explicit. The type-safety win is real and is the reason to do it — it is just not a baseline win. **#23 is different and will genuinely retire entries** (see below).

## Probe result that de-risks #23

A throwaway probe (added, measured, reverted — not in the diff) established:

| Declaration | Flagged? |
|---|---|
| `data class ProbeRaw(val rawName: String)` | ✅ flagged |
| `data class ProbeRaw(val rawId: UUID)` | ❌ not flagged |
| `@JvmInline value class ProbeStringVo(val value: String)` | ❌ **not flagged** |
| `@JvmInline value class ProbeUuidVo(val value: UUID)` | ❌ not flagged |

**A value class's own backing field is not primitive obsession.** So #23's `Email` and `TokenHash` will each retire a real baseline entry, and the same shape works. #23's ID work (UserId, TeamId, EventTypeId, AttendanceId, PositionId) will, like this one, retire nothing — worth knowing before it is scoped as "remove all remaining primitive-obsession entries", which it cannot do on IDs alone.

---

# 🔶 DECISION REQUESTED — confirm the pattern before #23 replicates it

### Q1. Does the VO cross the aggregate boundary? (the one real design call)

I made `Attendance.eventId` an `EventId`, not a raw UUID.

- **For:** this is where the type safety actually pays. `setAttendance(teamId, eventId, userId, …)` was three interchangeable UUIDs; it is now one `EventId` and two UUIDs, and will be fully typed after #23. A VO confined to its own aggregate would leave every cross-reference — the most transposable arguments in the codebase — raw.
- **Against:** it couples `Attendance` to the `Event` aggregate's type, and it grows each VO's blast radius (this one touched `AttendanceService`, `AttendanceRepository`, `AttendanceMapper`, `JpaAttendanceRepositoryAdapter`, `AttendanceController`).

**Recommendation: yes, cross the boundary.** The alternative buys decoupling that the domain does not actually have — an attendance row is meaningless without its event — at the cost of the main benefit.

### Q2. Edge conversion — explicit `.value`, or lean on `toString()`?

`EventId` overrides `toString()` to render the bare UUID, but **the wire edge does not use it**: `produce()` calls `value.toString()` explicitly, so the wire format never depends on an override someone could delete. The override exists purely so interpolated diagnostics (`EventNotFoundException`, `SeriesModification`'s `require`) stay readable. Both facts are pinned by `EventIdTest` (proven load-bearing: deleting the override fails it).

**Recommendation: keep the split** — explicit at the wire edge, `toString()` for diagnostics only.

### Q3. Mapper naming

Reused the names already in the codebase rather than inventing any: `internalize`/`externalize` at the JPA edge, `consume`/`produce` at the Wirespec edge. The one new name is `consumeEventId()` — `consume()` alone would collide on `String` receivers once #23 adds more id types.

**Recommendation: keep, and let #23 follow `consume<Type>()`.**

### Q4. No `EventId.random()` factory

Minting stays `EventId(UUID.randomUUID())` at the two call sites in `EventService`. A `companion object { fun random() }` would read better but adds a concept; with #23 adding seven more VOs that is seven more factories.

**Recommendation: no factory** — but this is the cheapest one to overrule, and doing so is mechanical.

---

## Acceptance

- [x] `EventId` is a `@JvmInline value class` used across domain, application, and both edge mappers.
- [x] Event endpoints round-trip (request → VO → persistence → VO → response); no API/schema change. **Already pinned by an existing untouched IT**: `EventSeriesControllerIT` seeds a UUID straight into the DB, drives `PUT /api/events/{id}`, and asserts `$.events[0].id` equals the bare UUID string.
- [x] `:api:detekt` stays green.
- [⚠️] "Event-aggregate primitive-obsession baseline entries removed" — **vacuous as written**; see above. Baseline byte-identical to `main`.

## Verification

- `./gradlew :api:detekt` — green. Baseline unchanged (57 entries, byte-identical to `main`).
- `:api:test` — **296/296**, counted from the JUnit XML rather than trusting `BUILD SUCCESSFUL` (293 on `main` + 3 new `EventIdTest` cases). Includes every `@SpringBootTest` IT and all 6 ArchUnit rules.
- `test-app` — 47 files / 255 tests.
- **Real full-stack Playwright — 7/7**, including the attendance toggle: the exact path where `EventId` now crosses from the Event aggregate into Attendance.
- Pre-commit hook ran with **no `--no-verify`**.

## #20's read-boundary lesson does not apply

No service lost a `@Transactional` and no adapter read path changed. `JpaEventRepositoryAdapter`'s `@Transactional(readOnly = true)` reads are intact — verified, per the note carried on #22.

## Pre-existing issue found, deliberately not fixed here

The baseline entry `DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional` is **stale on `main` already** — #20's rotate commit removed that import but left the entry. Detekt does not fail on stale entries, so it is harmless. Out of scope here; #80 or #24 should drop it. (Confirmed against `origin/main`, not introduced by this branch.)