### PR TITLE
feat(api): create-team backend — code-gated self-service onboarding (Slice 2, #154)

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -4,6 +4,8 @@
   <CurrentIssues>
     <ID>AdapterCannotDependOnAdapter:DemoDataSeeder.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
     <ID>AdapterCannotDependOnAdapter:E2eEnvironmentInitializer.kt:import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager</ID>
+    <ID>AdapterCannotDependOnAdapter:PlatformAdminGuard.kt:import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins</ID>
+    <ID>AdapterCannotDependOnAdapter:ScalewayTeamNotifier.kt:import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins</ID>
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.identity.UserContext</ID>
     <ID>AdapterCannotDependOnAdapter:SessionTenantContextFilter.kt:import com.github.zzave.teambalance.api.infrastructure.persistence.SpringDataTeamMemberRepository</ID>
@@ -25,6 +27,7 @@
     <ID>DomainNoFrameworkImports:PositionService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.transaction.annotation.Transactional</ID>
+    <ID>DomainNoFrameworkImports:TeamService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>
@@ -47,9 +50,17 @@
     <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val onboarded: Boolean</ID>
     <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val position: String?</ID>
     <ID>DomainNoPrimitiveObsession:TeamMember.kt:TeamMember$val role: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamNaming.kt:TeamNames$val name: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamNaming.kt:TeamNames$val schemaName: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamNaming.kt:TeamNames$val slug: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamService.kt:CreatedTeam$val name: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamService.kt:CreatedTeam$val slug: String</ID>
     <ID>DomainNoPrimitiveObsession:User.kt:User$val displayName: String</ID>
     <ID>DomainNoPrimitiveObsession:User.kt:User$val email: String</ID>
     <ID>PortNamingConvention:EmailSender.kt:EmailSender</ID>
+    <ID>PortNamingConvention:TeamNotifier.kt:TeamNotifier</ID>
+    <ID>PortNamingConvention:TeamRegistrar.kt:TeamRegistrar</ID>
+    <ID>PortNamingConvention:TenantProvisioner.kt:TenantProvisioner</ID>
     <ID>PortsInDomainOnly:SpringDataAttendanceRepository.kt:SpringDataAttendanceRepository : JpaRepository</ID>
     <ID>PortsInDomainOnly:SpringDataEventRepository.kt:SpringDataEventRepository : JpaRepository</ID>
     <ID>PortsInDomainOnly:SpringDataEventTypeRepository.kt:SpringDataEventTypeRepository : JpaRepository</ID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -1,0 +1,109 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.AlreadyInTeamException
+import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
+import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
+import com.github.zzave.teambalance.api.domain.model.TeamNaming
+import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
+import com.github.zzave.teambalance.api.domain.port.TeamNotifier
+import com.github.zzave.teambalance.api.domain.port.TeamRegistrar
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TenantProvisioner
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/** The newly created team, as returned to the founder (schema_name is deliberately not exposed). */
+data class CreatedTeam(val id: UUID, val name: String, val slug: String)
+
+/**
+ * Self-service team creation (issue #154, ADR-0015). A logged-in, teamless user creates a team from a
+ * name + a one-time creation code and becomes its founding admin.
+ *
+ * Ordering is deliberately provision-first so a partial failure never strands a consumed code:
+ *  1. reject if the caller already belongs to a team (v1 one-team-per-user, #143);
+ *  2. derive + validate the slug / tenant schema name (bad name → 400);
+ *  3. pre-check slug uniqueness and code redeemability (fast, clean 409 / opaque 403 before any writes);
+ *  4. provision the tenant schema (idempotent, on its own connection — commits independently);
+ *  5. atomically consume the code and insert the team + founding admin ([TeamRegistrar]).
+ *
+ * If step 4 fails nothing is consumed and the user simply retries. If step 5 loses a race (code taken
+ * or slug collision) the only residue is a harmless empty orphan schema, self-healed by the startup
+ * migration runner. Notifications are best-effort and can never fail a committed creation.
+ */
+@Service
+class TeamService(
+    private val teamMemberRepository: TeamMemberRepository,
+    private val teamRepository: TeamRepository,
+    private val creationCodeRepository: TeamCreationCodeRepository,
+    private val tenantProvisioner: TenantProvisioner,
+    private val teamRegistrar: TeamRegistrar,
+    private val userRepository: UserRepository,
+    private val teamNotifier: TeamNotifier,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(TeamService::class.java)
+
+    fun createTeam(founderId: UUID, rawName: String, creationCode: String): CreatedTeam {
+        requireTeamless(founderId)
+        val names = TeamNaming.derive(rawName)
+        requireSlugAvailable(names.slug)
+
+        val now = clock.instant()
+        // Peek before provisioning so an obviously-bad code is rejected without leaving an orphan
+        // schema behind. The authoritative, race-free consume happens inside register().
+        requireRedeemable(creationCode, now)
+
+        tenantProvisioner.provisionTenant(names.schemaName)
+
+        val teamId = teamRegistrar.register(
+            creationCode = creationCode,
+            founderId = founderId,
+            name = names.name,
+            slug = names.slug,
+            schemaName = names.schemaName,
+            now = now,
+        )
+
+        notifyBestEffort(founderId, names.name, names.slug)
+
+        return CreatedTeam(id = teamId, name = names.name, slug = names.slug)
+    }
+
+    private fun requireTeamless(founderId: UUID) {
+        teamMemberRepository.findTeamId(founderId)?.let { throw AlreadyInTeamException(founderId) }
+    }
+
+    private fun requireSlugAvailable(slug: String) {
+        if (teamRepository.existsBySlug(slug)) {
+            throw TeamSlugTakenException(slug)
+        }
+    }
+
+    private fun requireRedeemable(creationCode: String, now: Instant) {
+        if (!creationCodeRepository.isRedeemable(creationCode, now)) {
+            throw InvalidCreationCodeException()
+        }
+    }
+
+    /**
+     * Emits the creator + audit notifications. The team is already committed, so nothing here may
+     * propagate: a notifier is contractually fire-and-forget, and this extra guard also stops an
+     * unexpected failure (e.g. resolving the founder's email) from turning a successful creation into
+     * a 500 — hence the deliberately broad catch.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun notifyBestEffort(founderId: UUID, teamName: String, teamSlug: String) {
+        try {
+            val founderEmail = userRepository.findById(founderId)?.email ?: return
+            teamNotifier.teamCreated(founderEmail, teamName, teamSlug)
+            teamNotifier.creationCodeConsumed(teamName, teamSlug, founderEmail)
+        } catch (e: Exception) {
+            log.warn("Post-create notifications failed for team '{}' (creation succeeded)", teamSlug, e)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -5,6 +5,12 @@ import java.util.UUID
 
 sealed class TeambalanceException(message: String) : RuntimeException(message)
 
+// Well-formed request that cannot yield a valid team name/slug/schema → 400 (base TeambalanceException
+// handler). Blank, too long, or with no slug-usable characters, or one whose derived tenant schema
+// exceeds Postgres' 63-byte identifier limit (rejected, never truncated — truncation would desync
+// schema_name from the real schema and break search_path routing).
+class InvalidTeamNameException(message: String) : TeambalanceException(message)
+
 sealed class NotFoundException(message: String) : TeambalanceException(message)
 
 class EventNotFoundException(id: EventId) : NotFoundException("Event not found: $id")
@@ -25,8 +31,18 @@ sealed class ForbiddenException(message: String, val code: String) : Teambalance
 class NotTeamAdminException(userId: UUID, teamId: UUID) :
     ForbiddenException("User $userId is not an admin of team $teamId", "NOT_TEAM_ADMIN")
 
+// Opaque by design: a creation code that is unknown, already consumed, or expired all surface the same
+// 403 with the same code/message, so a caller can't enumerate which codes exist or probe their state.
+class InvalidCreationCodeException :
+    ForbiddenException("Invalid creation code", "INVALID_CREATION_CODE")
+
 class NoTeamMembershipException(userId: UUID) :
     ForbiddenException("User $userId has no active team membership", "NO_TEAM_MEMBERSHIP")
+
+// Caller is not on the platform-admin allowlist (teambalance.platform-admins). Fail-closed: the empty
+// default forbids everyone. Gates the platform-admin surface (creation-codes CRUD, #154 Slice 4).
+class NotPlatformAdminException(userId: UUID) :
+    ForbiddenException("User $userId is not a platform admin", "NOT_PLATFORM_ADMIN")
 
 class CannotChangeOwnRoleException(userId: UUID) :
     ForbiddenException("User $userId cannot elevate their own role", "CANNOT_SELF_PROMOTE")
@@ -63,3 +79,13 @@ class LastAdminException(teamId: UUID) :
 
 class PositionLabelTakenException(label: String) :
     ConflictException("Position '$label' already exists in this team", "POSITION_LABEL_TAKEN")
+
+// The founder already belongs to a team. v1 is one-team-per-user (routing does ORDER BY … LIMIT 1);
+// multi-team membership + switcher is deferred to #143.
+class AlreadyInTeamException(userId: UUID) :
+    ConflictException("User $userId already belongs to a team", "ALREADY_IN_TEAM")
+
+// A team with this slug (and therefore this derived schema) already exists. No auto-suffixing — the
+// caller picks a different name.
+class TeamSlugTakenException(slug: String) :
+    ConflictException("A team with slug '$slug' already exists", "TEAM_SLUG_TAKEN")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNaming.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNaming.kt
@@ -1,0 +1,67 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
+
+/** A validated team name with its derived URL slug and tenant schema identifier. */
+data class TeamNames(
+    val name: String,
+    val slug: String,
+    val schemaName: String,
+)
+
+/**
+ * Pure, framework-free derivation of a team's slug and tenant schema name from a raw display name.
+ *
+ * The schema name is interpolated into `CREATE SCHEMA` / `SET search_path`, so this is the injection
+ * boundary: the derivation only ever emits `[a-z0-9_]`, and the result is asserted against a strict
+ * whitelist before it leaves this class. Length is capped at Postgres' 63-byte identifier limit and
+ * over-long names are rejected (never truncated — a truncated schema_name would no longer match the
+ * schema actually created, silently breaking tenant routing).
+ */
+object TeamNaming {
+    const val MAX_NAME_LENGTH = 100
+    const val MAX_SCHEMA_BYTES = 63
+
+    private const val SCHEMA_PREFIX = "team_"
+    private val NON_SLUG_CHARS = Regex("[^a-z0-9]+")
+    private val SAFE_SCHEMA = Regex("^team_[a-z0-9_]+$")
+
+    fun derive(rawName: String): TeamNames {
+        val name = validatedName(rawName)
+        val slug = slugOf(name)
+        val schemaName = schemaNameFor(name, slug)
+        return TeamNames(name = name, slug = slug, schemaName = schemaName)
+    }
+
+    private fun validatedName(rawName: String): String {
+        val name = rawName.trim()
+        if (name.isBlank()) {
+            throw InvalidTeamNameException("Team name must not be blank")
+        }
+        if (name.length > MAX_NAME_LENGTH) {
+            throw InvalidTeamNameException("Team name must be at most $MAX_NAME_LENGTH characters")
+        }
+        return name
+    }
+
+    private fun slugOf(name: String): String {
+        val slug = name.lowercase().replace(NON_SLUG_CHARS, "-").trim('-')
+        if (slug.isEmpty()) {
+            throw InvalidTeamNameException("Team name '$name' has no characters usable for a URL slug")
+        }
+        return slug
+    }
+
+    private fun schemaNameFor(name: String, slug: String): String {
+        val schemaName = SCHEMA_PREFIX + slug.replace('-', '_')
+        if (schemaName.toByteArray(Charsets.UTF_8).size > MAX_SCHEMA_BYTES) {
+            throw InvalidTeamNameException(
+                "Team name '$name' derives a schema longer than $MAX_SCHEMA_BYTES bytes — choose a shorter name",
+            )
+        }
+        // Defensive: the derivation above can only emit [a-z0-9_], but assert the injection-safety
+        // invariant explicitly so any future change to the slug rules can't silently weaken it.
+        require(SAFE_SCHEMA.matches(schemaName)) { "derived schema '$schemaName' is not a safe identifier" }
+        return schemaName
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamCreationCodeRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamCreationCodeRepository.kt
@@ -1,0 +1,17 @@
+package com.github.zzave.teambalance.api.domain.port
+
+import java.time.Instant
+
+/**
+ * Read-side access to the platform's one-time team-creation codes. Consumption is not here: it must be
+ * atomic with the team/member inserts, so it lives in [TeamRegistrar.register] inside that transaction.
+ */
+interface TeamCreationCodeRepository {
+    /**
+     * True if [code] is currently redeemable at [now] — it exists, is unconsumed, and is unexpired.
+     * A pre-provision peek only: it lets create-team reject an obviously-bad code with a 403 *before*
+     * provisioning a schema, so bad-code spam can't accrete orphan schemas. The authoritative,
+     * race-free check is the conditional UPDATE in [TeamRegistrar.register].
+     */
+    fun isRedeemable(code: String, now: Instant): Boolean
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamNotifier.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamNotifier.kt
@@ -1,0 +1,13 @@
+package com.github.zzave.teambalance.api.domain.port
+
+/**
+ * Fire-and-forget notifications emitted after a team is created. Implementations MUST swallow their own
+ * failures (a bounced email must never fail team creation) — callers treat every method as best-effort.
+ */
+interface TeamNotifier {
+    /** Tells the founder their new team is ready. */
+    fun teamCreated(founderEmail: String, teamName: String, teamSlug: String)
+
+    /** Audit trail to the platform admins: a creation code was consumed and a team was created. */
+    fun creationCodeConsumed(teamName: String, teamSlug: String, founderEmail: String)
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRegistrar.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRegistrar.kt
@@ -1,0 +1,32 @@
+package com.github.zzave.teambalance.api.domain.port
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The atomic write half of create-team: in a single transaction it consumes the creation code and
+ * inserts the new team plus its founding ADMIN member. Splitting this from provisioning keeps the
+ * provision-first ordering — the tenant schema is created (idempotently, on its own connection) before
+ * this commits, so a failure here leaves at worst a harmless empty orphan schema (the startup runner
+ * self-heals it) and never a consumed code without a team.
+ */
+interface TeamRegistrar {
+    /**
+     * Atomically: consume [creationCode] (conditional on it still being redeemable at [now]), insert
+     * the team ([name]/[slug]/[schemaName]), and insert [founderId] as its ADMIN with onboarding
+     * already complete ([now]). Returns the new team id. Writes nothing on failure.
+     *
+     * @throws com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
+     *   if the code was no longer redeemable at commit time (a race lost the code).
+     * @throws com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
+     *   if the slug / schema name collides with an existing team.
+     */
+    fun register(
+        creationCode: String,
+        founderId: UUID,
+        name: String,
+        slug: String,
+        schemaName: String,
+        now: Instant,
+    ): UUID
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -7,4 +7,11 @@ package com.github.zzave.teambalance.api.domain.port
 interface TeamRepository {
     /** Schema names of all teams — the source of truth for which tenant schemas must exist. */
     fun findAllSchemaNames(): List<String>
+
+    /**
+     * True if a team with this [slug] already exists. A best-effort pre-check so create-team can reject
+     * a duplicate name before provisioning a schema; the `slug`/`schema_name` UNIQUE constraints remain
+     * the authoritative guard against a concurrent collision.
+     */
+    fun existsBySlug(slug: String): Boolean
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantProvisioner.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantProvisioner.kt
@@ -1,0 +1,12 @@
+package com.github.zzave.teambalance.api.domain.port
+
+/**
+ * Creates a team's tenant schema and migrates it to head. Idempotent: provisioning an already-current
+ * schema is a no-op, so create-team can retry safely and the startup runner can re-run it every boot.
+ *
+ * The application layer depends on this port rather than the infrastructure `TenantSchemaManager`
+ * directly (hexagonal boundary — application must not import infrastructure).
+ */
+interface TenantProvisioner {
+    fun provisionTenant(schemaName: String)
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/PlatformAdmins.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/PlatformAdmins.kt
@@ -1,0 +1,22 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * The platform-admin allowlist, bound from `teambalance.platform-admins` (comma-separated emails, via
+ * PLATFORM_ADMIN_EMAILS). Fail-closed by design: the empty default means nobody is a platform admin.
+ * Matching is case-insensitive and whitespace-trimmed. Consumed by the platform-admin guard
+ * (creation-codes surface, #154 Slice 4) and as the audit recipients for team-created notifications.
+ */
+@Component
+class PlatformAdmins(
+    @Value("\${teambalance.platform-admins:}") rawEmails: List<String>,
+) {
+    private val emails: Set<String> = rawEmails.map { it.trim().lowercase() }.filter { it.isNotBlank() }.toSet()
+
+    fun contains(email: String): Boolean = emails.contains(email.trim().lowercase())
+
+    /** The configured admin emails, e.g. as audit-notification recipients. Empty when unset. */
+    fun all(): Set<String> = emails
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailConfiguration.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailConfiguration.kt
@@ -1,0 +1,14 @@
+package com.github.zzave.teambalance.api.infrastructure.email
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+/**
+ * Registers [EmailProperties] only in prod, where the Scaleway TEM senders — and their secrets — are
+ * active. Binding it in dev/test would fail: `teambalance.email.api-key` / `project-id` have no default.
+ */
+@Configuration
+@Profile("prod")
+@EnableConfigurationProperties(EmailProperties::class)
+class EmailConfiguration

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailProperties.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailProperties.kt
@@ -1,0 +1,18 @@
+package com.github.zzave.teambalance.api.infrastructure.email
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Scaleway Transactional Email (TEM) config, bound from `teambalance.email.*`. Co-located with the
+ * email adapters that consume it ([ScalewayTemEmailSender], [ScalewayTeamNotifier]). The secrets
+ * (`api-key` / `project-id`) have no default, so it is registered under `@Profile("prod")` only (see
+ * [EmailConfiguration]) — dev/test/e2e use the console/logging senders and never read it.
+ */
+@ConfigurationProperties(prefix = "teambalance.email")
+data class EmailProperties(
+    val fromName: String,
+    val fromAddress: String,
+    val apiKey: String,
+    val projectId: String,
+    val region: String,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/LoggingTeamNotifier.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/LoggingTeamNotifier.kt
@@ -1,0 +1,24 @@
+package com.github.zzave.teambalance.api.infrastructure.email
+
+import com.github.zzave.teambalance.api.domain.port.TeamNotifier
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * Dev/test/e2e [TeamNotifier]: logs the notifications instead of sending real email. Active in every
+ * profile except prod, where [ScalewayTeamNotifier] takes over. Mirrors [ConsoleEmailSender].
+ */
+@Component
+@Profile("!prod")
+class LoggingTeamNotifier : TeamNotifier {
+    private val log = LoggerFactory.getLogger(LoggingTeamNotifier::class.java)
+
+    override fun teamCreated(founderEmail: String, teamName: String, teamSlug: String) {
+        log.info("Team-created notification for {}: team '{}' ({})", founderEmail, teamName, teamSlug)
+    }
+
+    override fun creationCodeConsumed(teamName: String, teamSlug: String, founderEmail: String) {
+        log.info("Creation-code-consumed audit: team '{}' ({}) created by {}", teamName, teamSlug, founderEmail)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTeamNotifier.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTeamNotifier.kt
@@ -3,7 +3,6 @@ package com.github.zzave.teambalance.api.infrastructure.email
 import com.github.zzave.teambalance.api.domain.port.TeamNotifier
 import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
@@ -20,17 +19,13 @@ import org.springframework.web.client.RestClient
 @Primary
 @Profile("prod")
 class ScalewayTeamNotifier(
-    @Value("\${teambalance.email.from-name}") private val fromName: String,
-    @Value("\${teambalance.email.from-address}") private val fromAddress: String,
-    @Value("\${teambalance.email.api-key}") private val apiKey: String,
-    @Value("\${teambalance.email.project-id}") private val projectId: String,
-    @Value("\${teambalance.email.region}") private val region: String,
+    private val email: EmailProperties,
     private val platformAdmins: PlatformAdmins,
     restClientBuilder: RestClient.Builder,
 ) : TeamNotifier {
     private val log = LoggerFactory.getLogger(ScalewayTeamNotifier::class.java)
     private val restClient = restClientBuilder.build()
-    private val from = TemAddress(email = fromAddress, name = fromName)
+    private val from = TemAddress(email = email.fromAddress, name = email.fromName)
 
     override fun teamCreated(founderEmail: String, teamName: String, teamSlug: String) {
         send(
@@ -59,11 +54,11 @@ class ScalewayTeamNotifier(
                 subject = rendered.subject,
                 text = rendered.text,
                 html = rendered.html,
-                projectId = projectId,
+                projectId = email.projectId,
             )
             restClient.post()
-                .uri("https://api.scaleway.com/transactional-email/v1alpha1/regions/{region}/emails", region)
-                .header("X-Auth-Token", apiKey)
+                .uri("https://api.scaleway.com/transactional-email/v1alpha1/regions/{region}/emails", email.region)
+                .header("X-Auth-Token", email.apiKey)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTeamNotifier.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTeamNotifier.kt
@@ -1,0 +1,76 @@
+package com.github.zzave.teambalance.api.infrastructure.email
+
+import com.github.zzave.teambalance.api.domain.port.TeamNotifier
+import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+/**
+ * Production [TeamNotifier]: sends the create-team notifications via the Scaleway TEM API, reusing the
+ * same transport as [ScalewayTemEmailSender]. Fire-and-forget — every failure is caught and logged so a
+ * mail hiccup can never fail a committed team creation. The audit mail goes to the [PlatformAdmins]
+ * allowlist; with no admins configured it is silently skipped.
+ */
+@Component
+@Primary
+@Profile("prod")
+class ScalewayTeamNotifier(
+    @Value("\${teambalance.email.from-name}") private val fromName: String,
+    @Value("\${teambalance.email.from-address}") private val fromAddress: String,
+    @Value("\${teambalance.email.api-key}") private val apiKey: String,
+    @Value("\${teambalance.email.project-id}") private val projectId: String,
+    @Value("\${teambalance.email.region}") private val region: String,
+    private val platformAdmins: PlatformAdmins,
+    restClientBuilder: RestClient.Builder,
+) : TeamNotifier {
+    private val log = LoggerFactory.getLogger(ScalewayTeamNotifier::class.java)
+    private val restClient = restClientBuilder.build()
+    private val from = TemAddress(email = fromAddress, name = fromName)
+
+    override fun teamCreated(founderEmail: String, teamName: String, teamSlug: String) {
+        send(
+            recipients = listOf(TemAddress(email = founderEmail)),
+            rendered = TeamNotificationEmails.teamCreated(teamName),
+            description = "team-created to $founderEmail",
+        )
+    }
+
+    override fun creationCodeConsumed(teamName: String, teamSlug: String, founderEmail: String) {
+        val recipients = platformAdmins.all().map { TemAddress(email = it) }
+        if (recipients.isEmpty()) return
+        send(
+            recipients = recipients,
+            rendered = TeamNotificationEmails.creationCodeConsumed(teamName, teamSlug, founderEmail),
+            description = "creation-code-consumed audit for '$teamSlug'",
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun send(recipients: List<TemAddress>, rendered: RenderedEmail, description: String) {
+        try {
+            val payload = TemSendEmailRequest(
+                from = from,
+                to = recipients,
+                subject = rendered.subject,
+                text = rendered.text,
+                html = rendered.html,
+                projectId = projectId,
+            )
+            restClient.post()
+                .uri("https://api.scaleway.com/transactional-email/v1alpha1/regions/{region}/emails", region)
+                .header("X-Auth-Token", apiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity()
+        } catch (e: Exception) {
+            // Fire-and-forget: a failed notification must never fail the (already committed) creation.
+            log.warn("TeamNotifier send failed ({}) — ignored", description, e)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTemEmailSender.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTemEmailSender.kt
@@ -16,11 +16,7 @@ import org.springframework.web.client.RestClient
 @Profile("prod")
 class ScalewayTemEmailSender(
     @Value("\${teambalance.frontend-base-url}") private val frontendBaseUrl: String,
-    @Value("\${teambalance.email.from-name}") private val fromName: String,
-    @Value("\${teambalance.email.from-address}") private val fromAddress: String,
-    @Value("\${teambalance.email.api-key}") private val apiKey: String,
-    @Value("\${teambalance.email.project-id}") private val projectId: String,
-    @Value("\${teambalance.email.region}") private val region: String,
+    private val emailProperties: EmailProperties,
     restClientBuilder: RestClient.Builder,
 ) : EmailSender {
 
@@ -28,13 +24,16 @@ class ScalewayTemEmailSender(
 
     override fun sendMagicLink(email: String, token: String) {
         val payload = MagicLinkEmail.render(MagicLinkEmail.url(frontendBaseUrl, token)).externalize(
-            from = TemAddress(email = fromAddress, name = fromName),
+            from = TemAddress(email = emailProperties.fromAddress, name = emailProperties.fromName),
             to = TemAddress(email = email),
-            projectId = projectId,
+            projectId = emailProperties.projectId,
         )
         restClient.post()
-            .uri("https://api.scaleway.com/transactional-email/v1alpha1/regions/{region}/emails", region)
-            .header("X-Auth-Token", apiKey)
+            .uri(
+                "https://api.scaleway.com/transactional-email/v1alpha1/regions/{region}/emails",
+                emailProperties.region,
+            )
+            .header("X-Auth-Token", emailProperties.apiKey)
             .contentType(MediaType.APPLICATION_JSON)
             .body(payload)
             .retrieve()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/TeamNotificationEmails.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/email/TeamNotificationEmails.kt
@@ -1,0 +1,53 @@
+package com.github.zzave.teambalance.api.infrastructure.email
+
+/**
+ * Pure, framework-free copy for the create-team notifications: the founder's "your team is ready" mail
+ * and the platform-admin audit "a code was consumed" mail. Dutch multipart bodies, mirroring
+ * [MagicLinkEmail] so text and HTML can't drift.
+ */
+object TeamNotificationEmails {
+
+    private const val NO_REPLY = "Dit is een automatisch bericht — je kunt hier niet op reageren."
+
+    fun teamCreated(teamName: String): RenderedEmail {
+        val subject = "Je team '$teamName' is klaar"
+        return RenderedEmail(
+            subject = subject,
+            text = """
+                Hoi,
+
+                Je team '$teamName' is aangemaakt en klaar voor gebruik. Je bent beheerder van dit team.
+
+                $NO_REPLY
+            """.trimIndent(),
+            html = """
+                <div style="font-family:Arial,Helvetica,sans-serif;max-width:480px;margin:0 auto;color:#1a1a1a;">
+                  <p style="font-size:20px;font-weight:bold;">TeamBalance</p>
+                  <p>Hoi,</p>
+                  <p>Je team <strong>$teamName</strong> is aangemaakt en klaar voor gebruik. Je bent beheerder van dit team.</p>
+                  <p style="font-size:12px;color:#999;">$NO_REPLY</p>
+                </div>
+            """.trimIndent(),
+        )
+    }
+
+    fun creationCodeConsumed(teamName: String, teamSlug: String, founderEmail: String): RenderedEmail {
+        val subject = "Aanmaakcode gebruikt — team '$teamName' aangemaakt"
+        val line = "Er is een aanmaakcode gebruikt: team '$teamName' (slug $teamSlug) is aangemaakt door $founderEmail."
+        return RenderedEmail(
+            subject = subject,
+            text = """
+                $line
+
+                $NO_REPLY
+            """.trimIndent(),
+            html = """
+                <div style="font-family:Arial,Helvetica,sans-serif;max-width:480px;margin:0 auto;color:#1a1a1a;">
+                  <p style="font-size:20px;font-weight:bold;">TeamBalance</p>
+                  <p>$line</p>
+                  <p style="font-size:12px;color:#999;">$NO_REPLY</p>
+                </div>
+            """.trimIndent(),
+        )
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGuard.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGuard.kt
@@ -1,0 +1,34 @@
+package com.github.zzave.teambalance.api.infrastructure.identity
+
+import com.github.zzave.teambalance.api.domain.exception.NotPlatformAdminException
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Authorizes the current caller as a platform admin by resolving their email (via [UserRepository])
+ * and checking it against the [PlatformAdmins] allowlist. Reads the caller from [UserContext], mirroring
+ * how `SessionTenantContextFilter` reads the authenticated user.
+ *
+ * Fail-closed: an unknown user or an empty allowlist (the default) forbids everyone. Built here for
+ * #154 Slice 2; wired to the creation-codes admin surface in Slice 4.
+ */
+@Component
+class PlatformAdminGuard(
+    private val userRepository: UserRepository,
+    private val platformAdmins: PlatformAdmins,
+) {
+    /** Throws [NotPlatformAdminException] (→ 403) unless the current caller is on the allowlist. */
+    fun requirePlatformAdmin() {
+        val userId = UserContext.require()
+        if (!isPlatformAdmin(userId)) {
+            throw NotPlatformAdminException(userId)
+        }
+    }
+
+    fun isPlatformAdmin(userId: UUID): Boolean {
+        val email = userRepository.findById(userId)?.email ?: return false
+        return platformAdmins.contains(email)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManager.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaManager.kt
@@ -1,11 +1,15 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
+import com.github.zzave.teambalance.api.domain.port.TenantProvisioner
 import org.flywaydb.core.Flyway
 import org.springframework.stereotype.Component
 import javax.sql.DataSource
 
 @Component
-class TenantSchemaManager(private val dataSource: DataSource) {
+class TenantSchemaManager(private val dataSource: DataSource) : TenantProvisioner {
+
+    /** Port method for create-team; delegates to the existing idempotent provisioning primitive. */
+    override fun provisionTenant(schemaName: String) = provisionTenantSchema(schemaName)
 
     fun provisionPlatformSchema() {
         Flyway.configure()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamCreationCodeRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamCreationCodeRepositoryAdapter.kt
@@ -1,0 +1,34 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.Timestamp
+import java.time.Instant
+
+/**
+ * Reads `public.team_creation_codes` over the raw datasource (public-qualified, like the sibling
+ * platform adapters) so it works with no tenant resolved. Only the peek lives here; the authoritative
+ * consume is the conditional UPDATE in [JdbcTeamRegistrationAdapter], which must be atomic with the
+ * team/member inserts.
+ */
+@Repository
+class JdbcTeamCreationCodeRepositoryAdapter(
+    private val jdbcTemplate: JdbcTemplate,
+) : TeamCreationCodeRepository {
+
+    override fun isRedeemable(code: String, now: Instant): Boolean =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS(
+                SELECT 1 FROM public.team_creation_codes
+                WHERE code = ?
+                  AND consumed_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > ?)
+            )
+            """.trimIndent(),
+            Boolean::class.java,
+            code,
+            Timestamp.from(now),
+        ) ?: false
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRegistrationAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRegistrationAdapter.kt
@@ -1,0 +1,89 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
+import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.port.TeamRegistrar
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The atomic write of create-team. `@Transactional` puts the transaction boundary in the adapter: the
+ * code consume and both inserts commit together or not at all — a race that loses the code, or a slug
+ * collision, rolls everything back so no team is half-created.
+ *
+ * All statements are public-qualified and use [JdbcTemplate] (not Hibernate), matching the sibling
+ * platform adapters: create-team runs with no tenant resolved, where the tenant-routed JPA path fails
+ * closed.
+ */
+@Repository
+class JdbcTeamRegistrationAdapter(
+    private val jdbcTemplate: JdbcTemplate,
+) : TeamRegistrar {
+
+    @Transactional
+    override fun register(
+        creationCode: String,
+        founderId: UUID,
+        name: String,
+        slug: String,
+        schemaName: String,
+        now: Instant,
+    ): UUID {
+        val at = Timestamp.from(now)
+
+        // Consume the code conditionally: exactly one row updates iff it is still redeemable. Zero rows
+        // means it was consumed/expired between the pre-check and now — opaque 403, whole tx rolls back.
+        val consumed = jdbcTemplate.update(
+            """
+            UPDATE public.team_creation_codes
+            SET consumed_at = ?, consumed_by_user_id = ?
+            WHERE code = ?
+              AND consumed_at IS NULL
+              AND (expires_at IS NULL OR expires_at > ?)
+            """.trimIndent(),
+            at,
+            founderId,
+            creationCode,
+            at,
+        )
+        if (consumed != 1) {
+            throw InvalidCreationCodeException()
+        }
+
+        val teamId = insertTeam(name, slug, schemaName)
+
+        // Founding admin: ADMIN role, onboarding already complete (skips /welcome), no position yet.
+        jdbcTemplate.update(
+            "INSERT INTO public.team_members (team_id, user_id, role, onboarded_at) VALUES (?, ?, ?, ?)",
+            teamId,
+            founderId,
+            Role.ADMIN.name,
+            at,
+        )
+
+        return teamId
+    }
+
+    // The DuplicateKeyException is intentionally translated (not chained) into a clean domain 409:
+    // the slug / schema_name UNIQUE constraint tripped because a team was created under this name in
+    // the window after the pre-check. The driver-level cause carries no caller-actionable detail.
+    @Suppress("SwallowedException")
+    private fun insertTeam(name: String, slug: String, schemaName: String): UUID =
+        try {
+            jdbcTemplate.queryForObject(
+                "INSERT INTO public.teams (name, slug, schema_name) VALUES (?, ?, ?) RETURNING id",
+                UUID::class.java,
+                name,
+                slug,
+                schemaName,
+            )!!
+        } catch (e: DuplicateKeyException) {
+            throw TeamSlugTakenException(slug)
+        }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -17,4 +17,11 @@ class JdbcTeamRepositoryAdapter(
     override fun findAllSchemaNames(): List<String> =
         // schema_name is NOT NULL; filterNotNull only satisfies queryForList's nullable element type.
         jdbcTemplate.queryForList("SELECT schema_name FROM public.teams", String::class.java).filterNotNull()
+
+    override fun existsBySlug(slug: String): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT EXISTS(SELECT 1 FROM public.teams WHERE slug = ?)",
+            Boolean::class.java,
+            slug,
+        ) ?: false
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -1,0 +1,38 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.application.CreatedTeam
+import com.github.zzave.teambalance.api.application.TeamService
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateTeam
+import com.github.zzave.teambalance.api.interfaces.generated.model.Team
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Self-service team creation (#154, ADR-0015). The caller is authenticated but, by definition, has no
+ * team yet — so this only resolves the current *user* (never `requireCurrentTeamId`, which would
+ * fail-closed with 403 for a teamless user). Error mapping (bad name → 400, invalid code → opaque 403,
+ * already-in-team / slug clash → 409) is handled by the thrown domain exceptions via
+ * [GlobalExceptionHandler]; only the 201 success branch is produced here.
+ */
+@RestController
+class TeamController(
+    private val teamService: TeamService,
+    private val currentUserGateway: CurrentUserGateway,
+) : CreateTeam.Handler {
+
+    override suspend fun createTeam(request: CreateTeam.Request): CreateTeam.Response<*> {
+        val founderId = currentUserGateway.requireCurrentUserId()
+        val created = teamService.createTeam(
+            founderId = founderId,
+            rawName = request.body.name,
+            creationCode = request.body.creationCode,
+        )
+        return CreateTeam.Response201(created.toDto())
+    }
+}
+
+private fun CreatedTeam.toDto() = Team(
+    id = id.toString(),
+    name = name,
+    slug = slug,
+)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -100,6 +100,10 @@ teambalance:
       enabled: false
   # Base URL of the SPA; used to build the clickable magic-link (…/auth/verify?token=…).
   frontend-base-url: ${TEAMBALANCE_FRONTEND_BASE_URL:https://app.teambalance.nl}
+  # Comma-separated platform-admin emails (PLATFORM_ADMIN_EMAILS). Empty default = fail-closed: nobody
+  # is a platform admin. Gates the creation-codes admin surface (#154 Slice 4) and receives the
+  # "code consumed → team created" audit notifications. See ADR-0015.
+  platform-admins: ${PLATFORM_ADMIN_EMAILS:}
   session:
     # Absolute session lifetime, enforced by SessionUserContextFilter (Spring Session itself only does
     # the sliding idle timeout above). A single login — even one kept continuously active — must

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -2,8 +2,8 @@
 -- AFTER Flyway (platform) and provisionTenantSchema('team_test') have run.
 -- Pure INSERTs only (no DDL); idempotent so repeated backend starts against the same DB are safe.
 
-INSERT INTO public.teams (id, name, slug, sport, schema_name)
-VALUES ('e2e00000-0000-0000-0000-000000000001', 'E2E Test Team', 'e2e-test-team', 'volleyball', 'team_test')
+INSERT INTO public.teams (id, name, slug, schema_name)
+VALUES ('e2e00000-0000-0000-0000-000000000001', 'E2E Test Team', 'e2e-test-team', 'team_test')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO public.users (id, email, display_name)

--- a/api/src/main/resources/db/migration/V006__team_creation_codes.sql
+++ b/api/src/main/resources/db/migration/V006__team_creation_codes.sql
@@ -1,0 +1,13 @@
+-- Platform-level one-time codes that gate self-service team creation (issue #154, ADR-0015).
+-- A code is redeemable while consumed_at IS NULL and (expires_at IS NULL OR expires_at > now());
+-- create-team consumes it atomically (single conditional UPDATE) so a code can be spent at most once.
+CREATE TABLE team_creation_codes (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code                 VARCHAR(100) NOT NULL UNIQUE,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- NULL = never expires; otherwise the code stops being redeemable once now() passes it.
+    expires_at           TIMESTAMPTZ,
+    -- NULL until spent; stamped together with consumed_by_user_id in the same atomic UPDATE.
+    consumed_at          TIMESTAMPTZ,
+    consumed_by_user_id  UUID REFERENCES users(id)
+);

--- a/api/src/main/resources/db/migration/V007__drop_teams_sport.sql
+++ b/api/src/main/resources/db/migration/V007__drop_teams_sport.sql
@@ -1,0 +1,9 @@
+-- Self-service onboarding (ADR-0015) creates teams from a name + creation code only — no sport is
+-- collected. The column was never surfaced in the API or UI and carried a single placeholder value,
+-- so drop it. Auto-pinned to `public` by spring.flyway.schemas (application.yml).
+--
+-- Note: the test-only seed V1_1__seed_demo_data.sql still inserts a sport value; it runs at version 1.1
+-- (before this drop), reflecting the schema as it was then — exactly like it still seeds the legacy
+-- team_role column that V003 later drops. Post-migration insert sites (dev/e2e seeds, ITs, the runbook)
+-- run after this drop and therefore omit sport.
+ALTER TABLE teams DROP COLUMN sport;

--- a/api/src/main/resources/db/seed/demo_data.sql
+++ b/api/src/main/resources/db/seed/demo_data.sql
@@ -3,8 +3,8 @@
 -- idempotent (ON CONFLICT DO NOTHING) so a dev restart against an existing DB is a no-op.
 -- The test-fixture equivalent is src/test/resources/db/migration/V1_1__seed_demo_data.sql.
 
-INSERT INTO teams (id, name, slug, sport, schema_name) VALUES
-    ('a0000000-0000-0000-0000-000000000001', 'Setpoint VT', 'setpoint-vt', 'Volleyball', 'team_setpoint_vt')
+INSERT INTO teams (id, name, slug, schema_name) VALUES
+    ('a0000000-0000-0000-0000-000000000001', 'Setpoint VT', 'setpoint-vt', 'team_setpoint_vt')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO users (id, email, display_name) VALUES

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -1,0 +1,17 @@
+type CreateTeamRequest {
+    name: String,
+    creationCode: String
+}
+
+type Team {
+    id: String,
+    name: String,
+    slug: String
+}
+
+endpoint CreateTeam POST CreateTeamRequest /api/teams -> {
+    201 -> Team
+    400 -> Unit
+    403 -> Unit
+    409 -> Unit
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -1,0 +1,185 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.exception.AlreadyInTeamException
+import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
+import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
+import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.model.User
+import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TeamNotifier
+import com.github.zzave.teambalance.api.domain.port.TeamRegistrar
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.TenantProvisioner
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+private class FakeMemberRepo(private val existingTeam: UUID?) : TeamMemberRepository {
+    override fun findTeamId(userId: UUID): UUID? = existingTeam
+    override fun findByTeamId(teamId: UUID): List<TeamMember> = emptyList()
+    override fun findDisplayName(userId: UUID): String? = null
+    override fun findMembersByUserIds(userIds: Set<UUID>): Map<UUID, TeamMember> = emptyMap()
+    override fun findRole(teamId: UUID, userId: UUID): Role? = null
+    override fun addMember(teamId: UUID, userId: UUID) = Unit
+    override fun updateRole(teamId: UUID, userId: UUID, role: Role) = Unit
+    override fun deactivate(teamId: UUID, userId: UUID) = Unit
+    override fun assignPosition(teamId: UUID, userId: UUID, positionId: UUID?) = Unit
+    override fun markOnboarded(teamId: UUID, userId: UUID, at: Instant) = Unit
+    override fun countAdmins(teamId: UUID): Int = 0
+}
+
+private class FakeTeamRepo(private val existingSlugs: Set<String> = emptySet()) : TeamRepository {
+    override fun findAllSchemaNames(): List<String> = emptyList()
+    override fun existsBySlug(slug: String): Boolean = slug in existingSlugs
+}
+
+private class FakeCodeRepo(private val redeemable: Boolean) : TeamCreationCodeRepository {
+    override fun isRedeemable(code: String, now: Instant): Boolean = redeemable
+}
+
+// Both the provisioner and the registrar append to one shared log so tests can assert ordering
+// (provision-first) as well as whether each step ran at all.
+private class RecordingProvisioner(private val calls: MutableList<String>, private val fail: Boolean = false) :
+    TenantProvisioner {
+    override fun provisionTenant(schemaName: String) {
+        if (fail) throw IllegalStateException("provision boom")
+        calls += "provision:$schemaName"
+    }
+}
+
+private class RecordingRegistrar(
+    private val calls: MutableList<String>,
+    private val teamId: UUID,
+) : TeamRegistrar {
+    override fun register(
+        creationCode: String,
+        founderId: UUID,
+        name: String,
+        slug: String,
+        schemaName: String,
+        now: Instant,
+    ): UUID {
+        calls += "register:$slug"
+        return teamId
+    }
+}
+
+private class FakeUserRepo(private val user: User?) : UserRepository {
+    override fun findById(id: UUID): User? = user
+    override fun findByEmail(email: String): User? = null
+    override fun save(user: User): User = user
+}
+
+private class RecordingNotifier(private val throwing: Boolean = false) : TeamNotifier {
+    val created = mutableListOf<Triple<String, String, String>>()
+    val audited = mutableListOf<Triple<String, String, String>>()
+    override fun teamCreated(founderEmail: String, teamName: String, teamSlug: String) {
+        if (throwing) throw IllegalStateException("mail boom")
+        created += Triple(founderEmail, teamName, teamSlug)
+    }
+    override fun creationCodeConsumed(teamName: String, teamSlug: String, founderEmail: String) {
+        if (throwing) throw IllegalStateException("mail boom")
+        audited += Triple(teamName, teamSlug, founderEmail)
+    }
+}
+
+class TeamServiceTest : FunSpec() {
+    init {
+        val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+        val founder = UUID.randomUUID()
+        val newTeamId = UUID.randomUUID()
+        val founderUser = User(id = founder, email = "founder@example.com", displayName = "Founder")
+
+        fun service(
+            calls: MutableList<String> = mutableListOf(),
+            existingTeam: UUID? = null,
+            existingSlugs: Set<String> = emptySet(),
+            redeemable: Boolean = true,
+            provisionFails: Boolean = false,
+            user: User? = founderUser,
+            notifier: TeamNotifier = RecordingNotifier(),
+        ) = TeamService(
+            teamMemberRepository = FakeMemberRepo(existingTeam),
+            teamRepository = FakeTeamRepo(existingSlugs),
+            creationCodeRepository = FakeCodeRepo(redeemable),
+            tenantProvisioner = RecordingProvisioner(calls, provisionFails),
+            teamRegistrar = RecordingRegistrar(calls, newTeamId),
+            userRepository = FakeUserRepo(user),
+            teamNotifier = notifier,
+            clock = clock,
+        )
+
+        test("creates the team: provisions the schema, registers, and returns id/name/slug") {
+            val calls = mutableListOf<String>()
+            val created = service(calls).createTeam(founder, "Setpoint VT", "GOODCODE")
+
+            created.id shouldBe newTeamId
+            created.name shouldBe "Setpoint VT"
+            created.slug shouldBe "setpoint-vt"
+            // Provision-first: the schema is created before the atomic register commits.
+            calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
+        }
+
+        test("rejects a founder who already belongs to a team, without provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<AlreadyInTeamException> {
+                service(calls, existingTeam = UUID.randomUUID()).createTeam(founder, "New Team", "GOODCODE")
+            }
+            calls shouldBe emptyList()
+        }
+
+        test("rejects a blank / underivable name with 400 before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<InvalidTeamNameException> { service(calls).createTeam(founder, "   ", "GOODCODE") }
+            calls shouldBe emptyList()
+        }
+
+        test("rejects a taken slug with 409 before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<TeamSlugTakenException> {
+                service(calls, existingSlugs = setOf("setpoint-vt")).createTeam(founder, "Setpoint VT", "GOODCODE")
+            }
+            calls shouldBe emptyList()
+        }
+
+        test("rejects a non-redeemable code with opaque 403 and does NOT provision a schema") {
+            val calls = mutableListOf<String>()
+            shouldThrow<InvalidCreationCodeException> {
+                service(calls, redeemable = false).createTeam(founder, "Setpoint VT", "BADCODE")
+            }
+            // The peek gates provisioning — a bad code never leaves an orphan schema behind.
+            calls shouldBe emptyList()
+        }
+
+        test("a provisioning failure propagates and no registration happens") {
+            val calls = mutableListOf<String>()
+            shouldThrow<RuntimeException> {
+                service(calls, provisionFails = true).createTeam(founder, "Setpoint VT", "GOODCODE")
+            }
+            calls shouldBe emptyList() // provisioner threw before recording; register never reached
+        }
+
+        test("notifies the founder and audits the platform admins on success") {
+            val notifier = RecordingNotifier()
+            service(notifier = notifier).createTeam(founder, "Setpoint VT", "GOODCODE")
+
+            notifier.created shouldContainExactly listOf(Triple("founder@example.com", "Setpoint VT", "setpoint-vt"))
+            notifier.audited shouldContainExactly listOf(Triple("Setpoint VT", "setpoint-vt", "founder@example.com"))
+        }
+
+        test("a failing notifier never fails a committed creation (fire-and-forget)") {
+            val created = service(notifier = RecordingNotifier(throwing = true))
+                .createTeam(founder, "Setpoint VT", "GOODCODE")
+            created.id shouldBe newTeamId
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNamingTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNamingTest.kt
@@ -1,0 +1,74 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pure derivation of a team's slug + tenant schema name from a raw display name. The schema name is
+ * fed straight into `SET search_path`, so this is the security-critical sanitisation boundary: the
+ * whitelist regex `^team_[a-z0-9_]+$` is what makes the derived identifier injection-safe.
+ */
+class TeamNamingTest : FunSpec() {
+    init {
+        test("lowercases and hyphenates a simple name into slug + team_ schema") {
+            val names = TeamNaming.derive("Setpoint VT")
+            names.name shouldBe "Setpoint VT"
+            names.slug shouldBe "setpoint-vt"
+            names.schemaName shouldBe "team_setpoint_vt"
+        }
+
+        test("collapses runs of non-alphanumeric characters into a single hyphen") {
+            TeamNaming.derive("  Ajax   //  Amsterdam!! ").let {
+                it.slug shouldBe "ajax-amsterdam"
+                it.schemaName shouldBe "team_ajax_amsterdam"
+            }
+        }
+
+        test("trims leading and trailing separators from the slug") {
+            TeamNaming.derive("--Rockets--").slug shouldBe "rockets"
+        }
+
+        test("maps accented and non-ascii characters through the separator (never into the identifier)") {
+            // é / ü are not [a-z0-9]; they must not leak into the schema identifier.
+            TeamNaming.derive("Café Zürich 4").let {
+                it.slug shouldBe "caf-z-rich-4"
+                it.schemaName shouldBe "team_caf_z_rich_4"
+            }
+        }
+
+        test("keeps digits and treats a purely numeric name as valid") {
+            TeamNaming.derive("2024").let {
+                it.slug shouldBe "2024"
+                it.schemaName shouldBe "team_2024"
+            }
+        }
+
+        test("derived schema always matches the injection-safe whitelist") {
+            Regex("^team_[a-z0-9_]+$").matches(TeamNaming.derive("A B C 1").schemaName) shouldBe true
+        }
+
+        test("rejects a blank name") {
+            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("   ") }
+        }
+
+        test("rejects a name with no slug-usable characters") {
+            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("!!! @#$ %^&") }
+        }
+
+        test("rejects a name longer than the 100-char column limit") {
+            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("a".repeat(101)) }
+        }
+
+        test("rejects a name whose derived schema would exceed 63 bytes (never truncates)") {
+            // 60 'a's → schema "team_" + 60 = 65 bytes > 63. Must reject, not silently truncate.
+            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("a".repeat(60)) }
+        }
+
+        test("accepts a name whose derived schema is exactly at the 63-byte limit") {
+            // "team_" (5) + 58 = 63 bytes exactly.
+            TeamNaming.derive("a".repeat(58)).schemaName.toByteArray().size shouldBe 63
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailSenderProfileTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/email/EmailSenderProfileTest.kt
@@ -15,7 +15,13 @@ class EmailSenderProfileTest : FunSpec({
     fun runnerFor(profile: String) = ApplicationContextRunner()
         .withInitializer { it.environment.setActiveProfiles(profile) }
         .withBean(RestClient.Builder::class.java, { RestClient.builder() })
-        .withUserConfiguration(ScalewayTemEmailSender::class.java, ConsoleEmailSender::class.java)
+        // EmailConfiguration (@Profile("prod")) supplies the EmailProperties the Scaleway sender binds;
+        // it registers only under the prod run, exactly as in the real app.
+        .withUserConfiguration(
+            EmailConfiguration::class.java,
+            ScalewayTemEmailSender::class.java,
+            ConsoleEmailSender::class.java,
+        )
         .withPropertyValues(
             "teambalance.frontend-base-url=https://app.teambalance.nl",
             "teambalance.email.from-name=TeamBalance",

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTemEmailSenderTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/email/ScalewayTemEmailSenderTest.kt
@@ -19,11 +19,13 @@ class ScalewayTemEmailSenderTest : FunSpec() {
 
     private fun sender(builder: RestClient.Builder) = ScalewayTemEmailSender(
         frontendBaseUrl = "https://app.teambalance.nl",
-        fromName = "TeamBalance",
-        fromAddress = "login@teambalance.nl",
-        apiKey = "secret-key",
-        projectId = "project-42",
-        region = "fr-par",
+        emailProperties = EmailProperties(
+            fromName = "TeamBalance",
+            fromAddress = "login@teambalance.nl",
+            apiKey = "secret-key",
+            projectId = "project-42",
+            region = "fr-par",
+        ),
         restClientBuilder = builder,
     )
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGuardTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGuardTest.kt
@@ -1,0 +1,63 @@
+package com.github.zzave.teambalance.api.infrastructure.identity
+
+import com.github.zzave.teambalance.api.domain.exception.NotPlatformAdminException
+import com.github.zzave.teambalance.api.domain.model.User
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import com.github.zzave.teambalance.api.infrastructure.config.PlatformAdmins
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+private class FakeUsers(private val byId: Map<UUID, User>) : UserRepository {
+    override fun findById(id: UUID): User? = byId[id]
+    override fun findByEmail(email: String): User? = byId.values.firstOrNull { it.email == email }
+    override fun save(user: User): User = user
+}
+
+class PlatformAdminGuardTest : FunSpec() {
+    init {
+        val adminId = UUID.randomUUID()
+        val plainId = UUID.randomUUID()
+        val admin = User(adminId, "admin@teambalance.nl", "Admin")
+        val plain = User(plainId, "someone@example.com", "Someone")
+        val users = FakeUsers(mapOf(adminId to admin, plainId to plain))
+
+        fun guard(allowlist: List<String>) = PlatformAdminGuard(users, PlatformAdmins(allowlist))
+
+        test("isPlatformAdmin is true for an allowlisted email, case-insensitively") {
+            guard(listOf("Admin@TeamBalance.NL")).isPlatformAdmin(adminId) shouldBe true
+        }
+
+        test("isPlatformAdmin is false for a non-allowlisted user") {
+            guard(listOf("admin@teambalance.nl")).isPlatformAdmin(plainId) shouldBe false
+        }
+
+        test("empty allowlist is fail-closed — nobody is a platform admin") {
+            guard(emptyList()).isPlatformAdmin(adminId) shouldBe false
+        }
+
+        test("unknown user id is fail-closed") {
+            guard(listOf("admin@teambalance.nl")).isPlatformAdmin(UUID.randomUUID()) shouldBe false
+        }
+
+        test("requirePlatformAdmin passes for an allowlisted caller in context") {
+            UserContext.set(adminId)
+            try {
+                shouldNotThrowAny { guard(listOf("admin@teambalance.nl")).requirePlatformAdmin() }
+            } finally {
+                UserContext.clear()
+            }
+        }
+
+        test("requirePlatformAdmin throws 403 for a non-admin caller in context") {
+            UserContext.set(plainId)
+            try {
+                shouldThrow<NotPlatformAdminException> { guard(listOf("admin@teambalance.nl")).requirePlatformAdmin() }
+            } finally {
+                UserContext.clear()
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -98,8 +98,8 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
             userId, "member-$userId@test.com", "Test Member",
         )
         jdbcTemplate.update(
-            "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
-            teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
+            "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
+            teamId, "Test Team", "test-team-$teamId", schemaName,
         )
         jdbcTemplate.update(
             "INSERT INTO public.team_members (team_id, user_id, role) VALUES (?, ?, 'USER')",

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/StartupTenantMigrationRunnerIT.kt
@@ -66,10 +66,9 @@ class StartupTenantMigrationRunnerIT : TeamBalanceIT() {
         val token = UUID.randomUUID().toString().replace("-", "").take(12)
         val schema = "team_s1_$token"
         jdbcTemplate.update(
-            "INSERT INTO public.teams (name, slug, sport, schema_name) VALUES (?, ?, ?, ?)",
+            "INSERT INTO public.teams (name, slug, schema_name) VALUES (?, ?, ?)",
             "Slice1 $token",
             "slice1-$token",
-            "Volleyball",
             schema,
         )
         return schema

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -70,8 +70,8 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
         val teamId = UUID.randomUUID()
         val schemaName = "team_${teamId.toString().replace("-", "")}"
         jdbcTemplate.update(
-            "INSERT INTO public.teams (id, name, slug, sport, schema_name) VALUES (?, ?, ?, ?, ?)",
-            teamId, "Test Team", "test-team-$teamId", "Volleyball", schemaName,
+            "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
+            teamId, "Test Team", "test-team-$teamId", schemaName,
         )
         val userId = seedMemberOnTeam(teamId, role, active)
         return teamId to userId

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceAuthorizationIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceAuthorizationIT.kt
@@ -90,8 +90,8 @@ class AttendanceAuthorizationIT : TeamBalanceIT() {
     private fun newTeamMember(teamId: UUID, email: String, name: String): String {
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$teamId'::uuid, 'Team $teamId', 'authz-$teamId', 'Volleyball', 'authz-$teamId')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$teamId'::uuid, 'Team $teamId', 'authz-$teamId', 'authz-$teamId')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
@@ -36,8 +36,8 @@ class AttendanceControllerTest : TeamBalanceIT() {
             tenantSchemaManager.provisionTenantSchema("public")
 
             jdbcTemplate.execute("""
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team 2', 'test-team-2', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team 2', 'test-team-2', 'public')
                 ON CONFLICT DO NOTHING
             """)
             jdbcTemplate.execute("""
@@ -80,8 +80,8 @@ class AttendanceControllerTest : TeamBalanceIT() {
             tenantSchemaManager.provisionTenantSchema("public")
 
             jdbcTemplate.execute("""
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team 2', 'test-team-2', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team 2', 'test-team-2', 'public')
                 ON CONFLICT DO NOTHING
             """)
             jdbcTemplate.execute("""
@@ -129,8 +129,8 @@ class AttendanceControllerTest : TeamBalanceIT() {
             val editorId = UUID.randomUUID().toString()
 
             jdbcTemplate.execute("""
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$teamId'::uuid, 'Cross Edit Team', 'cross-edit-team-$teamId', 'Volleyball', 'cross-edit-team-$teamId')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$teamId'::uuid, 'Cross Edit Team', 'cross-edit-team-$teamId', 'cross-edit-team-$teamId')
                 ON CONFLICT DO NOTHING
             """)
             jdbcTemplate.execute("""

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceMembershipIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceMembershipIT.kt
@@ -88,8 +88,8 @@ class AttendanceMembershipIT : TeamBalanceIT() {
     private fun seedTeam() {
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$teamId'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$teamId'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
@@ -1,0 +1,197 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaManager
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+// Spec-dedicated ids/schemas so the one-team-per-user guard and the shared (no-rollback) Testcontainers
+// DB don't bleed between specs. Each test that must actually create a team uses a fresh founder + name.
+@AutoConfigureMockMvc
+class CreateTeamControllerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaManager: TenantSchemaManager
+
+    private fun seedUser(id: String, email: String) {
+        tenantSchemaManager.provisionPlatformSchema()
+        jdbcTemplate.update(
+            "INSERT INTO public.users (id, email, display_name) VALUES (?::uuid, ?, ?) " +
+                "ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email",
+            id,
+            email,
+            "Founder $email",
+        )
+    }
+
+    private fun seedCode(code: String, expiresSql: String = "NULL") {
+        jdbcTemplate.update(
+            "INSERT INTO public.team_creation_codes (code, expires_at) VALUES (?, $expiresSql) " +
+                "ON CONFLICT (code) DO NOTHING",
+            code,
+        )
+    }
+
+    private fun createTeam(userId: String, name: String, code: String) =
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/teams")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"$name","creationCode":"$code"}"""),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    /** Versioned tenant migrations applied to [schema] (baseline excluded) — proves migration-to-head. */
+    private fun appliedTenantMigrations(schema: String): Int = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM \"$schema\".flyway_tenant_schema_history " +
+            "WHERE success = true AND version IS NOT NULL AND \"type\" <> 'BASELINE'",
+        Int::class.java,
+    ) ?: 0
+
+    private fun tenantMigrationsOnClasspath(): Int =
+        PathMatchingResourcePatternResolver()
+            .getResources("classpath*:db/tenant-migration/V*__*.sql")
+            .size
+
+    init {
+        test("POST /api/teams provisions the tenant schema, makes the founder ADMIN, and consumes the code") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "happy-${founder.take(8)}@test.com")
+            seedCode("CT-HAPPY-${founder.take(8)}")
+
+            createTeam(founder, "Create IT Happy", "CT-HAPPY-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Create IT Happy"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.slug").value("create-it-happy"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").isNotEmpty)
+                // schema_name is deliberately not exposed on the DTO.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.schema_name").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.schemaName").doesNotExist())
+
+            val schema = "team_create_it_happy"
+
+            // Tenant schema provisioned and migrated to head.
+            appliedTenantMigrations(schema) shouldBe tenantMigrationsOnClasspath()
+
+            // Founder is the founding ADMIN with onboarding already stamped (skips /welcome), no position.
+            val member = jdbcTemplate.queryForMap(
+                "SELECT tm.role, tm.onboarded_at, tm.position_id, tm.active FROM public.team_members tm " +
+                    "JOIN public.teams t ON t.id = tm.team_id WHERE tm.user_id = ?::uuid",
+                founder,
+            )
+            member["role"] shouldBe "ADMIN"
+            member["onboarded_at"].shouldNotBeNull()
+            member["position_id"] shouldBe null
+            member["active"] shouldBe true
+
+            // Code is consumed by this founder (single-use).
+            val consumedBy = jdbcTemplate.queryForObject(
+                "SELECT consumed_by_user_id::text FROM public.team_creation_codes WHERE code = ?",
+                String::class.java,
+                "CT-HAPPY-${founder.take(8)}",
+            )
+            consumedBy shouldBe founder
+
+            // Routing resolves the new team immediately (the SessionTenantContextFilter lookup).
+            val routedSchema = jdbcTemplate.queryForObject(
+                "SELECT t.schema_name FROM public.team_members tm JOIN public.teams t ON t.id = tm.team_id " +
+                    "WHERE tm.user_id = ?::uuid AND tm.active = true",
+                String::class.java,
+                founder,
+            )
+            routedSchema shouldBe schema
+        }
+
+        test("a consumed code cannot be reused — second use returns opaque 403") {
+            val founder = UUID.randomUUID().toString()
+            val other = UUID.randomUUID().toString()
+            seedUser(founder, "reuse-a-${founder.take(8)}@test.com")
+            seedUser(other, "reuse-b-${other.take(8)}@test.com")
+            seedCode("CT-REUSE-${founder.take(8)}")
+
+            createTeam(founder, "Create IT Reuse", "CT-REUSE-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+
+            // A different (teamless) user tries the now-consumed code.
+            createTeam(other, "Create IT Reuse Two", "CT-REUSE-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("an unknown creation code returns opaque 403") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "unknown-${founder.take(8)}@test.com")
+
+            createTeam(founder, "Create IT Unknown", "NO-SUCH-CODE-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("an expired creation code returns opaque 403 and provisions nothing") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "expired-${founder.take(8)}@test.com")
+            seedCode("CT-EXPIRED-${founder.take(8)}", expiresSql = "now() - interval '1 day'")
+
+            createTeam(founder, "Create IT Expired", "CT-EXPIRED-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("a founder already in a team gets 409 and the code stays unconsumed") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "already-${founder.take(8)}@test.com")
+            seedCode("CT-FIRST-${founder.take(8)}")
+            seedCode("CT-SECOND-${founder.take(8)}")
+
+            createTeam(founder, "Create IT First", "CT-FIRST-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+
+            createTeam(founder, "Create IT Second", "CT-SECOND-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isConflict)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("ALREADY_IN_TEAM"))
+
+            // The one-team guard trips before the code is touched, so the second code is still redeemable.
+            val consumedAt = jdbcTemplate.queryForObject(
+                "SELECT consumed_at FROM public.team_creation_codes WHERE code = ?",
+                java.sql.Timestamp::class.java,
+                "CT-SECOND-${founder.take(8)}",
+            )
+            consumedAt shouldBe null
+        }
+
+        test("a blank team name returns 400") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "blank-${founder.take(8)}@test.com")
+            seedCode("CT-BLANK-${founder.take(8)}")
+
+            createTeam(founder, "   ", "CT-BLANK-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+        }
+
+        test("creating a team without an authenticated user returns 401") {
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/teams")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"Nope","creationCode":"whatever"}"""),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTenantIsolationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTenantIsolationTest.kt
@@ -43,15 +43,15 @@ class EventControllerTenantIsolationTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$ALPHA_TEAM_ID'::uuid, 'Team Alpha', 'team-alpha-iso', 'Volleyball', '$ALPHA_SCHEMA')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$ALPHA_TEAM_ID'::uuid, 'Team Alpha', 'team-alpha-iso', '$ALPHA_SCHEMA')
                 ON CONFLICT DO NOTHING
                 """
             )
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$BETA_TEAM_ID'::uuid, 'Team Beta', 'team-beta-iso', 'Volleyball', '$BETA_SCHEMA')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$BETA_TEAM_ID'::uuid, 'Team Beta', 'team-beta-iso', '$BETA_SCHEMA')
                 ON CONFLICT DO NOTHING
                 """
             )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -50,8 +50,8 @@ class EventControllerTest : TeamBalanceIT() {
             // Seed the minimal platform data this test needs.
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -103,8 +103,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -157,8 +157,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -242,8 +242,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -303,8 +303,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -363,8 +363,8 @@ class EventControllerTest : TeamBalanceIT() {
             // team ($TEAM_ID) — inserts are idempotent (ON CONFLICT DO NOTHING) across tests.
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -477,8 +477,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -531,8 +531,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -596,8 +596,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -649,8 +649,8 @@ class EventControllerTest : TeamBalanceIT() {
             val noPositionUserId = "b0000000-0000-0000-0000-0000000000c1"
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -698,8 +698,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )
@@ -756,8 +756,8 @@ class EventControllerTest : TeamBalanceIT() {
 
             jdbcTemplate.execute(
                 """
-                INSERT INTO public.teams (id, name, slug, sport, schema_name)
-                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
                 ON CONFLICT DO NOTHING
             """
             )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventReferencesControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventReferencesControllerTest.kt
@@ -37,8 +37,8 @@ class EventReferencesControllerTest : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
         """
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
@@ -388,8 +388,8 @@ class EventSeriesControllerIT : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
@@ -117,8 +117,8 @@ class EventTransactionBoundaryIT : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -43,8 +43,8 @@ class InvitationControllerTest : TeamBalanceIT() {
         tenantSchemaManager.provisionPlatformSchema()
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
-            "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
-                "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public') ON CONFLICT DO NOTHING",
+            "INSERT INTO public.teams (id, name, slug, schema_name) " +
+                "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public') ON CONFLICT DO NOTHING",
         )
         jdbcTemplate.execute(
             "INSERT INTO public.users (id, email, display_name) " +
@@ -120,8 +120,8 @@ class InvitationControllerTest : TeamBalanceIT() {
             tenantSchemaManager.provisionTenantSchema("public")
 
             jdbcTemplate.execute(
-                "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
-                    "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public') ON CONFLICT DO NOTHING",
+                "INSERT INTO public.teams (id, name, slug, schema_name) " +
+                    "VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public') ON CONFLICT DO NOTHING",
             )
             jdbcTemplate.execute(
                 "INSERT INTO public.users (id, email, display_name) " +

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationRotationBoundaryIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationRotationBoundaryIT.kt
@@ -104,8 +104,8 @@ class InvitationRotationBoundaryIT : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
@@ -35,8 +35,8 @@ class MemberControllerIT : TeamBalanceIT() {
         tenantSchemaManager.provisionPlatformSchema()
         tenantSchemaManager.provisionTenantSchema(TEAM_SCHEMA)
         jdbcTemplate.execute(
-            "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
-                "VALUES ('$TEAM_ID'::uuid, 'Member IT Team', 'member-it-team', 'Volleyball', '$TEAM_SCHEMA') " +
+            "INSERT INTO public.teams (id, name, slug, schema_name) " +
+                "VALUES ('$TEAM_ID'::uuid, 'Member IT Team', 'member-it-team', '$TEAM_SCHEMA') " +
                 "ON CONFLICT DO NOTHING",
         )
         // The Testcontainers DB is shared across all tests with no per-test rollback, so reset this

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/PositionControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/PositionControllerIT.kt
@@ -34,8 +34,8 @@ class PositionControllerIT : TeamBalanceIT() {
         tenantSchemaManager.provisionPlatformSchema()
         tenantSchemaManager.provisionTenantSchema(TEAM_SCHEMA)
         jdbcTemplate.execute(
-            "INSERT INTO public.teams (id, name, slug, sport, schema_name) " +
-                "VALUES ('$TEAM_ID'::uuid, 'Position IT Team', 'position-it-team', 'Volleyball', '$TEAM_SCHEMA') " +
+            "INSERT INTO public.teams (id, name, slug, schema_name) " +
+                "VALUES ('$TEAM_ID'::uuid, 'Position IT Team', 'position-it-team', '$TEAM_SCHEMA') " +
                 "ON CONFLICT DO NOTHING",
         )
         // Shared DB, no per-test rollback — reset this team's roster and positions to a known state.

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RecurringEventControllerTest.kt
@@ -210,8 +210,8 @@ class RecurringEventControllerTest : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """.trimIndent(),
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/SeasonControllerIT.kt
@@ -247,8 +247,8 @@ class SeasonControllerIT : TeamBalanceIT() {
         tenantSchemaManager.provisionTenantSchema("public")
         jdbcTemplate.execute(
             """
-            INSERT INTO public.teams (id, name, slug, sport, schema_name)
-            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'Volleyball', 'public')
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
             ON CONFLICT DO NOTHING
             """,
         )

--- a/docs/ops/provision-team.md
+++ b/docs/ops/provision-team.md
@@ -18,7 +18,7 @@
     Credentials are secrets (container env `SPRING_DATASOURCE_*` / Secret Manager). Never print them.
 - **Docker** (for Step 2 — the tenant migration runs via the Flyway CLI image; no local `flyway`/`psql` needed).
 - A local checkout of this repo (Step 2 mounts `api/src/main/resources/db/tenant-migration/`).
-- The team's: name, slug (URL-safe), sport.
+- The team's: name, slug (URL-safe).
 - The owner's email + display name. (Positions are optional up front — see Step 3.)
 
 ## Step 1 — Insert the Team + owner (one transaction)
@@ -35,8 +35,8 @@ intended key — misleading for a first insert).
 BEGIN;
 
 WITH t AS (
-    INSERT INTO public.teams (name, slug, sport, schema_name)
-    VALUES ('Setpoint VT', 'setpoint-vt', 'Volleyball', 'team_setpoint_vt')
+    INSERT INTO public.teams (name, slug, schema_name)
+    VALUES ('Setpoint VT', 'setpoint-vt', 'team_setpoint_vt')
     RETURNING id
 ),
 u AS (


### PR DESCRIPTION
Part of #154 (self-service team onboarding). **Slice 2 — create-team backend**, on top of the merged Slice 1 (#163) and rebased onto current `main` (incl. the #164 `EventId` refactor).

A logged-in, teamless user creates a team from a **name + one-time creation code** and becomes its founding admin.

## Contract (wirespec-first)

New `api/src/main/wirespec/teams.ws`:

```
CreateTeam POST CreateTeamRequest /api/teams -> { 201 -> Team, 400, 403, 409 }
```

`POST /api/teams { name, creationCode }` → `201 { id, name, slug }` (`schema_name` is deliberately not exposed). Errors are raised as typed domain exceptions and mapped by the existing `GlobalExceptionHandler`:

| Case | Status |
|------|--------|
| code invalid / expired / consumed | **403**, opaque (`INVALID_CREATION_CODE`) — no enumeration |
| caller already in a team | **409** (`ALREADY_IN_TEAM`) |
| name/slug collision | **409** (`TEAM_SLUG_TAKEN`) |
| blank / too-long / underivable name | **400** |

## Provision-first flow

Ordering guarantees a partial failure never strands a consumed code:

1. reject if the caller already belongs to a team (v1 one-team-per-user → #143)
2. derive + validate slug / tenant schema — `TeamNaming`, pure & framework-free, injection-safe whitelist `^team_[a-z0-9_]+$`, **63-byte cap: reject, never truncate** (a truncated `schema_name` would desync from the real schema and break `SET search_path` routing)
3. pre-check slug uniqueness + code redeemability (clean early 409 / opaque 403 **before** provisioning, so bad-code spam can't accrete orphan schemas)
4. provision the tenant schema (idempotent `TenantSchemaManager`, own connection/commit)
5. **atomically** consume the code + insert the team + insert the founding **ADMIN** member (`onboarded_at` set, skips `/welcome`; no position) — transaction boundary lives in `JdbcTeamRegistrationAdapter`

A provision failure leaves the code unconsumed (user retries). A lost race after provisioning leaves only a harmless empty orphan schema, self-healed by the Slice-1 startup runner.

## Migrations & `sport`

- `V006__team_creation_codes.sql` — `code` unique, `expires_at`/`consumed_at`/`consumed_by_user_id` nullable; consumed via a single conditional `UPDATE … WHERE consumed_at IS NULL AND (expires_at IS NULL OR expires_at > now())`.
- `V007__drop_teams_sport.sql` — self-service collects no sport. Stripped `sport` from every **post-migration** insert site (dev/e2e seeds, the two IT seeds, the runbook). The version-1.1 test seed **keeps** `sport` on purpose — it runs *before* the drop, exactly like it still seeds the legacy `team_role` that V003 later drops.

## Platform-admin identity & notifications

- `teambalance.platform-admins` allowlist (`PLATFORM_ADMIN_EMAILS`, empty default = **fail-closed**). `PlatformAdminGuard` reads the caller via `CurrentUserGateway`/`UserRepository`; built here, wired to the codes-admin surface in Slice 4, and used now as the audit-mail recipient set.
- Fire-and-forget notifications via the Scaleway TEM transport (prod) / logging (non-prod): founder “team ready” + platform-admin “code consumed” audit. A mail failure can **never** fail a committed creation.

## Hexagonal boundaries

Added a `TenantProvisioner` port (implemented by `TenantSchemaManager`) so the application layer never imports infrastructure — ArchUnit-enforced.

## Tests — lowest layer that proves each behaviour

- **Kotest units:** `TeamNamingTest` (derivation, sanitisation, 63-byte edge cases); `TeamServiceTest` (one-team reject, opaque-403 peek-before-provision, provision-first ordering, fire-and-forget); `PlatformAdminGuardTest` (allow/deny/fail-closed).
- **Testcontainers MockMvc IT** (`CreateTeamControllerIT`): provision-first + atomic consume + founding-ADMIN + post-create routing + endpoint error mapping (happy path, code reuse, unknown/expired code, already-in-team, blank name, 401).
- **No new e2e:** the create-team stack seam is exercised by Slice 3's plain-HTML flow.

Detekt: standard-rule issues fixed outright; new-code violations that match already-baselined codebase conventions (`@Service` on an application service, primitive-typed data classes, domain-meaningful port names à la `EmailSender`, intra-infra adapter deps) are added to `detekt-baseline.xml`.

## Verification note

`:api:compileTestKotlin` + `:api:detekt` are green, and the 25 Kotest unit tests pass. The Testcontainers ITs could not be executed in the authoring sandbox (Docker image-blob egress is policy-blocked and only JDK 21 is present); they compile and are left for CI (Docker + JDK 25) to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoK124gRStUyzcQrwni9At

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoK124gRStUyzcQrwni9At)_