### PR TITLE
refactor(api): make the auth/onboarding services framework-free (#80)

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -16,8 +16,6 @@
     <ID>DomainNoFrameworkImports:CreationCodeAdminService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
-    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.beans.factory.annotation.Value</ID>
-    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
     <ID>DomainNoFrameworkImports:TeamService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -16,7 +16,6 @@
     <ID>DomainNoFrameworkImports:CreationCodeAdminService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
-    <ID>DomainNoFrameworkImports:InvitationService.kt:import org.springframework.transaction.annotation.Transactional</ID>
     <ID>DomainNoFrameworkImports:TeamService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>

--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -13,8 +13,6 @@
     <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
     <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>
-    <ID>DomainNoFrameworkImports:AuthService.kt:import org.springframework.stereotype.Service</ID>
-    <ID>DomainNoFrameworkImports:AuthorizationService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:CreationCodeAdminService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -10,7 +10,6 @@ import com.github.zzave.teambalance.api.domain.port.EmailSender
 import com.github.zzave.teambalance.api.domain.port.MagicLinkTokenRepository
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import com.github.zzave.teambalance.api.domain.port.UserRepository
-import org.springframework.stereotype.Service
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Clock
@@ -19,7 +18,6 @@ import java.time.Instant
 import java.util.Base64
 import java.util.UUID
 
-@Service
 class AuthService(
     private val magicLinkTokenRepository: MagicLinkTokenRepository,
     private val userRepository: UserRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -6,7 +6,6 @@ import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
-import org.springframework.stereotype.Service
 import java.util.UUID
 
 /**
@@ -21,7 +20,6 @@ import java.util.UUID
  * The check is fail-closed: a missing, inactive, or wrong-team membership yields no role and is
  * therefore neither a member nor an admin.
  */
-@Service
 class AuthorizationService(
     private val teamMemberRepository: TeamMemberRepository,
 ) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -7,8 +7,6 @@ import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Service
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Clock
@@ -20,15 +18,15 @@ import java.util.UUID
 /** The plaintext invite token (shown to the admin once) plus its expiry. Never persisted. */
 data class GeneratedInvitation(val token: InviteToken, val expiresAt: Instant)
 
-@Service
 class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val teamMemberRepository: TeamMemberRepository,
     private val authorizationService: AuthorizationService,
     private val clock: Clock,
-    // App-wide secret mixed into the token hash. Supplied via INVITATION_TOKEN_SALT in live
-    // environments (see application.yml); dev and test use a hardcoded value.
-    @Value("\${teambalance.invitation.token-salt}") private val tokenSalt: String,
+    // App-wide secret mixed into the token hash. Read from teambalance.invitation.token-salt by the
+    // composition root — INVITATION_TOKEN_SALT in live environments (see application.yml), a
+    // hardcoded value in dev and test.
+    private val tokenSalt: String,
 ) {
     companion object {
         // Invite links don't expire on a timer by default in v1 — an admin rotates/expires

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
@@ -1,0 +1,44 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.AuthService
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.domain.port.EmailSender
+import com.github.zzave.teambalance.api.domain.port.MagicLinkTokenRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Composition root for the **auth** area (ADR-0018), sibling to [EventCompositionRoot]: who is
+ * calling ([AuthService], magic-link sign-in) and what they are allowed to do
+ * ([AuthorizationService], team-scoped role checks). The two belong together because both answer a
+ * question about the caller rather than about team data, and neither owns a repository the other
+ * needs.
+ *
+ * [AuthorizationService] is the one service every other area depends on — the sibling roots take it
+ * as a constructor parameter and Spring resolves it to the bean declared here.
+ */
+@Configuration
+class AuthCompositionRoot {
+
+    @Bean
+    fun authService(
+        magicLinkTokenRepository: MagicLinkTokenRepository,
+        userRepository: UserRepository,
+        teamRepository: TeamRepository,
+        emailSender: EmailSender,
+        clock: Clock,
+    ) = AuthService(
+        magicLinkTokenRepository = magicLinkTokenRepository,
+        userRepository = userRepository,
+        teamRepository = teamRepository,
+        emailSender = emailSender,
+        clock = clock,
+    )
+
+    @Bean
+    fun authorizationService(teamMemberRepository: TeamMemberRepository) = AuthorizationService(teamMemberRepository)
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InvitationCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InvitationCompositionRoot.kt
@@ -1,0 +1,38 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.AuthorizationService
+import com.github.zzave.teambalance.api.application.InvitationService
+import com.github.zzave.teambalance.api.domain.port.InvitationRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Composition root for the **invitation** area (ADR-0018), sibling to [MembershipCompositionRoot]:
+ * minting, rotating and accepting the links by which someone joins a team. Its own root rather than
+ * part of the membership area because an invite link is a credential — it carries a salted token
+ * hash and an admin-only mint path that the roster services know nothing about.
+ *
+ * Reading the token salt from configuration is this root's job: [InvitationService] takes the secret
+ * as a plain constructor argument and never learns where it came from.
+ */
+@Configuration
+class InvitationCompositionRoot {
+
+    @Bean
+    fun invitationService(
+        invitationRepository: InvitationRepository,
+        teamMemberRepository: TeamMemberRepository,
+        authorizationService: AuthorizationService,
+        clock: Clock,
+        @Value("\${teambalance.invitation.token-salt}") tokenSalt: String,
+    ) = InvitationService(
+        invitationRepository = invitationRepository,
+        teamMemberRepository = teamMemberRepository,
+        authorizationService = authorizationService,
+        clock = clock,
+        tokenSalt = tokenSalt,
+    )
+}


### PR DESCRIPTION
Closes #80. Wave 4 of the flock-detekt hexagonal-enforcement epic (#17) — and the last rollout slice: **all nine services from the PRD are now framework-free.**

`AuthService`, `AuthorizationService` and `InvitationService` lose `@Service`/`@Value` and are constructed by composition roots in `infrastructure/config`, following the pattern #20 established and #21 replicated.

## Commits (one logical change each, full pre-commit gate on every one, no `--no-verify`)

| | |
|---|---|
| `393be63` | `AuthService` + `AuthorizationService` framework-free (+ `AuthCompositionRoot`) |
| `245a821` | `InvitationService` framework-free (+ `InvitationCompositionRoot`) |
| `04bf874` | drop the stale `InvitationService` `Transactional` baseline entry |

## Acceptance

- [x] Auth, Authorization, Invitation have no Spring annotations/imports; constructed via composition roots.
- [x] `InvitationService`'s `@Value` config supplied explicitly through the composition root.
- [x] Transactional behaviour preserved (rotate/expire invite, magic-link sign-in stay atomic), verified through the REST boundary.
- [x] Their framework-import baseline entries removed; `:api:detekt` stays green.
- [x] Spring context boots; auth/invite endpoints work end-to-end.

## Two new composition roots (a judgment call — overrule freely)

- **`AuthCompositionRoot`** — `authService` + `authorizationService`. They share an area because both answer a question about the *caller* (who is this / what may they do) rather than about team data. `AuthorizationService` is the service every other area depends on; the five sibling roots keep taking it as a constructor parameter and Spring now resolves it to this `@Bean` instead of a component-scanned `@Service`. **No call site changed.**
- **`InvitationCompositionRoot`** — on its own rather than inside `MembershipCompositionRoot`, because an invite link is a *credential* (salted token hash, admin-only mint path) that the roster services know nothing about. Folding it into Membership is a one-line move if you'd rather have five roots than six.

## The `@Value` moved, it was not wrapped

The bean method carries `@Value("\${teambalance.invitation.token-salt}")` and hands the secret in as a plain `String`. The service takes an ordinary constructor argument and never learns where it came from — no config-holder class, no port for a string.

## No transactional work remained — #20's prediction held exactly

None of the three carried `@Transactional`: invite rotation went behind `InvitationRepository.rotate` in #20, and the magic-link token consume behind `MagicLinkTokenRepository.consumeAndResolveUser` in #160/#169. So **#20's read-boundary hazard does not apply** — no service lost an annotation and no adapter read path changed. Verified rather than assumed: `MagicLinkSignInBoundaryIT` and `InvitationRotationBoundaryIT`, the two tests that pin those guarantees, both still pass.

## Baseline 59 → 54, and the stale-entry gap is finally zero

Four live entries removed (`AuthService` `@Service`, `AuthorizationService` `@Service`, `InvitationService` `@Service` + `@Value`), **plus** the known-stale `DomainNoFrameworkImports:InvitationService.kt:...Transactional` entry that #22, #21 and #23 each flagged and left for "#80 or #24". It gets its own commit.

Measured, not asserted: with the baseline emptied this branch reports **exactly 54 live violations against 54 entries** — the 1-entry gap every previous run measured is closed. And the removals are proven load-bearing: re-adding `@Service` to `AuthService` fails `:api:detekt` at `AuthService.kt:13`, then reverted → green. That doubles as proof detekt really analyses on its ~1s cached runs.

## ⚠️ A blocker for #24 found here — flagged, deliberately not fixed

`main` has grown **two services since this PRD was written**, both `@Service`-annotated and both baselined:

- `TeamService` (#158, create-team) — `DomainNoFrameworkImports` + 2 primitive-obsession entries
- `CreationCodeAdminService` (#154, creation codes) — `DomainNoFrameworkImports`

plus four more new primitive-obsession entries (`TeamNames` name/schemaName/slug, `TeamSummary` name/slug, `TeamCreationCode.code`) that #23's VO rollout never saw.

They are outside #80's named scope, and silently widening a rollout ticket is how a refactor stops being reviewable — so I left them. But **#24 cannot reach its zero-baseline definition of done until they are handled.** Your call: fold them into #24, or open a #80-shaped follow-up. (Related: the baseline was 53 when #23 delivered and 59 when #80 started — #24 should re-count against `main` rather than trust a number in the plan.)

## Verification

- `./gradlew :api:detekt` green after every slice; baseline 54 entries.
- `:api:test` **356/356 across 59 classes**, run with `--rerun-tasks` on the final commit and counted from the JUnit XML rather than a `BUILD SUCCESSFUL` line. Includes `MagicLinkSignInBoundaryIT`, `InvitationRotationBoundaryIT`, `MemberEditBoundaryIT`, `InvitationControllerTest`, `AuthControllerTest`, `AttendanceAuthorizationIT`, every `@SpringBootTest` IT (which is what proves the two new roots wire real beans) and the 6 ArchUnit rules.
- `test-app` 54 files / 301 tests.
- Real full-stack Playwright **8/8** (`./scripts/e2e.sh`): magic-link login, invite onboarding, create-team, attendance toggle, auth guard, logout — every endpoint served by the three rewired services.
- **No test file was touched.** The unit tests already constructed all three services directly — itself the evidence they were plain classes wearing an annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)