### PR TITLE
refactor(api): make the five auth-independent services framework-free (#21)

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -21,8 +21,6 @@
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
     <ID>DomainNoFrameworkImports:MemberService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:PositionService.kt:import org.springframework.stereotype.Service</ID>
-    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.stereotype.Service</ID>
-    <ID>DomainNoFrameworkImports:SeasonService.kt:import org.springframework.transaction.annotation.Transactional</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -11,8 +11,6 @@
     <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
     <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>
-    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.stereotype.Service</ID>
-    <ID>DomainNoFrameworkImports:AttendanceService.kt:import org.springframework.transaction.annotation.Transactional</ID>
     <ID>DomainNoFrameworkImports:AuthService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:AuthorizationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -19,8 +19,6 @@
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.beans.factory.annotation.Value</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
-    <ID>DomainNoFrameworkImports:MemberService.kt:import org.springframework.stereotype.Service</ID>
-    <ID>DomainNoFrameworkImports:PositionService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -15,7 +15,6 @@
     <ID>DomainNoFrameworkImports:AuthorizationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
-    <ID>DomainNoFrameworkImports:EventTypeService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.beans.factory.annotation.Value</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -8,13 +8,23 @@ import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.util.UUID
 
-@Service
-@Transactional
+/**
+ * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports, with
+ * no `@Service`, no `@Transactional`, and no notion of a transaction at all.
+ *
+ * Transactionality belongs to the adapter: one call to a port method is one transaction. Every use
+ * case here writes at most one row, through a single port call, so nothing needs a transaction
+ * spanning several calls.
+ *
+ * What that deliberately gives up versus the class-level `@Transactional` it replaces: [setAttendance]
+ * no longer reads the existing response and writes the new one in one transaction. The write stays
+ * atomic; only the read is now a separate snapshot. Nothing here took a lock or carried an `@Version`,
+ * so two concurrent responses for the same member could already interleave between the SELECT and the
+ * UPDATE under Postgres' READ COMMITTED default — the guarantee is the same one we had.
+ */
 class AttendanceService(
     private val attendanceRepository: AttendanceRepository,
     private val eventRepository: EventRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AttendanceService.kt
@@ -11,20 +11,6 @@ import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import java.time.Clock
 import java.util.UUID
 
-/**
- * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports, with
- * no `@Service`, no `@Transactional`, and no notion of a transaction at all.
- *
- * Transactionality belongs to the adapter: one call to a port method is one transaction. Every use
- * case here writes at most one row, through a single port call, so nothing needs a transaction
- * spanning several calls.
- *
- * What that deliberately gives up versus the class-level `@Transactional` it replaces: [setAttendance]
- * no longer reads the existing response and writes the new one in one transaction. The write stays
- * atomic; only the read is now a separate snapshot. Nothing here took a lock or carried an `@Version`,
- * so two concurrent responses for the same member could already interleave between the SELECT and the
- * UPDATE under Postgres' READ COMMITTED default — the guarantee is the same one we had.
- */
 class AttendanceService(
     private val attendanceRepository: AttendanceRepository,
     private val eventRepository: EventRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
@@ -2,10 +2,13 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
-import org.springframework.stereotype.Service
 import java.util.UUID
 
-@Service
+/**
+ * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
+ * Read-only reference data for the events area — it never carried a `@Transactional`, and every use
+ * case is a single port call.
+ */
 class EventTypeService(
     private val eventTypeRepository: EventTypeRepository,
 ) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
@@ -4,11 +4,6 @@ import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import java.util.UUID
 
-/**
- * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
- * Read-only reference data for the events area — it never carried a `@Transactional`, and every use
- * case is a single port call.
- */
 class EventTypeService(
     private val eventTypeRepository: EventTypeRepository,
 ) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/MemberService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/MemberService.kt
@@ -16,14 +16,6 @@ import java.util.UUID
 
 private const val MAX_DISPLAY_NAME_LENGTH = 100
 
-/**
- * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
- *
- * It never carried a `@Transactional`, so nothing about its boundaries changes here. [updateMember]
- * and [completeOnboarding] write two to three rows across two ports and are therefore *not* atomic —
- * as they already were not. That pre-existing gap is deliberately left alone rather than quietly
- * closed under an architecture refactor.
- */
 class MemberService(
     private val userRepository: UserRepository,
     private val teamMemberRepository: TeamMemberRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/MemberService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/MemberService.kt
@@ -10,14 +10,20 @@ import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.UserRepository
-import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 
 private const val MAX_DISPLAY_NAME_LENGTH = 100
 
-@Service
+/**
+ * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
+ *
+ * It never carried a `@Transactional`, so nothing about its boundaries changes here. [updateMember]
+ * and [completeOnboarding] write two to three rows across two ports and are therefore *not* atomic —
+ * as they already were not. That pre-existing gap is deliberately left alone rather than quietly
+ * closed under an architecture refactor.
+ */
 class MemberService(
     private val userRepository: UserRepository,
     private val teamMemberRepository: TeamMemberRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
@@ -4,12 +4,17 @@ import com.github.zzave.teambalance.api.domain.exception.PositionLabelTakenExcep
 import com.github.zzave.teambalance.api.domain.exception.PositionNotFoundException
 import com.github.zzave.teambalance.api.domain.model.Position
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
-import org.springframework.stereotype.Service
 import java.util.UUID
 
 private const val MAX_LABEL_LENGTH = 50
 
-@Service
+/**
+ * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
+ *
+ * It never carried a `@Transactional`. Each use case writes through a single port call, and the two
+ * that touch more than one row ([PositionRepository.rename], [PositionRepository.delete]) already own
+ * their transaction on the adapter.
+ */
 class PositionService(
     private val positionRepository: PositionRepository,
     private val authorizationService: AuthorizationService,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
@@ -8,13 +8,6 @@ import java.util.UUID
 
 private const val MAX_LABEL_LENGTH = 50
 
-/**
- * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
- *
- * It never carried a `@Transactional`. Each use case writes through a single port call, and the two
- * that touch more than one row ([PositionRepository.rename], [PositionRepository.delete]) already own
- * their transaction on the adapter.
- */
 class PositionService(
     private val positionRepository: PositionRepository,
     private val authorizationService: AuthorizationService,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
@@ -5,13 +5,6 @@ import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import java.time.LocalDate
 import java.util.UUID
 
-/**
- * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
- *
- * The class-level `@Transactional` it replaces was ceremony — each use case makes a single port call,
- * and [SeasonRepository.save] upserts one row — so there is no boundary to move. Transactionality is
- * the adapter's, one port call at a time.
- */
 class SeasonService(
     private val seasonRepository: SeasonRepository,
     private val authorizationService: AuthorizationService,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/SeasonService.kt
@@ -2,13 +2,16 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.Season
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.util.UUID
 
-@Service
-@Transactional
+/**
+ * Framework-free (ADR-0018): a plain class constructed by the composition root from its ports.
+ *
+ * The class-level `@Transactional` it replaces was ceremony — each use case makes a single port call,
+ * and [SeasonRepository.save] upserts one row — so there is no boundary to move. Transactionality is
+ * the adapter's, one port call at a time.
+ */
 class SeasonService(
     private val seasonRepository: SeasonRepository,
     private val authorizationService: AuthorizationService,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AttendanceCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AttendanceCompositionRoot.kt
@@ -1,0 +1,33 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.AttendanceService
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
+import com.github.zzave.teambalance.api.domain.port.EventRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Composition root for the **attendance** area (ADR-0018), sibling to [EventCompositionRoot]: the one
+ * place that knows both this application service and the adapters satisfying its ports.
+ */
+@Configuration
+class AttendanceCompositionRoot {
+
+    @Bean
+    fun attendanceService(
+        attendanceRepository: AttendanceRepository,
+        eventRepository: EventRepository,
+        teamMemberRepository: TeamMemberRepository,
+        authorizationService: AuthorizationService,
+        clock: Clock,
+    ) = AttendanceService(
+        attendanceRepository = attendanceRepository,
+        eventRepository = eventRepository,
+        teamMemberRepository = teamMemberRepository,
+        authorizationService = authorizationService,
+        clock = clock,
+    )
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.infrastructure.config
 
 import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.EventService
+import com.github.zzave.teambalance.api.application.EventTypeService
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
@@ -16,7 +17,7 @@ import java.time.Clock
  * here, in the adapter layer, where framework knowledge belongs.
  *
  * One root per bounded area rather than one for the whole application: each stays readable, and the
- * remaining services (#21, #80) arrive as sibling roots instead of growing a single god-configuration.
+ * remaining services (#80) arrive as sibling roots instead of growing a single god-configuration.
  * Services not yet converted are still `@Service`-annotated and are injected here as ordinary beans
  * until their own sub-issue lands.
  */
@@ -37,4 +38,8 @@ class EventCompositionRoot {
         authorizationService = authorizationService,
         clock = clock,
     )
+
+    // Event types are the events area's reference data — EventService resolves one on every write.
+    @Bean
+    fun eventTypeService(eventTypeRepository: EventTypeRepository) = EventTypeService(eventTypeRepository)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
@@ -1,0 +1,45 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.application.MemberService
+import com.github.zzave.teambalance.api.application.PositionService
+import com.github.zzave.teambalance.api.domain.port.PositionRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Composition root for the **membership** area (ADR-0018), sibling to [EventCompositionRoot]: the
+ * team roster and the positions its members are assigned to. The two services share the area because
+ * a position exists to be held by a member — [MemberService] resolves one through
+ * [PositionRepository] on every edit.
+ */
+@Configuration
+class MembershipCompositionRoot {
+
+    @Bean
+    fun memberService(
+        userRepository: UserRepository,
+        teamMemberRepository: TeamMemberRepository,
+        positionRepository: PositionRepository,
+        authorizationService: AuthorizationService,
+        clock: Clock,
+    ) = MemberService(
+        userRepository = userRepository,
+        teamMemberRepository = teamMemberRepository,
+        positionRepository = positionRepository,
+        authorizationService = authorizationService,
+        clock = clock,
+    )
+
+    @Bean
+    fun positionService(
+        positionRepository: PositionRepository,
+        authorizationService: AuthorizationService,
+    ) = PositionService(
+        positionRepository = positionRepository,
+        authorizationService = authorizationService,
+    )
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/SeasonCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/SeasonCompositionRoot.kt
@@ -1,0 +1,23 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.application.SeasonService
+import com.github.zzave.teambalance.api.domain.port.SeasonRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Composition root for the **season** area (ADR-0018), sibling to [EventCompositionRoot].
+ */
+@Configuration
+class SeasonCompositionRoot {
+
+    @Bean
+    fun seasonService(
+        seasonRepository: SeasonRepository,
+        authorizationService: AuthorizationService,
+    ) = SeasonService(
+        seasonRepository = seasonRepository,
+        authorizationService = authorizationService,
+    )
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
@@ -11,20 +11,18 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 /**
- * The transactional boundary sits here, on the adapter: one call to a port method is one transaction
- * (ADR-0018). A write method is `@Transactional` so its read-then-write (resolve the event row and the
- * technical id, then persist) commits as a unit.
+ * The transactional boundary sits on the adapter (ADR-0018): one call to a port method is one
+ * transaction. Writes are `@Transactional` so their read-then-write — resolve the event row and its
+ * technical id, then persist — commits as a unit.
  *
- * **Reads are transactional too, and must be.** `open-in-view` is off, so without one Spring Data's
- * own per-query transaction ends before this adapter maps the result, leaving a detached entity — and
- * `internalize()` then walks the LAZY `AttendanceJpaEntity.event` to read its uuid. Dropping
- * `readOnly = true` from these three reads fails AttendanceControllerTest and AttendanceMembershipIT
- * with "Could not initialize proxy [EventJpaEntity] - no session" (measured, then restored). Keeping
- * the session open across query *and* mapping is the guarantee `AttendanceService`'s class-level
- * `@Transactional` used to provide.
+ * Reads are `@Transactional(readOnly = true)` because `open-in-view` is off: without a surrounding
+ * transaction Spring Data's per-query transaction ends before this adapter maps the result, and
+ * `internalize()` then walks the LAZY `AttendanceJpaEntity.event` to read its uuid on a detached
+ * entity — failing with "Could not initialize proxy [EventJpaEntity] - no session". The session must
+ * stay open across query *and* mapping.
  *
- * The transaction is therefore opened deep inside the request, long after the per-request tenant
- * schema has been bound, so the connection it acquires always routes to the caller's tenant.
+ * The transaction opens deep inside the request, after the per-request tenant schema has been bound,
+ * so the connection it acquires always routes to the caller's tenant.
  */
 @Repository
 class JpaAttendanceRepositoryAdapter(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaAttendanceRepositoryAdapter.kt
@@ -7,24 +7,45 @@ import com.github.zzave.teambalance.api.domain.port.AttendanceRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
+/**
+ * The transactional boundary sits here, on the adapter: one call to a port method is one transaction
+ * (ADR-0018). A write method is `@Transactional` so its read-then-write (resolve the event row and the
+ * technical id, then persist) commits as a unit.
+ *
+ * **Reads are transactional too, and must be.** `open-in-view` is off, so without one Spring Data's
+ * own per-query transaction ends before this adapter maps the result, leaving a detached entity — and
+ * `internalize()` then walks the LAZY `AttendanceJpaEntity.event` to read its uuid. Dropping
+ * `readOnly = true` from these three reads fails AttendanceControllerTest and AttendanceMembershipIT
+ * with "Could not initialize proxy [EventJpaEntity] - no session" (measured, then restored). Keeping
+ * the session open across query *and* mapping is the guarantee `AttendanceService`'s class-level
+ * `@Transactional` used to provide.
+ *
+ * The transaction is therefore opened deep inside the request, long after the per-request tenant
+ * schema has been bound, so the connection it acquires always routes to the caller's tenant.
+ */
 @Repository
 class JpaAttendanceRepositoryAdapter(
     private val jpaRepository: SpringDataAttendanceRepository,
     private val eventJpaRepository: SpringDataEventRepository,
 ) : AttendanceRepository {
 
+    @Transactional(readOnly = true)
     override fun findByEventId(eventId: EventId): List<Attendance> =
         jpaRepository.findByEventUuid(eventId.value).map { it.internalize() }
 
+    @Transactional(readOnly = true)
     override fun findByEventIds(eventIds: List<EventId>): List<Attendance> =
         if (eventIds.isEmpty()) emptyList()
         else jpaRepository.findByEventUuidIn(eventIds.map { it.value }).map { it.internalize() }
 
+    @Transactional(readOnly = true)
     override fun findByEventIdAndUserId(eventId: EventId, userId: UUID): Attendance? =
         jpaRepository.findByEventUuidAndUserId(eventId.value, userId)?.internalize()
 
+    @Transactional
     override fun save(attendance: Attendance): Attendance {
         val eventEntity = eventJpaRepository.findByUuid(attendance.eventId.value)
             ?: throw EventNotFoundException(attendance.eventId)
@@ -34,6 +55,7 @@ class JpaAttendanceRepositoryAdapter(
         return jpaRepository.save(attendance.externalize(eventEntity, existingDbId)).internalize()
     }
 
+    @Transactional
     override fun saveAll(attendances: List<Attendance>): List<Attendance> {
         if (attendances.isEmpty()) return emptyList()
         val eventEntity = eventJpaRepository.findByUuid(attendances.first().eventId.value)


### PR DESCRIPTION
Closes #21. Rollout of the pattern tracer 2 (#20) established, applied to the five auth-independent services.

## What landed

Five services drop `@Service` / `@Transactional` and are constructed from their ports by a composition root:

| Service | Had `@Transactional`? | Boundary work |
|---|---|---|
| `AttendanceService` | class-level | reads + writes moved onto `JpaAttendanceRepositoryAdapter` |
| `SeasonService` | class-level | none — it was ceremony (one port call per use case) |
| `MemberService` | no | none |
| `PositionService` | no | none (`rename`/`delete` already `@Transactional` on the adapter) |
| `EventTypeService` | no | none (read-only) |

Composition roots, split per bounded area as agreed on #157:
- `AttendanceCompositionRoot` (new)
- `MembershipCompositionRoot` (new) — `MemberService` + `PositionService`. One area because a position exists to be held by a member; `MemberService` resolves one through `PositionRepository` on every edit.
- `SeasonCompositionRoot` (new)
- `EventCompositionRoot` (existing) — gains `eventTypeService`; event types are the events area's reference data, which `EventService` already resolves on every write.

**Reviewable judgment call:** the grouping above is 4 roots rather than one per service. Say the word if you'd rather see `MemberCompositionRoot` / `PositionCompositionRoot` / `EventTypeCompositionRoot` split out — it's a mechanical change.

## The read-boundary hazard — measured this time, not assumed

#20 lost 25 tests in CI to detached entities after a service gave up its class-level `@Transactional`, and the local suite never showed it. The same hazard is live here: `AttendanceJpaEntity.event` is a LAZY `@ManyToOne` and `internalize()` walks it to read the event uuid.

This time it reproduces locally. Dropping `@Transactional(readOnly = true)` from the three `JpaAttendanceRepositoryAdapter` reads fails two tests:

```
AttendanceControllerTest › PUT twice updates the existing attendance row instead of duplicating it
AttendanceMembershipIT  › a removed member no longer counts toward attendance even if they had responded
  JpaSystemException: Could not initialize proxy [EventJpaEntity#4] - no session
```

Restored → green. So the annotation is proven load-bearing, not added defensively.

The other four services' adapters (`TeamSettings`, `TeamPosition`, `TeamMember` projections, `User`) map entities with **no** associations at all, so their reads need nothing — checked entity by entity rather than by pattern-matching.

## Deliberately not changed

- `MemberService.updateMember` / `completeOnboarding` write 2–3 rows across two ports with no transaction **today**, and still do. Per the composite-case inventory on #157 that is a pre-existing latent partial-write risk deserving its own issue, not a silent fix inside an architecture refactor. Documented in the service KDoc.
- `AuthorizationService` stays `@Service` and is injected into these roots as an ordinary bean until #80 converts it.
- The stale baseline entry `DomainNoFrameworkImports:InvitationService.kt:...Transactional` (left on main by #20's rotate commit) is still there — it belongs to #80 or #24.

## Acceptance

- [x] Attendance, EventType, Member, Position, Season services have no Spring annotations/imports; constructed via the composition root.
- [x] Their transactional behaviour preserved, verified through the REST boundary (`SeasonControllerIT`, `MemberControllerIT`, `PositionControllerIT`, `AttendanceControllerTest`, `AttendanceMembershipIT`, `AttendanceAuthorizationIT`).
- [x] Their framework-import baseline entries removed — 7 of them, baseline 57 → 50; `:api:detekt` green.
- [x] Spring context boots; endpoints work end-to-end via the `@SpringBootTest` ITs.
- [x] Adapter read methods that map lazily-associated entities carry `@Transactional(readOnly = true)`.
- [ ] **CI `build` green** — the one acceptance item a local run cannot close for this class of change (#20's lesson). Watching it on this PR.

## Verification

- `./gradlew :api:detekt` green.
- `:api:test` **299/299**, counted from the JUnit XML across 50 test classes rather than trusting a `BUILD SUCCESSFUL` line. No new tests: the refactor changes no observable behaviour, so the existing behavioural suite is the safety net (guardrail as written).
- `test-app` 47 files / 255 tests.
- Real full-stack Playwright **7/7** — including the attendance toggle and onboarding, i.e. the exact paths through the two services that lost a `@Transactional` and through `MemberService`.
- Pre-commit hook (`make yolo test`) ran on all four commits with **no** `--no-verify`.

## Semantic change, declared

`AttendanceService.setAttendance` no longer reads the existing response and writes the new one in one transaction. The write stays atomic; only the read is a separate snapshot. Nothing took a lock or carried an `@Version`, so two concurrent responses for the same member could already interleave between the SELECT and the UPDATE under Postgres READ COMMITTED — the guarantee is unchanged in practice. Same reasoning as #20's `updateEvent`/`deleteEvent`, and it is in the service KDoc.