### PR TITLE
fix(build): make installGitHooks worktree-safe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,17 +17,33 @@ allprojects {
     }
 }
 
-// Installs the committed git hooks (.githooks) into .git/hooks so the
-// pre-commit gate (`make format test e2e`) is enforced for every contributor.
-val installGitHooks by tasks.registering(Copy::class) {
-    description = "Installs git hooks from .githooks into .git/hooks"
-    group = "git hooks"
-    from(layout.projectDirectory.dir(".githooks"))
-    into(layout.projectDirectory.dir(".git/hooks"))
-    filePermissions { unix("0755") }
-}
+// Installs the committed git hooks (.githooks) into the repository's hooks dir
+// so the pre-commit gate (`make yolo test`) is enforced for every contributor.
+// The destination is resolved via `git rev-parse --git-path hooks` rather than
+// hardcoded to `.git/hooks`: in a linked worktree `.git` is a file pointing at
+// the shared common dir, so hooks live elsewhere. git's own answer is correct
+// for both a normal checkout and a worktree. Uses the config-cache-safe
+// providers.exec API; a missing git binary or non-repo build yields blank
+// output and the task skips instead of failing.
+val resolvedHooksDir: String = providers.exec {
+    isIgnoreExitValue = true
+    workingDir = layout.projectDirectory.asFile
+    commandLine("git", "rev-parse", "--git-path", "hooks")
+}.standardOutput.asText.get().trim()
 
-// Auto-install whenever anything is built, mirroring husky's `prepare` step.
-subprojects {
-    tasks.matching { it.name == "build" }.configureEach { dependsOn(installGitHooks) }
+// Blank output means no git binary or not a git repo (e.g. a source archive
+// build): skip wiring the task entirely rather than fabricating a `.git` dir.
+if (resolvedHooksDir.isNotBlank()) {
+    val installGitHooks by tasks.registering(Copy::class) {
+        description = "Installs git hooks from .githooks into the git-resolved hooks dir"
+        group = "git hooks"
+        from(layout.projectDirectory.dir(".githooks"))
+        into(resolvedHooksDir)
+        filePermissions { unix("0755") }
+    }
+
+    // Auto-install whenever anything is built, mirroring husky's `prepare` step.
+    subprojects {
+        tasks.matching { it.name == "build" }.configureEach { dependsOn(installGitHooks) }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,13 +18,9 @@ allprojects {
 }
 
 // Installs the committed git hooks (.githooks) into the repository's hooks dir
-// so the pre-commit gate (`make yolo test`) is enforced for every contributor.
-// The destination is resolved via `git rev-parse --git-path hooks` rather than
-// hardcoded to `.git/hooks`: in a linked worktree `.git` is a file pointing at
-// the shared common dir, so hooks live elsewhere. git's own answer is correct
-// for both a normal checkout and a worktree. Uses the config-cache-safe
-// providers.exec API; a missing git binary or non-repo build yields blank
-// output and the task skips instead of failing.
+// so the pre-commit gate is enforced for every contributor. The destination is 
+// resolved via `git rev-parse --git-path hooks` rather than
+// hardcoded to `.git/hooks` to support worktrees
 val resolvedHooksDir: String = providers.exec {
     isIgnoreExitValue = true
     workingDir = layout.projectDirectory.asFile


### PR DESCRIPTION
## Problem

The `:installGitHooks` Copy task hardcoded its destination to `<projectDir>/.git/hooks`. In a **linked git worktree** `.git` is a *file* (a `gitdir:` pointer), not a directory, so Gradle's `destinationDir` validation failed at **configuration time**:

```
Expected '.../.git' to be a directory but it's a file
```

Since `build` `dependsOn(installGitHooks)`, this broke **every default build** (`make yolo`, `./gradlew build`) run from a worktree — and therefore the pre-commit gate (`.githooks/pre-commit` → `make yolo test`) for anyone working in a worktree.

## Fix

Resolve the real hooks directory via `git rev-parse --git-path hooks`, which returns the correct path in both layouts (normal checkout → `.git/hooks`; worktree → the shared common-dir hooks). Details:

- Uses the **config-cache-safe** `providers.exec { ... }.standardOutput.asText` API (resolved eagerly to a `String` at configuration time — no lazy provider held on the task, which would capture a non-serializable script reference).
- `isIgnoreExitValue = true`; blank output (no git binary / not a repo, e.g. a source-archive build) → the task and its `dependsOn` wiring are skipped entirely rather than fabricating a `.git` dir.
- Normal checkouts install to `.git/hooks` unchanged.

## Verification (all real command output)

1. **Worktree** — `:installGitHooks` and `./gradlew build -x test -x detekt` both `BUILD SUCCESSFUL`; hook installed to the git-resolved shared hooks dir; config cache **stored and reused**.
2. **Pre-commit gate from a worktree** — committing this change itself fired `.githooks/pre-commit` → `make yolo test` (no `--no-verify`) from inside a worktree: build past the Copy task, `make test-api` (Testcontainers) green, `make test-app` 255/255 green, commit landed.
3. **Normal checkout** — a fresh clone (`.git` is a directory) installs to `.git/hooks`, content identical to `.githooks/pre-commit`, executable, `BUILD SUCCESSFUL`.

No new e2e: this is a build-config fix with no runtime/API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)