### PR TITLE
fix(app): enlarge three touch targets to ≥44px (F7, #159)

### DIFF
--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -110,7 +110,7 @@ function EventDetailPage() {
       {/* Sticky sub-header with back navigation — sits below the app header */}
       <div className="sticky top-[57px] z-30 -mx-4 mb-2 flex items-center gap-2 border-b border-border/60 bg-background/95 px-4 py-2 backdrop-blur-sm">
         <Link to="/" aria-label="Back to events">
-          <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+          <Button variant="ghost" size="icon" className="h-11 w-11 shrink-0">
             <ArrowLeft size={18} />
           </Button>
         </Link>

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -78,7 +78,8 @@ function EventListPage() {
                             setTab(t)
                         }}
                         className={[
-                            'rounded-full px-4 py-1 text-sm font-medium capitalize transition-all',
+                            'relative rounded-full px-4 py-1 text-sm font-medium capitalize transition-all',
+                            "before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']",
                             tab === t
                                 ? 'bg-card text-foreground shadow-sm'
                                 : 'text-muted-foreground hover:text-foreground',
@@ -92,7 +93,7 @@ function EventListPage() {
             {/* T3.3: Event type filter pills */}
             {eventTypes && eventTypes.length > 0 && (
                 <div
-                    className="-mx-4 mt-3 flex gap-2 overflow-x-auto px-4 pb-0.5 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+                    className="-mx-4 mt-3 flex min-h-[44px] items-center gap-2 overflow-x-auto px-4 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
                     {eventTypes.map((type) => {
                         const isActive = activeTypeIds.has(type.id)
                         const color = type.color ?? '#888'
@@ -109,7 +110,8 @@ function EventListPage() {
                                     color: '#fff'
                                 } : {borderColor: color + '66', color}}
                                 className={[
-                                    'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-all',
+                                    'relative shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-all',
+                                    "before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']",
                                     isActive ? '' : 'hover:opacity-80',
                                 ].join(' ')}
                             >


### PR DESCRIPTION
## What

Fixes **finding F7** of the #159 mobile-first/PWA UI audit: three interactive controls sat below the **44px native minimum touch target**. Scope was deliberately tightened to the three content-level controls that survive the planned nav redesign.

| # | Control | Before | Approach |
|---|---------|--------|----------|
| 1 | Back button — `routes/events/$eventId.tsx` sub-header | `h-8 w-8` = **32px** | Grow the box directly to 44×44 (it has surrounding space) |
| 2 | Upcoming/Past segmented toggle — `routes/index.tsx` | `px-4 py-1 text-sm` ≈ **28px** tall | Keep the compact pill; grow only the tap area |
| 3 | Event-type filter pills — `routes/index.tsx` (h-scroll row) | `px-3 py-1 text-xs` ≈ **26px** tall | Keep the compact pill; grow only the tap area |

## How — grow the *hit area*, preserve the compact visual

For the segmented toggle (#2) and the filter pills (#3), fattening the pills would break the intentionally dense filter row. Instead the visible pill is untouched and a **transparent 44px-tall `::before` overlay** provides the tap target:

```
before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']
```

`h-11` = 44px, vertically centered on the pill (`top-1/2` + `-translate-y-1/2`), spanning the pill width (`inset-x-0`). The pseudo-element receives pointer events and targets its host button, so the whole 44px band is tappable while the pill still *looks* identical.

**Filter-row clipping fix:** `overflow-x-auto` forces `overflow-y` to compute to `auto` (CSS overflow spec), which would **clip** the pseudo-element's vertical overflow and shrink the effective target back to ~26px. So the row container gets `min-h-[44px] items-center` — tall enough to contain the 44px hit area without clipping, `items-center` so pills don't stretch (which would fatten them). The hidden-scrollbar horizontal scroll (`overflow-x-auto` + `[scrollbar-width:none]` etc.) is preserved.

Back button (#1) simply becomes `h-11 w-11`; the `ArrowLeft` icon stays `size={18}`.

## 44px math (verified against the built CSS)

Tailwind v4 `--spacing: 0.25rem` (4px), confirmed in the compiled bundle:

- **Back button:** `.h-11 { height: calc(var(--spacing) * 11) }` = 4px × 11 = **44px**; same for `.w-11` → **44×44px**.
- **Toggle & pills:** `.before\:h-11:before { height: calc(var(--spacing) * 11) }` = **44px** tall, centered on the pill → effective vertical tap area **≥44px** across the pill width (`inset-x-0`; every event-type label ≥ 44px wide via `px-3`).
- **Filter row container:** compiled to `min-height: 44px` — contains the 44px overlay with no clip.

## Scope — explicitly excluded (per the tightened finding)

- **Header nav links** (Members / Settings / Profile / Log out) — being removed by F1 (nav redesign); enlarging now is throwaway.
- **`AttendanceToggle`** — already `py-3.5` (≥44px), compliant.

## Verification

Both run from repo root, both green:

**`make test-app`**
```
Test Files  47 passed (47)
     Tests  255 passed (255)
```

**`make lint`** (detekt + eslint)
```
> Task :api:detekt
BUILD SUCCESSFUL
> @teambalance/app@0.1.0 lint
> eslint .
(no errors)
```

Production build (`npm run build`) succeeds; the generated CSS was inspected to confirm every `before:*` / `h-11` / `min-h-[44px]` class compiles to the intended rules (44px). Change is CSS-only — no `EventListView` / index / `$eventId` story logic touched; Chromatic may re-baseline minor filter-row spacing (row grew from ~28px to a 44px band), which is expected and acceptable.

No new e2e: this introduces no new auth path, cross-tenant write, or external integration — it's a styling change to existing controls, so per the PR gate no new flow is justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
