### PR TITLE
feat(api): let any active member read the roster (B0, #159)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/MemberController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/MemberController.kt
@@ -37,7 +37,7 @@ class MemberController(
     override suspend fun listMembers(request: ListMembers.Request): ListMembers.Response<*> {
         val caller = currentUserGateway.requireCurrentUserId()
         val teamId = currentTeamGateway.requireCurrentTeamId()
-        authorizationService.requireAdmin(caller, teamId)
+        authorizationService.requireMember(caller, teamId)
         return ListMembers.Response200(MemberList(memberService.listMembers(teamId).map { it.toDto() }))
     }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
@@ -170,10 +170,20 @@ class MemberControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.members.length()").value(2))
         }
 
-        test("GET /api/members as a non-admin returns 403") {
+        test("GET /api/members as a non-admin returns the roster — any active member may read it") {
             seedTeam(janRole = "USER")
 
             listMembersAs(JAN_USER_ID)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                // Relative assertion: the shared Testcontainers DB accumulates membership across specs,
+                // so assert the caller is present rather than an absolute roster size.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.members[?(@.userId == '$JAN_USER_ID')]").exists())
+        }
+
+        test("DELETE /api/members/{otherUserId} by a non-admin is rejected with 403") {
+            seedTeam(janRole = "USER")
+
+            removeMemberAs(JAN_USER_ID, LISA_USER_ID)
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 


### PR DESCRIPTION
## What

Slice **B0** of finding **F1** from #159 — the prerequisite backend change for a member-facing "Team" roster page.

`ListMembers` now gates on `authorizationService.requireMember(caller, teamId)` instead of `requireAdmin`. Any **active** team member can now read the roster; roster **mutations** stay admin-only.

```diff
-        authorizationService.requireAdmin(caller, teamId)
+        authorizationService.requireMember(caller, teamId)
```

`requireMember` asserts active membership, is fail-closed, and throws `NoTeamMembershipException` for non-members — same security contract (`caller` = authenticated principal, `teamId` = server-resolved tenant; both sources unchanged).

## Scope guard rails

- **Untouched:** `updateMember`, `removeMember`, and the positions/`ManagePositions` endpoints. Their admin/self guards live in `MemberService` and stay exactly as-is. A `403` remains a valid response for the mutation endpoints.
- **Privacy (reviewed & approved):** the roster is now visible to every team member, *including* each member's `role` — the admin badge is intentionally shown to everyone. The roster DTO leaks **no email**: `toDto()` maps `Member(userId, displayName, role, position, onboarded)` only. No PII exposed.
- **Contract:** shape is UNCHANGED (`ListMembers` → `MemberList`); only authorization relaxes. No Wirespec regen.

## Test (Testcontainers IT, no mocks)

Extended `MemberControllerIT` to prove the new authz boundary:
- A non-admin (regular) member `GET /api/members` → **200** with the roster (asserted **relative** — the caller is present in the roster — because the shared Testcontainers DB accumulates membership across specs; no absolute counts).
- That same non-admin still gets **403** on `PUT` (updateMember) and **403** on `DELETE` (removeMember) of another member.
- Admin still **200** on list, update, and delete (pre-existing tests, unchanged).

TDD red→green verified:
- **RED** (before the one-line change): `GET /api/members as a non-admin returns the roster` FAILED at the `isOk` assertion (non-admin still got 403); other 14 tests passed.
- **GREEN** (after): all 16 tests in the spec pass.

## Verification (from repo root)

```
make test-api  → BUILD SUCCESSFUL
make lint      → BUILD SUCCESSFUL (detekt + flock/ArchUnit boundaries + eslint)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdU9u5nE5ue3zLC9WoSQgP