### PR TITLE
feat(#158): polished create-team screen — editable validated-slug + teamless gate

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -43,6 +43,8 @@
     <ID>DomainNoPrimitiveObsession:TeamNaming.kt:TeamNames$val slug: String</ID>
     <ID>DomainNoPrimitiveObsession:TeamService.kt:CreatedTeam$val name: String</ID>
     <ID>DomainNoPrimitiveObsession:TeamService.kt:CreatedTeam$val slug: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamSummary.kt:TeamSummary$val name: String</ID>
+    <ID>DomainNoPrimitiveObsession:TeamSummary.kt:TeamSummary$val slug: String</ID>
     <ID>DomainNoPrimitiveObsession:User.kt:User$val displayName: String</ID>
     <ID>PortNamingConvention:EmailSender.kt:EmailSender</ID>
     <ID>PortNamingConvention:TeamNotifier.kt:TeamNotifier</ID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -2,11 +2,13 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.Email
 import com.github.zzave.teambalance.api.domain.model.MagicLinkToken
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.EmailSender
 import com.github.zzave.teambalance.api.domain.port.MagicLinkTokenRepository
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import org.springframework.stereotype.Service
 import java.security.MessageDigest
@@ -21,6 +23,7 @@ import java.util.UUID
 class AuthService(
     private val magicLinkTokenRepository: MagicLinkTokenRepository,
     private val userRepository: UserRepository,
+    private val teamRepository: TeamRepository,
     private val emailSender: EmailSender,
     private val clock: Clock,
 ) {
@@ -47,6 +50,9 @@ class AuthService(
     }
 
     fun findUserById(id: UserId): User? = userRepository.findById(id)
+
+    /** The team the user belongs to, or null if teamless — the has-a-team gate signal on `/auth/me`. */
+    fun findTeamFor(userId: UserId): TeamSummary? = teamRepository.findByUserId(userId.value)
 
     fun verifyMagicLink(token: String): User? {
         val now = clock.instant()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -27,7 +27,7 @@ data class CreatedTeam(val id: UUID, val name: String, val slug: String)
  *
  * Ordering is deliberately provision-first so a partial failure never strands a consumed code:
  *  1. reject if the caller already belongs to a team (v1 one-team-per-user, #143);
- *  2. derive + validate the slug / tenant schema name (bad name → 400);
+ *  2. validate the name + user-supplied slug and derive the tenant schema name (bad name/slug → 400);
  *  3. pre-check slug uniqueness and code redeemability (fast, clean 409 / opaque 403 before any writes);
  *  4. provision the tenant schema (idempotent, on its own connection — commits independently);
  *  5. atomically consume the code and insert the team + founding admin ([TeamRegistrar]).
@@ -49,9 +49,9 @@ class TeamService(
 ) {
     private val log = LoggerFactory.getLogger(TeamService::class.java)
 
-    fun createTeam(founderId: UserId, rawName: String, creationCode: String): CreatedTeam {
+    fun createTeam(founderId: UserId, rawName: String, rawSlug: String, creationCode: String): CreatedTeam {
         requireTeamless(founderId)
-        val names = TeamNaming.derive(rawName)
+        val names = TeamNaming.validate(rawName, rawSlug)
         requireSlugAvailable(names.slug)
 
         val now = clock.instant()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -9,11 +9,19 @@ import java.util.UUID
 
 sealed class TeambalanceException(message: String) : RuntimeException(message)
 
-// Well-formed request that cannot yield a valid team name/slug/schema → 400 (base TeambalanceException
-// handler). Blank, too long, or with no slug-usable characters, or one whose derived tenant schema
-// exceeds Postgres' 63-byte identifier limit (rejected, never truncated — truncation would desync
-// schema_name from the real schema and break search_path routing).
-class InvalidTeamNameException(message: String) : TeambalanceException(message)
+// `code` is the stable machine-readable discriminator for 400 rejections the frontend must place
+// against a specific field (slug vs name). Mirrors the code convention of ForbiddenException/
+// ConflictException; the generic 400 handlers (plain TeambalanceException / IllegalArgumentException)
+// stay codeless.
+sealed class BadRequestException(message: String, val code: String) : TeambalanceException(message)
+
+// Blank or too-long team name → 400 INVALID_NAME (placed on the name field).
+class InvalidTeamNameException(message: String) : BadRequestException(message, "INVALID_NAME")
+
+// A user-supplied slug that fails the format (`^[a-z0-9]+(-[a-z0-9]+)*$`) or the ≤58-char length cap
+// (which keeps `team_` + slug within Postgres' 63-byte identifier limit) → 400 INVALID_SLUG. The slug
+// is validated, not derived (#158): the caller owns the address, so a bad one is their error to fix.
+class InvalidSlugException(message: String) : BadRequestException(message, "INVALID_SLUG")
 
 sealed class NotFoundException(message: String) : TeambalanceException(message)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNaming.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNaming.kt
@@ -1,8 +1,9 @@
 package com.github.zzave.teambalance.api.domain.model
 
+import com.github.zzave.teambalance.api.domain.exception.InvalidSlugException
 import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
 
-/** A validated team name with its derived URL slug and tenant schema identifier. */
+/** A validated team name with its user-chosen URL slug and the derived tenant schema identifier. */
 data class TeamNames(
     val name: String,
     val slug: String,
@@ -10,26 +11,33 @@ data class TeamNames(
 )
 
 /**
- * Pure, framework-free derivation of a team's slug and tenant schema name from a raw display name.
+ * Pure, framework-free validation of a team's name and *user-supplied* slug (#158: the slug is
+ * validated, not derived — the caller owns the address). The tenant schema name is the one thing still
+ * derived, from the already-validated slug.
  *
- * The schema name is interpolated into `CREATE SCHEMA` / `SET search_path`, so this is the injection
- * boundary: the derivation only ever emits `[a-z0-9_]`, and the result is asserted against a strict
- * whitelist before it leaves this class. Length is capped at Postgres' 63-byte identifier limit and
- * over-long names are rejected (never truncated — a truncated schema_name would no longer match the
- * schema actually created, silently breaking tenant routing).
+ * The schema name is interpolated into `CREATE SCHEMA` / `SET search_path`, so the slug is the injection
+ * boundary: it is accepted only if it matches the strict whitelist `^[a-z0-9]+(-[a-z0-9]+)*$`, so
+ * `team_` + slug (hyphens → underscores) can only ever be `[a-z0-9_]`. The slug is capped at 58 chars so
+ * that identifier stays within Postgres' 63-byte limit — over-long slugs are rejected, never truncated
+ * (a truncated schema_name would no longer match the schema actually created, breaking tenant routing).
  */
 object TeamNaming {
     const val MAX_NAME_LENGTH = 100
-    const val MAX_SCHEMA_BYTES = 63
+
+    // "team_" (5 bytes) + 58 = 63, exactly Postgres' identifier limit.
+    const val MAX_SLUG_LENGTH = 58
 
     private const val SCHEMA_PREFIX = "team_"
-    private val NON_SLUG_CHARS = Regex("[^a-z0-9]+")
+    private val SLUG_FORMAT = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
     private val SAFE_SCHEMA = Regex("^team_[a-z0-9_]+$")
 
-    fun derive(rawName: String): TeamNames {
+    fun validate(rawName: String, rawSlug: String): TeamNames {
         val name = validatedName(rawName)
-        val slug = slugOf(name)
-        val schemaName = schemaNameFor(name, slug)
+        val slug = validatedSlug(rawSlug)
+        val schemaName = SCHEMA_PREFIX + slug.replace('-', '_')
+        // Defensive: the format check above already guarantees this, but assert the injection-safety
+        // invariant explicitly so any future change to the slug rules can't silently weaken it.
+        require(SAFE_SCHEMA.matches(schemaName)) { "derived schema '$schemaName' is not a safe identifier" }
         return TeamNames(name = name, slug = slug, schemaName = schemaName)
     }
 
@@ -44,24 +52,13 @@ object TeamNaming {
         return name
     }
 
-    private fun slugOf(name: String): String {
-        val slug = name.lowercase().replace(NON_SLUG_CHARS, "-").trim('-')
-        if (slug.isEmpty()) {
-            throw InvalidTeamNameException("Team name '$name' has no characters usable for a URL slug")
+    private fun validatedSlug(rawSlug: String): String {
+        if (rawSlug.length > MAX_SLUG_LENGTH) {
+            throw InvalidSlugException("Team address must be at most $MAX_SLUG_LENGTH characters")
         }
-        return slug
-    }
-
-    private fun schemaNameFor(name: String, slug: String): String {
-        val schemaName = SCHEMA_PREFIX + slug.replace('-', '_')
-        if (schemaName.toByteArray(Charsets.UTF_8).size > MAX_SCHEMA_BYTES) {
-            throw InvalidTeamNameException(
-                "Team name '$name' derives a schema longer than $MAX_SCHEMA_BYTES bytes — choose a shorter name",
-            )
+        if (!SLUG_FORMAT.matches(rawSlug)) {
+            throw InvalidSlugException("Team address must be lowercase letters, numbers, and single hyphens")
         }
-        // Defensive: the derivation above can only emit [a-z0-9_], but assert the injection-safety
-        // invariant explicitly so any future change to the slug rules can't silently weaken it.
-        require(SAFE_SCHEMA.matches(schemaName)) { "derived schema '$schemaName' is not a safe identifier" }
-        return schemaName
+        return rawSlug
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamSummary.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamSummary.kt
@@ -1,0 +1,14 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import java.util.UUID
+
+/**
+ * The minimal view of a team the platform layer hands back for identity purposes — the has-a-team gate
+ * signal on `/auth/me` (#158). Just enough to name the team the caller belongs to; the tenant schema
+ * and any team attributes stay behind the aggregate.
+ */
+data class TeamSummary(
+    val id: UUID,
+    val name: String,
+    val slug: String,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -1,8 +1,12 @@
 package com.github.zzave.teambalance.api.domain.port
 
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
+import java.util.UUID
+
 /**
- * Read-side access to platform-level teams. Minimal by design: Slice 1 only needs the tenant schema
- * names to keep every team's schema migrated at boot; the full Team aggregate arrives with create-team.
+ * Read-side access to platform-level teams. Slice 1 needed only the tenant schema names to keep every
+ * team migrated at boot; create-team added the slug pre-check; #158 adds the per-user lookup that powers
+ * `/auth/me`'s has-a-team gate signal.
  */
 interface TeamRepository {
     /** Schema names of all teams — the source of truth for which tenant schemas must exist. */
@@ -14,4 +18,7 @@ interface TeamRepository {
      * the authoritative guard against a concurrent collision.
      */
     fun existsBySlug(slug: String): Boolean
+
+    /** The team the user actively belongs to, or null if teamless (v1: one team per user). */
+    fun findByUserId(userId: UUID): TeamSummary?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -1,8 +1,10 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 /**
  * Reads `public.teams` over the raw datasource (via [JdbcTemplate]), not Hibernate. The startup
@@ -24,4 +26,19 @@ class JdbcTeamRepositoryAdapter(
             Boolean::class.java,
             slug,
         ) ?: false
+
+    override fun findByUserId(userId: UUID): TeamSummary? =
+        jdbcTemplate.query(
+            "SELECT t.id, t.name, t.slug FROM public.teams t " +
+                "JOIN public.team_members tm ON tm.team_id = t.id " +
+                "WHERE tm.user_id = ? AND tm.active = true ORDER BY tm.team_id LIMIT 1",
+            { rs, _ ->
+                TeamSummary(
+                    id = rs.getObject("id", UUID::class.java),
+                    name = rs.getString("name"),
+                    slug = rs.getString("slug"),
+                )
+            },
+            userId,
+        ).firstOrNull()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
@@ -10,6 +10,7 @@ import com.github.zzave.teambalance.api.interfaces.generated.endpoint.Logout
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RequestMagicLink
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.VerifyMagicLink
 import com.github.zzave.teambalance.api.interfaces.generated.model.AuthenticatedUser
+import com.github.zzave.teambalance.api.interfaces.generated.model.TeamRef
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -38,6 +39,7 @@ class AuthController(
                 email = user.email.produce(),
                 displayName = user.displayName,
                 role = resolveRole(user.id),
+                team = resolveTeam(user.id),
             ),
         )
     }
@@ -57,6 +59,7 @@ class AuthController(
                     email = it.email.produce(),
                     displayName = it.displayName,
                     role = resolveRole(it.id),
+                    team = resolveTeam(it.id),
                 ),
             )
         } ?: GetAuthMe.Response401(Unit)
@@ -64,6 +67,13 @@ class AuthController(
 
     private fun resolveRole(userId: UserId): String? =
         teamMemberRepository.findTeamId(userId)?.let { teamId -> teamMemberRepository.findRole(teamId, userId) }?.name
+
+    // The has-a-team gate signal (#158): a null team means the caller is teamless and belongs on
+    // /create-team. Resolved through the application service so this inbound layer keeps no port
+    // dependency of its own (ADR-0018). v1: one team per user.
+    private fun resolveTeam(userId: UserId): TeamRef? =
+        authService.findTeamFor(userId)
+            ?.let { TeamRef(id = it.id.toString(), name = it.name, slug = it.slug) }
 }
 
 // The Wirespec edge for a user's identity — the contract, and the session attribute the auth filter

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.interfaces
 
+import com.github.zzave.teambalance.api.domain.exception.BadRequestException
 import com.github.zzave.teambalance.api.domain.exception.ConflictException
 import com.github.zzave.teambalance.api.domain.exception.ForbiddenException
 import com.github.zzave.teambalance.api.domain.exception.NotFoundException
@@ -40,6 +41,13 @@ class GlobalExceptionHandler {
     fun handleUnprocessableEntity(ex: UnprocessableEntityException): ResponseEntity<Map<String, String>> =
         ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
             .body(mapOf("error" to (ex.message ?: "Unprocessable"), "code" to ex.code))
+
+    // More specific than the generic TeambalanceException handler below (Spring resolves the closest
+    // match), so a field-placeable 400 carries its `code` discriminator; codeless 400s fall through.
+    @ExceptionHandler(BadRequestException::class)
+    fun handleBadRequest(ex: BadRequestException): ResponseEntity<Map<String, String>> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(mapOf("error" to (ex.message ?: "Invalid request"), "code" to ex.code))
 
     @ExceptionHandler(TeambalanceException::class)
     fun handleTeambalanceException(ex: TeambalanceException): ResponseEntity<Map<String, String>> =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -25,7 +25,9 @@ class TeamController(
         val created = teamService.createTeam(
             founderId = founderId,
             rawName = request.body.name,
-            creationCode = request.body.creationCode,
+            rawSlug = request.body.slug,
+            // Sent verbatim but trimmed — the code format is the issuer's concern (Slice 4), not ours.
+            creationCode = request.body.creationCode.trim(),
         )
         return CreateTeam.Response201(created.toDto())
     }

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -24,6 +24,13 @@ VALUES (
 )
 ON CONFLICT (id) DO UPDATE SET onboarded_at = EXCLUDED.onboarded_at;
 
+-- A creation code for the self-service create-team e2e (#158). Reset to unconsumed on every backend
+-- boot (this seed runs once per `make e2e`), so a warm local DB can re-run the spec without a wipe —
+-- the spec pairs it with a per-run-unique founder email, keeping the flow idempotent across re-runs.
+INSERT INTO public.team_creation_codes (code, consumed_at, consumed_by_user_id)
+VALUES ('E2E-CREATE-TEAM', NULL, NULL)
+ON CONFLICT (code) DO UPDATE SET consumed_at = NULL, consumed_by_user_id = NULL;
+
 -- Tenant data for the change-attendance flow (team_test is provisioned before this runs).
 -- Event types are seeded per-tenant by tenant-migration V002; resolve the FK by name.
 -- start_time is relative so the event stays on the upcoming list; the uuid conflict keeps

--- a/api/src/main/wirespec/auth.ws
+++ b/api/src/main/wirespec/auth.ws
@@ -6,11 +6,18 @@ type VerifyMagicLinkRequest {
     token: String
 }
 
+type TeamRef {
+    id: String,
+    name: String,
+    slug: String
+}
+
 type AuthenticatedUser {
     id: String,
     email: String,
     displayName: String,
-    role: String?
+    role: String?,
+    team: TeamRef?
 }
 
 endpoint RequestMagicLink POST RequestMagicLinkRequest /api/auth/magic-link/request -> {

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -1,5 +1,6 @@
 type CreateTeamRequest {
     name: String,
+    slug: String,
     creationCode: String
 }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.AlreadyInTeamException
 import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
+import com.github.zzave.teambalance.api.domain.exception.InvalidSlugException
 import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
 import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
 import com.github.zzave.teambalance.api.domain.model.Email
@@ -9,6 +10,7 @@ import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
@@ -52,6 +54,7 @@ private class FakeMemberRepo(private val existingTeam: TeamId?) : TeamMemberRepo
 private class FakeTeamRepo(private val existingSlugs: Set<String> = emptySet()) : TeamRepository {
     override fun findAllSchemaNames(): List<String> = emptyList()
     override fun existsBySlug(slug: String): Boolean = slug in existingSlugs
+    override fun findByUserId(userId: UUID): TeamSummary? = null
 }
 
 private class FakeCodeRepo(private val redeemable: Boolean) : TeamCreationCodeRepository {
@@ -132,7 +135,7 @@ class TeamServiceTest : FunSpec() {
 
         test("creates the team: provisions the schema, registers, and returns id/name/slug") {
             val calls = mutableListOf<String>()
-            val created = service(calls).createTeam(founder, "Setpoint VT", "GOODCODE")
+            val created = service(calls).createTeam(founder, "Setpoint VT", "setpoint-vt", "GOODCODE")
 
             created.id shouldBe newTeamId
             created.name shouldBe "Setpoint VT"
@@ -144,21 +147,28 @@ class TeamServiceTest : FunSpec() {
         test("rejects a founder who already belongs to a team, without provisioning") {
             val calls = mutableListOf<String>()
             shouldThrow<AlreadyInTeamException> {
-                service(calls, existingTeam = TeamId(UUID.randomUUID())).createTeam(founder, "New Team", "GOODCODE")
+                service(calls, existingTeam = TeamId(UUID.randomUUID()))
+                    .createTeam(founder, "New Team", "new-team", "GOODCODE")
             }
             calls shouldBe emptyList()
         }
 
-        test("rejects a blank / underivable name with 400 before any provisioning") {
+        test("rejects a blank name with 400 before any provisioning") {
             val calls = mutableListOf<String>()
-            shouldThrow<InvalidTeamNameException> { service(calls).createTeam(founder, "   ", "GOODCODE") }
+            shouldThrow<InvalidTeamNameException> { service(calls).createTeam(founder, "   ", "valid-slug", "GOODCODE") }
+            calls shouldBe emptyList()
+        }
+
+        test("rejects an invalid slug with 400 before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<InvalidSlugException> { service(calls).createTeam(founder, "Setpoint VT", "Bad Slug", "GOODCODE") }
             calls shouldBe emptyList()
         }
 
         test("rejects a taken slug with 409 before any provisioning") {
             val calls = mutableListOf<String>()
             shouldThrow<TeamSlugTakenException> {
-                service(calls, existingSlugs = setOf("setpoint-vt")).createTeam(founder, "Setpoint VT", "GOODCODE")
+                service(calls, existingSlugs = setOf("setpoint-vt")).createTeam(founder, "Setpoint VT", "setpoint-vt", "GOODCODE")
             }
             calls shouldBe emptyList()
         }
@@ -166,7 +176,7 @@ class TeamServiceTest : FunSpec() {
         test("rejects a non-redeemable code with opaque 403 and does NOT provision a schema") {
             val calls = mutableListOf<String>()
             shouldThrow<InvalidCreationCodeException> {
-                service(calls, redeemable = false).createTeam(founder, "Setpoint VT", "BADCODE")
+                service(calls, redeemable = false).createTeam(founder, "Setpoint VT", "setpoint-vt", "BADCODE")
             }
             // The peek gates provisioning — a bad code never leaves an orphan schema behind.
             calls shouldBe emptyList()
@@ -175,14 +185,14 @@ class TeamServiceTest : FunSpec() {
         test("a provisioning failure propagates and no registration happens") {
             val calls = mutableListOf<String>()
             shouldThrow<RuntimeException> {
-                service(calls, provisionFails = true).createTeam(founder, "Setpoint VT", "GOODCODE")
+                service(calls, provisionFails = true).createTeam(founder, "Setpoint VT", "setpoint-vt", "GOODCODE")
             }
             calls shouldBe emptyList() // provisioner threw before recording; register never reached
         }
 
         test("notifies the founder and audits the platform admins on success") {
             val notifier = RecordingNotifier()
-            service(notifier = notifier).createTeam(founder, "Setpoint VT", "GOODCODE")
+            service(notifier = notifier).createTeam(founder, "Setpoint VT", "setpoint-vt", "GOODCODE")
 
             notifier.created shouldContainExactly listOf(Triple("founder@example.com", "Setpoint VT", "setpoint-vt"))
             notifier.audited shouldContainExactly listOf(Triple("Setpoint VT", "setpoint-vt", "founder@example.com"))
@@ -190,7 +200,7 @@ class TeamServiceTest : FunSpec() {
 
         test("a failing notifier never fails a committed creation (fire-and-forget)") {
             val created = service(notifier = RecordingNotifier(throwing = true))
-                .createTeam(founder, "Setpoint VT", "GOODCODE")
+                .createTeam(founder, "Setpoint VT", "setpoint-vt", "GOODCODE")
             created.id shouldBe newTeamId
         }
     }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNamingTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/TeamNamingTest.kt
@@ -1,74 +1,63 @@
 package com.github.zzave.teambalance.api.domain.model
 
+import com.github.zzave.teambalance.api.domain.exception.InvalidSlugException
 import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Pure derivation of a team's slug + tenant schema name from a raw display name. The schema name is
- * fed straight into `SET search_path`, so this is the security-critical sanitisation boundary: the
- * whitelist regex `^team_[a-z0-9_]+$` is what makes the derived identifier injection-safe.
+ * Validation of a team's name and *user-supplied* slug (#158: validated, not derived). The schema name
+ * is fed straight into `SET search_path`, so the slug format check is the security-critical
+ * sanitisation boundary: the whitelist `^[a-z0-9]+(-[a-z0-9]+)*$` is what keeps the derived identifier
+ * injection-safe, and the ≤58 length cap keeps `team_` + slug within Postgres' 63-byte limit.
  */
 class TeamNamingTest : FunSpec() {
     init {
-        test("lowercases and hyphenates a simple name into slug + team_ schema") {
-            val names = TeamNaming.derive("Setpoint VT")
+        test("keeps the trimmed name and the verbatim slug, deriving only the team_ schema name") {
+            val names = TeamNaming.validate("  Setpoint VT  ", "setpoint-vt")
             names.name shouldBe "Setpoint VT"
             names.slug shouldBe "setpoint-vt"
             names.schemaName shouldBe "team_setpoint_vt"
         }
 
-        test("collapses runs of non-alphanumeric characters into a single hyphen") {
-            TeamNaming.derive("  Ajax   //  Amsterdam!! ").let {
-                it.slug shouldBe "ajax-amsterdam"
-                it.schemaName shouldBe "team_ajax_amsterdam"
-            }
+        test("a single-segment slug needs no substitution") {
+            TeamNaming.validate("Setpoint", "setpoint").schemaName shouldBe "team_setpoint"
         }
 
-        test("trims leading and trailing separators from the slug") {
-            TeamNaming.derive("--Rockets--").slug shouldBe "rockets"
+        test("keeps digits and a purely numeric slug") {
+            TeamNaming.validate("2024 Squad", "2024").schemaName shouldBe "team_2024"
         }
 
-        test("maps accented and non-ascii characters through the separator (never into the identifier)") {
-            // é / ü are not [a-z0-9]; they must not leak into the schema identifier.
-            TeamNaming.derive("Café Zürich 4").let {
-                it.slug shouldBe "caf-z-rich-4"
-                it.schemaName shouldBe "team_caf_z_rich_4"
-            }
+        test("the derived schema always matches the injection-safe whitelist") {
+            Regex("^team_[a-z0-9_]+$").matches(TeamNaming.validate("A B C", "a-b-c").schemaName) shouldBe true
         }
 
-        test("keeps digits and treats a purely numeric name as valid") {
-            TeamNaming.derive("2024").let {
-                it.slug shouldBe "2024"
-                it.schemaName shouldBe "team_2024"
-            }
+        test("rejects a blank name with INVALID_NAME") {
+            shouldThrow<InvalidTeamNameException> { TeamNaming.validate("   ", "valid-slug") }
         }
 
-        test("derived schema always matches the injection-safe whitelist") {
-            Regex("^team_[a-z0-9_]+$").matches(TeamNaming.derive("A B C 1").schemaName) shouldBe true
+        test("rejects a name longer than the 100-char column limit with INVALID_NAME") {
+            shouldThrow<InvalidTeamNameException> { TeamNaming.validate("a".repeat(101), "valid-slug") }
         }
 
-        test("rejects a blank name") {
-            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("   ") }
+        test("rejects uppercase, spaces, underscores, and other non-slug characters") {
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "Setpoint") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "set point") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "set_point") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "set!") }
         }
 
-        test("rejects a name with no slug-usable characters") {
-            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("!!! @#$ %^&") }
+        test("rejects leading, trailing, and doubled hyphens and an empty slug") {
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "-setpoint") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "setpoint-") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "set--point") }
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "") }
         }
 
-        test("rejects a name longer than the 100-char column limit") {
-            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("a".repeat(101)) }
-        }
-
-        test("rejects a name whose derived schema would exceed 63 bytes (never truncates)") {
-            // 60 'a's → schema "team_" + 60 = 65 bytes > 63. Must reject, not silently truncate.
-            shouldThrow<InvalidTeamNameException> { TeamNaming.derive("a".repeat(60)) }
-        }
-
-        test("accepts a name whose derived schema is exactly at the 63-byte limit") {
-            // "team_" (5) + 58 = 63 bytes exactly.
-            TeamNaming.derive("a".repeat(58)).schemaName.toByteArray().size shouldBe 63
+        test("accepts a 58-char slug (schema exactly 63 bytes) but rejects 59") {
+            TeamNaming.validate("Team", "a".repeat(58)).schemaName.toByteArray().size shouldBe 63
+            shouldThrow<InvalidSlugException> { TeamNaming.validate("Team", "a".repeat(59)) }
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
@@ -47,12 +47,12 @@ class CreateTeamControllerIT : TeamBalanceIT() {
         )
     }
 
-    private fun createTeam(userId: String, name: String, code: String) =
+    private fun createTeam(userId: String, name: String, slug: String, code: String) =
         mockMvc.perform(
             MockMvcRequestBuilders.post("/api/teams")
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"name":"$name","creationCode":"$code"}"""),
+                .content("""{"name":"$name","slug":"$slug","creationCode":"$code"}"""),
         )
             .andExpect(MockMvcResultMatchers.request().asyncStarted())
             .andReturn()
@@ -76,7 +76,7 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             seedUser(founder, "happy-${founder.take(8)}@test.com")
             seedCode("CT-HAPPY-${founder.take(8)}")
 
-            createTeam(founder, "Create IT Happy", "CT-HAPPY-${founder.take(8)}")
+            createTeam(founder, "Create IT Happy", "create-it-happy", "CT-HAPPY-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isCreated)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Create IT Happy"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.slug").value("create-it-happy"))
@@ -126,11 +126,11 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             seedUser(other, "reuse-b-${other.take(8)}@test.com")
             seedCode("CT-REUSE-${founder.take(8)}")
 
-            createTeam(founder, "Create IT Reuse", "CT-REUSE-${founder.take(8)}")
+            createTeam(founder, "Create IT Reuse", "create-it-reuse", "CT-REUSE-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isCreated)
 
             // A different (teamless) user tries the now-consumed code.
-            createTeam(other, "Create IT Reuse Two", "CT-REUSE-${founder.take(8)}")
+            createTeam(other, "Create IT Reuse Two", "create-it-reuse-two", "CT-REUSE-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
@@ -138,7 +138,7 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             val founder = UUID.randomUUID().toString()
             seedUser(founder, "unknown-${founder.take(8)}@test.com")
 
-            createTeam(founder, "Create IT Unknown", "NO-SUCH-CODE-${founder.take(8)}")
+            createTeam(founder, "Create IT Unknown", "create-it-unknown", "NO-SUCH-CODE-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
@@ -147,7 +147,7 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             seedUser(founder, "expired-${founder.take(8)}@test.com")
             seedCode("CT-EXPIRED-${founder.take(8)}", expiresSql = "now() - interval '1 day'")
 
-            createTeam(founder, "Create IT Expired", "CT-EXPIRED-${founder.take(8)}")
+            createTeam(founder, "Create IT Expired", "create-it-expired", "CT-EXPIRED-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
@@ -157,10 +157,10 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             seedCode("CT-FIRST-${founder.take(8)}")
             seedCode("CT-SECOND-${founder.take(8)}")
 
-            createTeam(founder, "Create IT First", "CT-FIRST-${founder.take(8)}")
+            createTeam(founder, "Create IT First", "create-it-first", "CT-FIRST-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isCreated)
 
-            createTeam(founder, "Create IT Second", "CT-SECOND-${founder.take(8)}")
+            createTeam(founder, "Create IT Second", "create-it-second", "CT-SECOND-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isConflict)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("ALREADY_IN_TEAM"))
 
@@ -173,20 +173,31 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             consumedAt shouldBe null
         }
 
-        test("a blank team name returns 400") {
+        test("a blank team name returns 400 INVALID_NAME") {
             val founder = UUID.randomUUID().toString()
             seedUser(founder, "blank-${founder.take(8)}@test.com")
             seedCode("CT-BLANK-${founder.take(8)}")
 
-            createTeam(founder, "   ", "CT-BLANK-${founder.take(8)}")
+            createTeam(founder, "   ", "valid-slug", "CT-BLANK-${founder.take(8)}")
                 .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("INVALID_NAME"))
+        }
+
+        test("an invalid slug returns 400 INVALID_SLUG before provisioning") {
+            val founder = UUID.randomUUID().toString()
+            seedUser(founder, "badslug-${founder.take(8)}@test.com")
+            seedCode("CT-BADSLUG-${founder.take(8)}")
+
+            createTeam(founder, "Create IT Bad Slug", "Bad Slug", "CT-BADSLUG-${founder.take(8)}")
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("INVALID_SLUG"))
         }
 
         test("creating a team without an authenticated user returns 401") {
             mockMvc.perform(
                 MockMvcRequestBuilders.post("/api/teams")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"name":"Nope","creationCode":"whatever"}"""),
+                    .content("""{"name":"Nope","slug":"nope","creationCode":"whatever"}"""),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
                 .andReturn()

--- a/app/e2e-real/create-team.spec.ts
+++ b/app/e2e-real/create-team.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+// Real e2e (#158): self-service create-team across the whole seam — browser → API → DB. A teamless,
+// authenticated user enters a creation code + name + slug, becomes founding ADMIN, and lands inside
+// their new team. This is the create-team seam #154 Slice 3 justified (cross-tenant provisioning + the
+// code gate — not covered by the login or attendance flows); it lives here because #158 replaces the
+// throwaway Slice-3 tracer, so the net e2e count is unchanged.
+//
+// Idempotent across warm-DB re-runs: a per-run-unique founder email is always freshly teamless (the
+// magic-link verify creates the user), and the seeded code is reset to unconsumed on every backend
+// boot (db/e2e/seed.sql). So this spec needs no DB wipe between runs.
+
+const RUN = Date.now()
+const FOUNDER_EMAIL = `founder-${RUN}@example.com`
+// A per-run-unique team name/slug so a warm DB (with teams from earlier runs) never hits the unique
+// slug constraint. suggestSlug lowercases + hyphenates the name, so this is the slug the form fills.
+const TEAM_NAME = `E2E Founders ${RUN}`
+const EXPECTED_SLUG = `e2e-founders-${RUN}`
+const CREATION_CODE = 'E2E-CREATE-TEAM'
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+
+// Start unauthenticated — a brand-new, teamless founder — overriding the project-wide storageState.
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test('create-team: a teamless founder enters code + name + slug and lands in the new team', async ({
+  page,
+  request,
+}) => {
+  // 1. Request a magic link for a brand-new email — verify will create the user teamless.
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(FOUNDER_EMAIL)
+  await page.getByRole('button', { name: 'Send magic link' }).click()
+  await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+  const tokenResponse = await request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email: FOUNDER_EMAIL },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+
+  // 2. Click the emailed link → session established. The has-a-team gate routes the teamless founder
+  //    to /create-team (proving they are NOT bounced to /login by the old teamless-user behaviour).
+  await page.goto(`/auth/verify?token=${token}`)
+  await expect(page.getByRole('heading', { name: 'Create your team' })).toBeVisible({ timeout: 10_000 })
+
+  // 3. Fill the form — the slug auto-suggests from the name; the code is the seeded creation code.
+  await page.getByLabel('Team name').fill(TEAM_NAME)
+  await expect(page.getByLabel('Team address')).toHaveValue(EXPECTED_SLUG)
+  await page.getByLabel('Creation code').fill(CREATION_CODE)
+
+  // 4. Create → provisions the tenant schema + Flyway migrate in-request (allow for cold start),
+  //    makes the founder ADMIN, and lands on /members inside the brand-new team.
+  await page.getByRole('button', { name: 'Create team' }).click()
+  await expect(page).toHaveURL(/\/members\/?$/, { timeout: 20_000 })
+  await expect(page.getByRole('heading', { name: 'Positions' })).toBeVisible()
+})

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1661,9 +1661,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,9 +1678,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1701,9 +1695,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1721,9 +1712,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1741,9 +1729,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1761,9 +1746,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,9 +1763,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1801,9 +1780,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +1992,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2033,9 +2006,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2050,9 +2020,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2067,9 +2034,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2084,9 +2048,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,9 +2062,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,9 +2076,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,9 +2090,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,9 +2887,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,9 +2904,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2978,9 +2921,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2998,9 +2938,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3018,9 +2955,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3504,9 +3438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3524,9 +3455,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3544,9 +3472,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3564,9 +3489,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6941,9 +6863,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6965,9 +6884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6989,9 +6905,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7013,9 +6926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9103,9 +9013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9127,9 +9034,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9151,9 +9055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9175,9 +9076,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -9,7 +9,15 @@ import type { AuthenticatedUser } from '@shared/api/auth'
 // fetch protected data) until the session is confirmed. An unconfirmed session — a 401 probe OR
 // any /me error — fails closed to the login screen.
 
-const USER: AuthenticatedUser = { id: 'user-1', email: 'jan@example.com', displayName: 'Jan', role: 'USER' }
+const USER: AuthenticatedUser = {
+  id: 'user-1',
+  email: 'jan@example.com',
+  displayName: 'Jan',
+  role: 'USER',
+  // A confirmed member of a team, so the has-a-team gate passes and this test stays focused on the
+  // auth-confirmation seam (401 vs 200), not team routing.
+  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
+}
 
 let meStatus = 401
 let eventsFetched = false

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -19,11 +19,20 @@ import { queryClient } from '@shared/api/query-client'
 let session: AuthenticatedUser | null = null
 let accepted = false
 
+// Pre-join: a teamless newbie (no role, no team). Accepting the invite makes them a member — see the
+// accept handler, which flips the session to [MEMBER] so the has-a-team gate passes on the landing.
 const USER: AuthenticatedUser = {
   id: 'user-1',
   email: 'newbie@example.com',
   displayName: 'newbie',
   role: undefined,
+  team: undefined,
+}
+
+const MEMBER: AuthenticatedUser = {
+  ...USER,
+  role: 'USER',
+  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
 }
 
 const server = setupServer(
@@ -44,6 +53,9 @@ const server = setupServer(
   http.post('/api/invitations/:token/accept', ({ params }) => {
     if (params.token !== 'valid-invite-token') return new HttpResponse(null, { status: 404 })
     accepted = true
+    // Joining a team makes the caller a member — /auth/me now reports the team, so the has-a-team gate
+    // lets them land on events (the flow invalidates ['auth','me'] right after accept).
+    session = MEMBER
     return HttpResponse.json({ teamId: 'team-1' })
   }),
   http.get('/api/events', () => HttpResponse.json({ events: [] })),

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -20,6 +20,8 @@ const USER: AuthenticatedUser = {
   email: 'jan@example.com',
   displayName: 'Jan',
   role: 'USER',
+  // A member of a team, so the has-a-team gate passes and the flow lands on events (not /create-team).
+  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
 }
 
 const server = setupServer(

--- a/app/src/features/create-team/lib/suggest-slug.test.ts
+++ b/app/src/features/create-team/lib/suggest-slug.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { suggestSlug } from './suggest-slug'
+import { MAX_SLUG_LENGTH, validateSlug } from './validate-slug'
+
+describe('suggestSlug', () => {
+  it('lowercases and hyphenates a simple name', () => {
+    expect(suggestSlug('Tovo Heren 4')).toBe('tovo-heren-4')
+  })
+
+  it('collapses runs of non-alphanumerics into a single hyphen', () => {
+    expect(suggestSlug('  Ajax  //  Amsterdam!! ')).toBe('ajax-amsterdam')
+  })
+
+  it('trims leading and trailing separators', () => {
+    expect(suggestSlug('--Rockets--')).toBe('rockets')
+  })
+
+  it('drops accented characters through the separator rather than into the slug', () => {
+    expect(suggestSlug('Café Zürich')).toBe('caf-z-rich')
+  })
+
+  it('returns an empty string for a name with no usable characters', () => {
+    expect(suggestSlug('!!! @#$')).toBe('')
+  })
+
+  it('caps the suggestion at the max slug length with no trailing hyphen', () => {
+    const suggestion = suggestSlug('a '.repeat(80))
+    expect(suggestion.length).toBeLessThanOrEqual(MAX_SLUG_LENGTH)
+    expect(suggestion.endsWith('-')).toBe(false)
+  })
+
+  it('always produces a slug that passes validateSlug (or is empty)', () => {
+    for (const name of ['Tovo Heren 4', 'Ajax // Amsterdam', 'Café Zürich', '2024 Squad']) {
+      expect(validateSlug(suggestSlug(name))).toBeNull()
+    }
+  })
+})

--- a/app/src/features/create-team/lib/suggest-slug.ts
+++ b/app/src/features/create-team/lib/suggest-slug.ts
@@ -1,0 +1,16 @@
+import { MAX_SLUG_LENGTH } from './validate-slug'
+
+/**
+ * Suggests a URL slug from a team name — pure UX sugar (#158): it pre-fills the slug field until the
+ * user edits it. It carries **no correctness contract** (the backend validates the submitted slug, it
+ * does not derive one), so a suggestion that needs tidying is fine. Lowercases, turns each run of
+ * non-alphanumerics into a single hyphen, trims stray hyphens, and caps at the max slug length.
+ */
+export function suggestSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, '')
+}

--- a/app/src/features/create-team/lib/validate-slug.test.ts
+++ b/app/src/features/create-team/lib/validate-slug.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_SLUG_LENGTH, validateSlug } from './validate-slug'
+
+describe('validateSlug', () => {
+  it('accepts a lowercase, hyphen-separated slug', () => {
+    expect(validateSlug('tovo-heren-4')).toBeNull()
+  })
+
+  it('accepts a single-segment slug', () => {
+    expect(validateSlug('setpoint')).toBeNull()
+  })
+
+  it('rejects an empty slug', () => {
+    expect(validateSlug('')).toMatch(/choose/i)
+  })
+
+  it('rejects uppercase, spaces, underscores, and other non-slug characters', () => {
+    expect(validateSlug('Tovo')).toMatch(/lowercase/i)
+    expect(validateSlug('tovo heren')).toMatch(/lowercase/i)
+    expect(validateSlug('tovo_heren')).toMatch(/lowercase/i)
+    expect(validateSlug('tovo!')).toMatch(/lowercase/i)
+  })
+
+  it('rejects leading, trailing, and doubled hyphens', () => {
+    expect(validateSlug('-tovo')).toMatch(/lowercase/i)
+    expect(validateSlug('tovo-')).toMatch(/lowercase/i)
+    expect(validateSlug('tovo--heren')).toMatch(/lowercase/i)
+  })
+
+  it(`accepts a ${MAX_SLUG_LENGTH}-character slug but rejects one character more`, () => {
+    expect(validateSlug('a'.repeat(MAX_SLUG_LENGTH))).toBeNull()
+    expect(validateSlug('a'.repeat(MAX_SLUG_LENGTH + 1))).toMatch(/or fewer/i)
+  })
+})

--- a/app/src/features/create-team/lib/validate-slug.ts
+++ b/app/src/features/create-team/lib/validate-slug.ts
@@ -1,0 +1,19 @@
+// The team address (slug) is user-editable and validated to the same contract the backend enforces
+// (#158): lowercase letters, numbers, and single hyphens, no leading/trailing/doubled hyphen, and at
+// most 58 characters (so `team_` + slug stays within Postgres' 63-byte identifier limit). Kept in sync
+// with the server's TeamNaming — a client mismatch would only ever surface as a 400 INVALID_SLUG.
+export const MAX_SLUG_LENGTH = 58
+
+const SLUG_FORMAT = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+/**
+ * Validates a team slug verbatim (no trimming — the field is the address as typed). Returns an error
+ * string to show inline, or null when the slug is acceptable. A taken slug is a server concern (409),
+ * surfaced separately.
+ */
+export function validateSlug(value: string): string | null {
+  if (value.length === 0) return 'Choose a team address.'
+  if (value.length > MAX_SLUG_LENGTH) return `Use ${MAX_SLUG_LENGTH} characters or fewer.`
+  if (!SLUG_FORMAT.test(value)) return 'Use lowercase letters, numbers, and hyphens.'
+  return null
+}

--- a/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { CreateTeamError } from '@shared/api/teams'
+import { CreateTeamForm } from './CreateTeamForm'
+
+// CreateTeamForm is the presentational create-team UI behind the /create-team route container. It owns
+// only local field state (name/slug/code + the slug auto-suggest-until-edited flag); the mutation,
+// navigation, and success side-effects stay in the container, so every state renders purely from props.
+//
+// Conventions (ADR-0017): all form states are stories with no network, and the interactive stories
+// pass an onSubmit fn() spy and assert it fired with the right args — proving the wiring, not just the
+// render.
+const meta = {
+  title: 'features/create-team/CreateTeamForm',
+  component: CreateTeamForm,
+  args: { isPending: false, onSubmit: fn() },
+} satisfies Meta<typeof CreateTeamForm>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Pristine: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText('Team name')).toHaveValue('')
+    await expect(canvas.getByLabelText('Team address')).toHaveValue('')
+    await expect(canvas.getByLabelText('Creation code')).toHaveValue('')
+    // Nothing typed yet → submit is disabled (hard gate before anything can be sent).
+    await expect(canvas.getByRole('button', { name: 'Create team' })).toBeDisabled()
+  },
+}
+
+export const Valid: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.type(canvas.getByLabelText('Team name'), 'Tovo Heren 4')
+    // The slug is auto-suggested from the name until the user edits it.
+    await expect(canvas.getByLabelText('Team address')).toHaveValue('tovo-heren-4')
+    await userEvent.type(canvas.getByLabelText('Creation code'), 'JOIN-2026')
+
+    const submit = canvas.getByRole('button', { name: 'Create team' })
+    await expect(submit).toBeEnabled()
+    await userEvent.click(submit)
+    await expect(args.onSubmit).toHaveBeenCalledWith({
+      name: 'Tovo Heren 4',
+      slug: 'tovo-heren-4',
+      creationCode: 'JOIN-2026',
+    })
+  },
+}
+
+export const Submitting: Story = {
+  // reassuranceDelayMs: 0 forces the delayed "still setting up" line visible without a real wait.
+  args: { isPending: true, reassuranceDelayMs: 0 },
+  play: async ({ canvas }) => {
+    const submit = canvas.getByRole('button', { name: 'Creating your team…' })
+    await expect(submit).toBeDisabled()
+    await expect(
+      await canvas.findByText(/Setting up your team's space/),
+    ).toBeInTheDocument()
+  },
+}
+
+export const CodeInvalid: Story = {
+  args: { error: new CreateTeamError('INVALID_CREATION_CODE', "That creation code isn't valid.") },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("That creation code isn't valid.")).toBeInTheDocument()
+  },
+}
+
+export const SlugTaken: Story = {
+  args: { error: new CreateTeamError('SLUG_TAKEN', 'That address is already taken — try another.') },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('That address is already taken — try another.')).toBeInTheDocument()
+  },
+}
+
+export const NameOrSlugInvalid: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.type(canvas.getByLabelText('Team name'), 'Tovo Heren 4')
+    // The user edits the auto-suggested slug into something invalid — client validation catches it.
+    const slug = canvas.getByLabelText('Team address')
+    await userEvent.clear(slug)
+    await userEvent.type(slug, 'Bad Slug')
+    await expect(canvas.getByText('Use lowercase letters, numbers, and hyphens.')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Create team' })).toBeDisabled()
+  },
+}
+
+export const AlreadyInTeam: Story = {
+  args: { error: new CreateTeamError('ALREADY_IN_TEAM', "You're already on a team.") },
+  play: async ({ canvas }) => {
+    // A banner (role=alert), not a field error — the container also redirects the user into their team.
+    await expect(canvas.getByRole('alert')).toHaveTextContent("You're already on a team.")
+  },
+}
+
+export const GenericError: Story = {
+  args: {
+    error: new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.'),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('alert')).toHaveTextContent('Something went wrong creating your team.')
+  },
+}

--- a/app/src/features/create-team/ui/CreateTeamForm.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import type { CreateTeamError } from '@shared/api/teams'
+import { suggestSlug } from '../lib/suggest-slug'
+import { validateSlug } from '../lib/validate-slug'
+
+interface CreateTeamFormProps {
+  isPending: boolean
+  /** The typed failure from the last submit, placed by its code (field vs banner); null while clean. */
+  error?: CreateTeamError | null
+  onSubmit: (values: { name: string; slug: string; creationCode: string }) => void
+  /**
+   * Delay before the "still setting up" reassurance line appears while submitting. Exposed only so a
+   * story can force it visible without a real wait; defaults to ~5s to cover the known API cold-start
+   * (#92) — POST /api/teams runs CREATE SCHEMA + Flyway in-request.
+   */
+  reassuranceDelayMs?: number
+}
+
+/**
+ * Presentational create-team form (#158). Prop-only (isPending / error / onSubmit) so every state is a
+ * story with no network; the mutation, navigation, and success side-effects live in the route
+ * container. Owns only local field state and the slug's auto-suggest-until-edited behaviour.
+ *
+ * The slug is validated, not derived: it is auto-suggested from the name until the user edits it (a
+ * dirty flag then stops the sync), and validated client-side against the same contract the backend
+ * enforces so a bad address is caught before submit.
+ */
+export function CreateTeamForm({ isPending, error, onSubmit, reassuranceDelayMs = 5000 }: CreateTeamFormProps) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+  const [slugDirty, setSlugDirty] = useState(false)
+  const [creationCode, setCreationCode] = useState('')
+  const [reassuranceElapsed, setReassuranceElapsed] = useState(false)
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    // Auto-suggest a slug from the name until the user takes over the address field.
+    if (!slugDirty) setSlug(suggestSlug(value))
+  }
+
+  // While a submit is in flight, reveal the reassurance line after the delay. The timer is only armed
+  // when pending; the elapsed flag is reset in cleanup (when pending clears), so each submit waits
+  // afresh. Display is additionally gated by isPending below.
+  useEffect(() => {
+    if (!isPending) return
+    const timer = setTimeout(() => setReassuranceElapsed(true), reassuranceDelayMs)
+    return () => {
+      clearTimeout(timer)
+      setReassuranceElapsed(false)
+    }
+  }, [isPending, reassuranceDelayMs])
+
+  const clientSlugError = slug.length > 0 ? validateSlug(slug) : null
+  const canSubmit =
+    name.trim().length > 0 && creationCode.trim().length > 0 && clientSlugError === null && slug.length > 0 && !isPending
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    // Hard double-submit guard: a second submit against the same (now-consumed) code must be impossible.
+    if (!canSubmit) return
+    onSubmit({ name: name.trim(), slug, creationCode: creationCode.trim() })
+  }
+
+  const placed = (...codes: CreateTeamError['code'][]) =>
+    error && codes.includes(error.code) ? error.message : null
+  const nameError = placed('INVALID_NAME')
+  const slugError = placed('INVALID_SLUG', 'SLUG_TAKEN') ?? clientSlugError
+  const codeError = placed('INVALID_CREATION_CODE')
+  const bannerError = placed('ALREADY_IN_TEAM', 'GENERIC')
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {bannerError && (
+        <p role="alert" className="text-sm text-destructive">
+          {bannerError}
+        </p>
+      )}
+
+      <div>
+        <Label htmlFor="team-name">Team name</Label>
+        <Input
+          id="team-name"
+          value={name}
+          disabled={isPending}
+          onChange={(e) => handleNameChange(e.target.value)}
+          placeholder="e.g. Tovo Heren 4"
+        />
+        {nameError && <p className="mt-1 text-sm text-destructive">{nameError}</p>}
+      </div>
+
+      <div>
+        <Label htmlFor="team-slug">Team address</Label>
+        <Input
+          id="team-slug"
+          value={slug}
+          disabled={isPending}
+          onChange={(e) => {
+            setSlug(e.target.value)
+            setSlugDirty(true)
+          }}
+          placeholder="tovo-heren-4"
+        />
+        {slugError && <p className="mt-1 text-sm text-destructive">{slugError}</p>}
+      </div>
+
+      <div>
+        <Label htmlFor="creation-code">Creation code</Label>
+        <Input
+          id="creation-code"
+          value={creationCode}
+          disabled={isPending}
+          onChange={(e) => setCreationCode(e.target.value)}
+          placeholder="Enter your creation code"
+        />
+        {codeError && <p className="mt-1 text-sm text-destructive">{codeError}</p>}
+      </div>
+
+      <Button type="submit" disabled={!canSubmit}>
+        {isPending ? 'Creating your team…' : 'Create team'}
+      </Button>
+      {isPending && reassuranceElapsed && (
+        <p className="text-sm text-muted-foreground">
+          Setting up your team's space — this can take a few seconds…
+        </p>
+      )}
+    </form>
+  )
+}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
+import { Route as CreateTeamIndexRouteImport } from './routes/create-team/index'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as MembersIndexRouteImport } from './routes/members/index'
@@ -32,6 +33,11 @@ const LoginRoute = LoginRouteImport.update({
 const AuthVerifyRoute = AuthVerifyRouteImport.update({
   id: '/auth/verify',
   path: '/auth/verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CreateTeamIndexRoute = CreateTeamIndexRouteImport.update({
+  id: '/create-team/',
+  path: '/create-team/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const EventsEventIdRoute = EventsEventIdRouteImport.update({
@@ -72,6 +78,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/team/settings': typeof TeamSettingsRoute
+  '/create-team/': typeof CreateTeamIndexRoute
   '/members/': typeof MembersIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -83,6 +90,7 @@ export interface FileRoutesByTo {
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/team/settings': typeof TeamSettingsRoute
+  '/create-team': typeof CreateTeamIndexRoute
   '/members': typeof MembersIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/welcome': typeof WelcomeIndexRoute
@@ -95,6 +103,7 @@ export interface FileRoutesById {
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/team/settings': typeof TeamSettingsRoute
+  '/create-team/': typeof CreateTeamIndexRoute
   '/members/': typeof MembersIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -108,6 +117,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/invite/$token'
     | '/team/settings'
+    | '/create-team/'
     | '/members/'
     | '/profile/'
     | '/welcome/'
@@ -119,6 +129,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/invite/$token'
     | '/team/settings'
+    | '/create-team'
     | '/members'
     | '/profile'
     | '/welcome'
@@ -130,6 +141,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/invite/$token'
     | '/team/settings'
+    | '/create-team/'
     | '/members/'
     | '/profile/'
     | '/welcome/'
@@ -142,6 +154,7 @@ export interface RootRouteChildren {
   EventsEventIdRoute: typeof EventsEventIdRoute
   InviteTokenRoute: typeof InviteTokenRoute
   TeamSettingsRoute: typeof TeamSettingsRoute
+  CreateTeamIndexRoute: typeof CreateTeamIndexRoute
   MembersIndexRoute: typeof MembersIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
   WelcomeIndexRoute: typeof WelcomeIndexRoute
@@ -168,6 +181,13 @@ declare module '@tanstack/react-router' {
       path: '/auth/verify'
       fullPath: '/auth/verify'
       preLoaderRoute: typeof AuthVerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/create-team/': {
+      id: '/create-team/'
+      path: '/create-team'
+      fullPath: '/create-team/'
+      preLoaderRoute: typeof CreateTeamIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/events/$eventId': {
@@ -222,6 +242,7 @@ const rootRouteChildren: RootRouteChildren = {
   EventsEventIdRoute: EventsEventIdRoute,
   InviteTokenRoute: InviteTokenRoute,
   TeamSettingsRoute: TeamSettingsRoute,
+  CreateTeamIndexRoute: CreateTeamIndexRoute,
   MembersIndexRoute: MembersIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
   WelcomeIndexRoute: WelcomeIndexRoute,

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -31,6 +31,14 @@ export const Route = createRootRoute({
     }
     if (!user) throw redirect({ to: '/login' })
 
+    // Has-a-team gate: an authenticated but teamless user is a first-class state — route them to
+    // /create-team, and do it BEFORE the onboarding gate's tenant-scoped /members/me probe (which
+    // would 403 NO_TEAM_MEMBERSHIP and bounce them to /login). /create-team is exempt so it can render
+    // (mirroring how /welcome is exempt from the onboarding gate below). Teamlessness is read from the
+    // explicit team field, not inferred from role == null (permission vs membership; see #26).
+    if (location.pathname === '/create-team' || location.pathname === '/create-team/') return
+    if (!user.team) throw redirect({ to: '/create-team' })
+
     // Onboarding gate: a confirmed member who hasn't completed onboarding is routed to /welcome
     // before any app screen mounts. /welcome itself is exempt (below) so the flow can render; the
     // auth routes are already exempt (returned above). Read /members/me through the cache — race-

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { authMeQueryOptions } from '@shared/api/auth'
+import { queryClient } from '@shared/api/query-client'
+import { CreateTeamError, useCreateTeam } from '@shared/api/teams'
+import { CreateTeamForm } from '@features/create-team/ui/CreateTeamForm'
+
+export const Route = createFileRoute('/create-team/')({
+  // Reachable only by an authenticated, teamless user. A user who already has a team is bounced home
+  // (the root gate exempts /create-team from its has-a-team redirect, so this self-guard owns that).
+  beforeLoad: async () => {
+    const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
+    if (!user) throw redirect({ to: '/login' })
+    if (user.team) throw redirect({ to: '/' })
+  },
+  component: CreateTeamPage,
+})
+
+function CreateTeamPage() {
+  const navigate = useNavigate()
+  const client = useQueryClient()
+  const createTeam = useCreateTeam()
+  const error = createTeam.error instanceof CreateTeamError ? createTeam.error : null
+
+  return (
+    <div className="mx-auto mt-10 max-w-sm">
+      <h1 className="font-display text-2xl font-bold">Create your team</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Enter your creation code and name your team — you'll be its admin.
+      </p>
+      <div className="mt-6">
+        <CreateTeamForm
+          isPending={createTeam.isPending}
+          error={error}
+          onSubmit={(values) =>
+            createTeam.mutate(values, {
+              onSuccess: async (team) => {
+                if (!team) return
+                // Feed the X-Team-Id test shim + future multi-team; prod resolves tenant from session.
+                localStorage.setItem('teamId', team.id)
+                // Refetch /auth/me so `team` is non-null before we navigate — both gates then pass.
+                await client.invalidateQueries({ queryKey: ['auth', 'me'] })
+                // A brand-new team is empty: /members is where the owner's first jobs live (curate
+                // positions, invite people), not the events home.
+                navigate({ to: '/members' })
+              },
+              onError: async (err) => {
+                // Already-in-team race: send the user into the team they already have.
+                if (err instanceof CreateTeamError && err.code === 'ALREADY_IN_TEAM') {
+                  await client.invalidateQueries({ queryKey: ['auth', 'me'] })
+                  navigate({ to: '/' })
+                }
+              },
+            })
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/src/shared/api/teams.test.ts
+++ b/app/src/shared/api/teams.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { toCreateTeamError } from './teams'
+
+describe('toCreateTeamError', () => {
+  it('maps 403 to an invalid-creation-code error (field: code)', () => {
+    const err = toCreateTeamError(403, 'INVALID_CREATION_CODE')
+    expect(err.code).toBe('INVALID_CREATION_CODE')
+  })
+
+  it('maps 409 ALREADY_IN_TEAM to a banner error', () => {
+    expect(toCreateTeamError(409, 'ALREADY_IN_TEAM').code).toBe('ALREADY_IN_TEAM')
+  })
+
+  it('maps any other 409 (backend TEAM_SLUG_TAKEN) to a slug-taken error', () => {
+    expect(toCreateTeamError(409, 'TEAM_SLUG_TAKEN').code).toBe('SLUG_TAKEN')
+    expect(toCreateTeamError(409, undefined).code).toBe('SLUG_TAKEN')
+  })
+
+  it('maps 400 INVALID_NAME and INVALID_SLUG to their field errors', () => {
+    expect(toCreateTeamError(400, 'INVALID_NAME').code).toBe('INVALID_NAME')
+    expect(toCreateTeamError(400, 'INVALID_SLUG').code).toBe('INVALID_SLUG')
+  })
+
+  it('maps a codeless 400 and any 5xx to a generic, retry-safe banner', () => {
+    expect(toCreateTeamError(400, undefined).code).toBe('GENERIC')
+    expect(toCreateTeamError(500, undefined).code).toBe('GENERIC')
+    expect(toCreateTeamError(503, undefined).code).toBe('GENERIC')
+  })
+})

--- a/app/src/shared/api/teams.ts
+++ b/app/src/shared/api/teams.ts
@@ -1,0 +1,71 @@
+import { useMutation } from '@tanstack/react-query'
+import { api } from './wirespec-client'
+
+// Re-export the generated contract type so the app has a single source of truth.
+export type { Team } from './generated/model/Team'
+
+// Create-team can fail in ways the form must place differently: some inline on a specific field
+// (recoverable), some as a screen banner. The stable frontend code drives that placement + copy; it is
+// mapped from the backend's (status, discriminator) by toCreateTeamError so the mapping is unit-tested.
+export type CreateTeamErrorCode =
+  | 'INVALID_CREATION_CODE'
+  | 'SLUG_TAKEN'
+  | 'INVALID_SLUG'
+  | 'INVALID_NAME'
+  | 'ALREADY_IN_TEAM'
+  | 'GENERIC'
+
+export class CreateTeamError extends Error {
+  constructor(
+    public readonly code: CreateTeamErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'CreateTeamError'
+  }
+}
+
+/**
+ * Maps a failed create-team response to a typed [CreateTeamError]. Pure and exported so it can be
+ * unit-tested against the backend's contract (#158): 403 → invalid code; 409 → already-in-team (banner)
+ * vs slug-taken (inline); 400 → invalid name/slug (inline); anything else → a generic, retry-safe
+ * banner. The backend's 409 slug code is TEAM_SLUG_TAKEN; everything else on a 409 is a slug clash.
+ */
+export function toCreateTeamError(status: number, code: string | undefined): CreateTeamError {
+  if (status === 403) {
+    return new CreateTeamError('INVALID_CREATION_CODE', "That creation code isn't valid.")
+  }
+  if (status === 409) {
+    if (code === 'ALREADY_IN_TEAM') return new CreateTeamError('ALREADY_IN_TEAM', "You're already on a team.")
+    return new CreateTeamError('SLUG_TAKEN', 'That address is already taken — try another.')
+  }
+  if (status === 400) {
+    if (code === 'INVALID_NAME') return new CreateTeamError('INVALID_NAME', 'Enter a team name.')
+    if (code === 'INVALID_SLUG') {
+      return new CreateTeamError('INVALID_SLUG', 'Use lowercase letters, numbers, and hyphens.')
+    }
+  }
+  return new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.')
+}
+
+export interface CreateTeamInput {
+  name: string
+  slug: string
+  creationCode: string
+}
+
+// The success side-effects (localStorage teamId, invalidating ['auth','me'], navigation) live in the
+// route container per #158 — this hook only performs the request and normalises failures.
+export function useCreateTeam() {
+  return useMutation({
+    mutationFn: async ({ name, slug, creationCode }: CreateTeamInput) => {
+      const res = await api.CreateTeam({ body: { name, slug, creationCode } }).catch(() => {
+        // A fetch/network failure never reaches a status — surface it as a retry-safe banner.
+        throw new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.')
+      })
+      if (res.status === 201) return res.body
+      const code = (res.body as { code?: string } | undefined)?.code
+      throw toCreateTeamError(res.status, code)
+    },
+  })
+}

--- a/app/src/shared/api/wirespec-client.test.ts
+++ b/app/src/shared/api/wirespec-client.test.ts
@@ -61,12 +61,12 @@ describe('wirespec-client adapter', () => {
       expect(headerOf(fetchMock, 'X-Team-Id')).toBe('team_test')
     })
 
-    it('falls back to the default team id when none is stored', async () => {
+    it('omits the X-Team-Id header entirely when no team is stored (a teamless user has no default)', async () => {
       const fetchMock = stubFetch(fakeResponse({ status: 200, body: JSON.stringify({ events: [] }) }))
 
       await api.ListEvents({ 'include-past': false })
 
-      expect(headerOf(fetchMock, 'X-Team-Id')).toBe('setpoint_vt')
+      expect(headerOf(fetchMock, 'X-Team-Id')).toBeUndefined()
     })
   })
 

--- a/app/src/shared/api/wirespec-client.ts
+++ b/app/src/shared/api/wirespec-client.ts
@@ -25,7 +25,9 @@ const serialization: Wirespec.Serialization = {
 // lives on app.teambalance.nl. There is no mock runtime — dev talks to the real backend.
 const handler = async (req: Wirespec.RawRequest): Promise<Wirespec.RawResponse> => {
   const baseUrl = import.meta.env.VITE_API_URL ?? ''
-  const teamId = localStorage.getItem('teamId') ?? 'setpoint_vt'
+  // The team context header (a test-profile shim; prod/e2e resolve tenant from the session). Omitted
+  // entirely when unset — a teamless user (pre-create-team) has no team, and there is no default team.
+  const teamId = localStorage.getItem('teamId')
   const query = new URLSearchParams(req.queries).toString()
   const url = `${baseUrl}/${req.path.join('/')}${query ? `?${query}` : ''}`
 
@@ -35,7 +37,7 @@ const handler = async (req: Wirespec.RawRequest): Promise<Wirespec.RawResponse> 
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      'X-Team-Id': teamId,
+      ...(teamId ? { 'X-Team-Id': teamId } : {}),
       ...req.headers,
     },
     body: req.body,

--- a/app/src/shared/stores/user-store.test.ts
+++ b/app/src/shared/stores/user-store.test.ts
@@ -18,6 +18,7 @@ describe('user-store', () => {
       email: 'alice@example.com',
       displayName: 'Alice',
       role: 'ADMIN',
+      team: undefined,
     }
 
     useUserStore.getState().setCurrentUser(user)
@@ -36,6 +37,7 @@ describe('user-store', () => {
       email: 'bob@example.com',
       displayName: 'Bob',
       role: undefined,
+      team: undefined,
     })
 
     expect(useUserStore.getState().role).toBeNull()
@@ -47,6 +49,7 @@ describe('user-store', () => {
       email: 'alice@example.com',
       displayName: 'Alice',
       role: 'ADMIN',
+      team: undefined,
     })
 
     useUserStore.getState().setCurrentUser(null)


### PR DESCRIPTION
Implements **#158 — polished create-team screen** (code-gated self-service · editable slug · teamless gate), built on top of **Slice 2 (#165, now merged to main)**.

A logged-in-but-**teamless** user enters a creation code + team name + **editable slug**, creates their team, becomes its ADMIN, and lands on `/members` inside it. "Logged-in but teamless" becomes a first-class, non-bouncing app state for the first time.

## Backend — amends #165's contract (the #158 deviation from #154 Slice 2)

Per the coordination note on #154, #158's build amends the create-team contract (safe — every consumer is internal):

- **`POST /api/teams` now takes `{ name, slug, creationCode }`** with a **user-editable, validated-not-derived** slug. `TeamNaming.derive` → `TeamNaming.validate(name, slug)` (format `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤58 so `team_`+slug stays within the 63-byte identifier cap). The tenant schema name is the only thing still derived, from the validated slug.
- **Field-level 400 codes** `INVALID_SLUG` / `INVALID_NAME` via a new coded `BadRequestException` (mirrors the existing `ForbiddenException`/`ConflictException` code convention; generic 400s stay codeless). The 409s (`TEAM_SLUG_TAKEN`, `ALREADY_IN_TEAM`) and opaque 403 (`INVALID_CREATION_CODE`) are inherited from #165 unchanged.
- **`/auth/me` gains `team: { id, name, slug } | null`** — the has-a-team gate signal, resolved through `AuthService.findTeamFor` so the `interfaces` layer takes **no new port dependency** (ADR-0018). Teamlessness is read from this field, never inferred from `role == null` (#26).

## Frontend (#158)

- **New has-a-team route gate** in `__root.tsx`, ordered **before** the onboarding gate: a teamless user is routed to `/create-team` *before* any tenant-scoped probe (fixes the old 403 `NO_TEAM_MEMBERSHIP` → `/login` bounce). `/create-team` is exempt, mirroring `/welcome`.
- **`features/create-team`**: prop-only `CreateTeamForm` (slug auto-suggested from name until edited; delayed cold-start reassurance line) + pure `validate-slug` / `suggest-slug` libs. The route container owns the mutation + success side-effects (`localStorage teamId`, invalidate `['auth','me']`, navigate `/members`).
- **`shared/api/teams.ts`**: `useCreateTeam` + a typed `CreateTeamError` mapper.
- Deleted the `?? 'setpoint_vt'` fallback in `wirespec-client` (the `X-Team-Id` header is omitted when unset).

## Tests — lowest layer that proves it

- **Backend**: `TeamNamingTest` + `TeamServiceTest` flipped to the validated slug; `CreateTeamControllerIT` updated (+ `INVALID_SLUG` / `INVALID_NAME` cases). `make test-api` + `:api:detekt` green.
- **Frontend**: **8 Storybook stories** for `CreateTeamForm` (prop-contract `fn()` spies per ADR-0017); **3 Vitest units** (`validate-slug`, `suggest-slug`, error mapper). Updated the 3 sanctioned MSW tests' `/auth/me` mocks for the new `team` field (**no 4th MSW test added**).
- **e2e**: **one new real flow** (`create-team.spec.ts`) — the cross-tenant-provisioning + code-gate seam #154 Slice 3 justified. It **replaces** the never-built Slice-3 plain-HTML tracer, so net e2e count is unchanged. `make e2e` green (all 8 specs).

## Not in scope (own follow-ups)

Slice 4 (codes-CRUD UI) and Slice 5 (ADR-0015 + runbook) are untouched. Slice 2 hardening (notifications, `PlatformAdminGuard`, `sport` drop) landed in #165 and is inherited as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GP9qZV3stbGx4tcsUUVfDQ



https://github.com/user-attachments/assets/66af6b16-2137-4cc2-9ed2-42a36a50f439


