### PR TITLE
refactor(app): UUID-stable, token-backed avatar colors (F10, #159)

### DIFF
--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -12,6 +12,7 @@ import { RoleBreakdown } from '@entities/event/ui/RoleBreakdown'
 import { SeriesPeek } from '@entities/event/ui/SeriesPeek'
 import { buildAttendeePanel } from '@entities/event/lib/attendee-panel'
 import { buildSeriesPeek } from '@entities/event/lib/series-peek'
+import { avatarColor, avatarInitials } from '@shared/lib/avatar'
 import { AttendanceToggle, type AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { EditEventDialog } from '@features/edit-event/ui/EditEventDialog'
 import { DeleteEventDialog } from '@features/edit-event/ui/DeleteEventDialog'
@@ -32,42 +33,14 @@ const ATTENDEE_TABS: {
   { state: 'NOT_RESPONDED', label: '?', barColor: 'bg-muted-foreground', badgeBg: 'bg-muted text-muted-foreground' },
 ]
 
-function getInitials(name: string): string {
-  return name
-    .split(' ')
-    .map((w) => w[0])
-    .slice(0, 2)
-    .join('')
-    .toUpperCase()
-}
-
-// Stable color derived from name — cycles through a palette
-const AVATAR_COLORS = [
-  '#225C9C', // blue
-  '#249E6C', // green
-  '#F4B400', // gold
-  '#E05252', // red
-  '#7B5EA7', // purple
-  '#E87C3E', // orange
-]
-
-function getAvatarColor(name: string): string {
-  let hash = 0
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) >>> 0
-  }
-  return AVATAR_COLORS[hash % AVATAR_COLORS.length]
-}
-
 function AttendeeRow({ attendance }: { attendance: AttendanceEntry }) {
-  const color = getAvatarColor(attendance.displayName)
   return (
     <div className="flex items-center gap-3 py-2 px-3">
       <div
         className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
-        style={{ backgroundColor: color }}
+        style={{ backgroundColor: avatarColor(attendance.userId) }}
       >
-        {getInitials(attendance.displayName)}
+        {avatarInitials(attendance.displayName)}
       </div>
       <div className="min-w-0">
         <span className="block text-sm leading-tight">{attendance.displayName}</span>

--- a/app/src/shared/lib/avatar.test.ts
+++ b/app/src/shared/lib/avatar.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { avatarColor, avatarInitials } from './avatar'
+
+// Pure, non-rendering logic: a UUID-keyed avatar colour and initials. The colour must be stable
+// per person across every listing and survive display-name changes, so it hashes the UUID — not
+// the name — into a fixed 6-entry palette of CSS-var tokens.
+const PALETTE = [
+  'var(--color-blue)',
+  'var(--color-green)',
+  'var(--color-gold)',
+  'var(--color-red)',
+  'var(--color-purple)',
+  'var(--color-orange)',
+]
+
+describe('avatarColor', () => {
+  it('returns the same colour for the same UUID across repeated calls', () => {
+    const uuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+    expect(avatarColor(uuid)).toBe(avatarColor(uuid))
+  })
+
+  it('always returns one of the six palette tokens', () => {
+    const uuids = [
+      'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      '00000000-0000-0000-0000-000000000000',
+      'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      '123e4567-e89b-12d3-a456-426614174000',
+    ]
+    for (const uuid of uuids) {
+      expect(PALETTE).toContain(avatarColor(uuid))
+    }
+  })
+
+  it('handles distinct sample UUIDs without throwing', () => {
+    expect(() => avatarColor('6ba7b810-9dad-11d1-80b4-00c04fd430c8')).not.toThrow()
+    expect(() => avatarColor('123e4567-e89b-12d3-a456-426614174000')).not.toThrow()
+  })
+})
+
+describe('avatarInitials', () => {
+  it('takes the first character of the first two words, uppercased', () => {
+    expect(avatarInitials('jane doe')).toBe('JD')
+  })
+
+  it('handles a single word', () => {
+    expect(avatarInitials('madonna')).toBe('M')
+  })
+})

--- a/app/src/shared/lib/avatar.ts
+++ b/app/src/shared/lib/avatar.ts
@@ -1,0 +1,28 @@
+// Deterministic, UUID-keyed avatar colour so a person keeps the same colour across every listing
+// and through display-name changes. The palette are CSS-var tokens (resolved globally via
+// design-tokens/tokens.css), so no avatar hex lives in component code.
+const AVATAR_PALETTE = [
+  'var(--color-blue)',
+  'var(--color-green)',
+  'var(--color-gold)',
+  'var(--color-red)',
+  'var(--color-purple)',
+  'var(--color-orange)',
+]
+
+export function avatarColor(userId: string): string {
+  let hash = 0
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0
+  }
+  return AVATAR_PALETTE[hash % AVATAR_PALETTE.length]
+}
+
+export function avatarInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+}

--- a/design-tokens/tokens.css
+++ b/design-tokens/tokens.css
@@ -12,6 +12,12 @@
   --color-red: #D93025;
   --color-red-light: #EF5350;
   --color-red-dark: #B71C1C;
+  --color-purple: #7B5EA7;
+  --color-purple-light: #9478BF;
+  --color-purple-dark: #5F4682;
+  --color-orange: #E87C3E;
+  --color-orange-light: #F0965F;
+  --color-orange-dark: #C25F26;
 
   /* Surfaces */
   --color-background: #F8F6F0;


### PR DESCRIPTION
## What & why

Finding **F10** from the mobile-first/PWA UI audit (#159). Promotes the ad-hoc avatar-color logic in `routes/events/$eventId.tsx` to a shared, token-backed, **UUID-stable** helper. A person now gets the exact same avatar color everywhere and forever — keyed on their UUID, so it's rename-proof and stable across every event listing, with zero storage.

## Changes

- **`design-tokens/tokens.css`** — add two brand tokens mirroring the existing 3-stop scale:
  - `--color-purple: #7B5EA7` (+ `-light` `#9478BF` / `-dark` `#5F4682`)
  - `--color-orange: #E87C3E` (+ `-light` `#F0965F` / `-dark` `#C25F26`)
- **`app/src/shared/lib/avatar.ts`** (new) — `avatarColor(userId)` deterministically hashes the **UUID** (reusing the exact existing hash: `hash*31 + charCodeAt`, `>>> 0`, `% palette.length`) into a 6-entry palette of `var(--color-*)` strings: blue, green, gold, red, purple, orange. `avatarInitials(name)` keeps the existing initials logic.
- **`app/src/routes/events/$eventId.tsx`** — `AttendeeRow` now derives **color from `attendance.userId`** and **initials from `displayName`**, importing from the shared lib. Deleted the orphaned local `AVATAR_COLORS`, `getAvatarColor`, `getInitials`.
- **`app/src/shared/lib/avatar.test.ts`** (new) — Vitest unit (TDD, written first, watched fail): same UUID → same color; return value always one of the 6 palette tokens; distinct sample UUIDs don't throw; initials logic.

### Design notes
- **Why UUID:** color must survive display-name changes and stay stable per person across listings. A deterministic hash of the UUID delivers that with no lookup table and no backend storage (explicitly out of scope). With 6 colors some users share a color by pigeonhole — accepted; initials disambiguate.
- **Expected visual shift:** avatar colors now flow through `var(--color-*)` tokens (and key off UUID, not name), so some avatars change color. No relevant Storybook story renders `AttendeeRow`, so there's no story to re-baseline.

## Testing
Per the repo's testing doc, this is pure non-rendering logic → the correct layer is a Vitest unit. No new e2e: the change introduces no new seam (no new auth path, cross-tenant write, or external integration).

- `make test-app` → **48 files, 260 tests passed**
- `make lint` (ESLint + detekt) → **clean, exit 0**
- `grep -rn "AVATAR_COLORS\|getAvatarColor" app/src` → no matches; no hardcoded avatar hex remains in component code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)