### PR TITLE
fix(app): loading + error shells on the events surfaces (F5, F6, #159)

### DIFF
--- a/app/src/entities/event/ui/EventDetailSkeleton.stories.tsx
+++ b/app/src/entities/event/ui/EventDetailSkeleton.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import { EventDetailSkeleton } from './EventDetailSkeleton'
+
+// The loading placeholder for the event detail route. It renders a labelled status region (no
+// network) so screen readers announce "Loading event" and Chromatic baselines the shimmer layout.
+const meta = {
+  title: 'entities/event/EventDetailSkeleton',
+  component: EventDetailSkeleton,
+} satisfies Meta<typeof EventDetailSkeleton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('status', { name: /loading event/i })).toBeInTheDocument()
+  },
+}

--- a/app/src/entities/event/ui/EventDetailSkeleton.tsx
+++ b/app/src/entities/event/ui/EventDetailSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from '@shared/ui/skeleton'
+
+/**
+ * Loading placeholder for the event detail route — sketches the real layout (header block, response
+ * toggle, tabbed attendee list) so the page shows its shape while the event loads, rather than a
+ * bare "Loading…" line.
+ */
+export function EventDetailSkeleton() {
+  return (
+    <div role="status" aria-label="Loading event">
+      {/* Header block: type icon + badge / title / date */}
+      <div className="mt-2 flex items-start gap-4">
+        <Skeleton className="h-11 w-11 rounded-xl" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-20 rounded-full" />
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      </div>
+
+      {/* Your response toggle */}
+      <div className="mt-6 space-y-3">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-11 w-full rounded-xl" />
+      </div>
+
+      {/* Tabbed attendee list */}
+      <div className="mt-6 overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm">
+        <div className="flex gap-2 border-b border-border/40 p-3">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-5 flex-1 rounded-full" />
+          ))}
+        </div>
+        <div className="divide-y divide-border/40">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-center gap-3 px-3 py-2">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Skeleton className="h-3.5 w-1/3" />
+                <Skeleton className="h-3 w-1/5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/entities/event/ui/EventListView.stories.tsx
+++ b/app/src/entities/event/ui/EventListView.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>
 export const Loading: Story = {
   args: { groups: [], isLoading: true },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('Loading...')).toBeInTheDocument()
+    await expect(canvas.getByRole('status', { name: /loading events/i })).toBeInTheDocument()
   },
 }
 

--- a/app/src/entities/event/ui/EventListView.tsx
+++ b/app/src/entities/event/ui/EventListView.tsx
@@ -1,4 +1,5 @@
 import type { Event } from '@shared/api/events'
+import { Skeleton } from '@shared/ui/skeleton'
 import { EventCard } from './EventCard'
 
 export interface EventGroup {
@@ -28,7 +29,7 @@ export function EventListView({
   // Data wins: keep showing cached events even when a background refetch is loading or has errored,
   // so a transient failure never blanks a list the user is already looking at.
   if (groups.length === 0) {
-    if (isLoading) return <p className="mt-4 text-muted-foreground">Loading...</p>
+    if (isLoading) return <EventListSkeleton />
     if (error) return <p className="mt-4 text-sm text-red-500">Couldn&apos;t load events.</p>
     return <p className="mt-4 text-muted-foreground">{emptyMessage}</p>
   }
@@ -50,5 +51,28 @@ export function EventListView({
         </div>
       ))}
     </>
+  )
+}
+
+/** A few skeleton cards mirroring EventCard's layout, shown while the first page of events loads. */
+function EventListSkeleton() {
+  return (
+    <div className="mt-4 flex flex-col gap-3" role="status" aria-label="Loading events">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="rounded-2xl border border-border/40 bg-card p-4 shadow-sm">
+          <div className="flex items-start gap-3.5">
+            <Skeleton className="h-10 w-10 shrink-0 rounded-xl" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-16 rounded-full" />
+              <Skeleton className="h-5 w-2/3" />
+            </div>
+          </div>
+          <Skeleton className="mt-3 ml-[50px] h-3.5 w-1/2" />
+          <div className="mt-3 border-t border-border/40 pt-3">
+            <Skeleton className="h-6 w-40 rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
   )
 }

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -7,6 +7,8 @@ import { useUserStore } from '@shared/stores/user-store'
 import { Button } from '@shared/ui/button'
 import { EventTypeBadge } from '@entities/event/ui/EventTypeBadge'
 import { EventTypeIcon } from '@entities/event/ui/EventTypeIcon'
+import { EventDetailSkeleton } from '@entities/event/ui/EventDetailSkeleton'
+import { QueryErrorState } from '@shared/ui/QueryErrorState'
 import { ReferenceChips } from '@entities/event/ui/ReferenceChips'
 import { RoleBreakdown } from '@entities/event/ui/RoleBreakdown'
 import { SeriesPeek } from '@entities/event/ui/SeriesPeek'
@@ -54,7 +56,7 @@ function AttendeeRow({ attendance }: { attendance: AttendanceEntry }) {
 
 function EventDetailPage() {
   const { eventId } = Route.useParams()
-  const { data: event, isLoading } = useEvent(eventId)
+  const { data: event, isLoading, isError, refetch } = useEvent(eventId)
   const currentUserId = useUserStore((s) => s.userId)
   const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
   const { mutate, isPending } = useSetAttendance()
@@ -62,7 +64,19 @@ function EventDetailPage() {
   // Only load the full list to find series siblings when this event actually belongs to a group.
   const { data: allEvents } = useEvents(true, !!event?.recurringGroup)
 
-  if (isLoading) return <p className="text-muted-foreground">Loading...</p>
+  if (isLoading) return <EventDetailSkeleton />
+  if (isError)
+    return (
+      <QueryErrorState
+        title="Couldn't load this event"
+        description="Something went wrong on our end. Give it another try."
+        onRetry={() => refetch()}
+      >
+        <Button asChild variant="ghost">
+          <Link to="/">Back to events</Link>
+        </Button>
+      </QueryErrorState>
+    )
   if (!event) return <p>Event not found.</p>
 
   const date = new Date(event.startTime)

--- a/app/src/shared/api/events.ts
+++ b/app/src/shared/api/events.ts
@@ -43,7 +43,9 @@ export function useEvent(id: string) {
     queryKey: ['events', id],
     queryFn: async () => {
       const res = await api.GetEvent({ id })
-      if (res.status === 404) throw new Error('Event not found')
+      // A missing event is a resolved-but-empty result, not a query error, so the detail page can
+      // tell "not found" apart from a real load failure (500/network) and render each distinctly.
+      if (res.status === 404) return null
       return res.body
     },
   })

--- a/app/src/shared/ui/QueryErrorState.stories.tsx
+++ b/app/src/shared/ui/QueryErrorState.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { Link } from '@tanstack/react-router'
+import { withRouter } from '@shared/testing/router-decorator'
+import { Button } from '@shared/ui/button'
+import { QueryErrorState } from './QueryErrorState'
+
+// QueryErrorState is the reusable "we couldn't load this" shell: a heading, an optional line of
+// context, a Retry button that re-runs the failed query, and an optional actions slot (e.g. a Back
+// link). It is distinct from an empty state — a failure is never rendered as "nothing here".
+const meta = {
+  title: 'shared/ui/QueryErrorState',
+  component: QueryErrorState,
+  decorators: [withRouter],
+} satisfies Meta<typeof QueryErrorState>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: "Couldn't load this event",
+    description: 'Something went wrong on our end.',
+    onRetry: fn(),
+  },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText("Couldn't load this event")).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /retry/i }))
+    await expect(args.onRetry).toHaveBeenCalled()
+  },
+}
+
+export const WithBackAction: Story = {
+  args: {
+    title: "Couldn't load this event",
+    onRetry: fn(),
+    children: (
+      <Button asChild variant="ghost">
+        <Link to="/">Back to events</Link>
+      </Button>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: /back to events/i })).toBeInTheDocument()
+  },
+}

--- a/app/src/shared/ui/QueryErrorState.tsx
+++ b/app/src/shared/ui/QueryErrorState.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@shared/ui/button'
+
+interface QueryErrorStateProps {
+  title: string
+  description?: string
+  onRetry: () => void
+  retryLabel?: string
+  /** Extra actions rendered beside Retry — e.g. a Back link. */
+  children?: ReactNode
+}
+
+/**
+ * The shell shown when a query fails to load — distinct from an empty state, so a real failure
+ * never reads as "there's nothing here". Always offers a Retry that re-runs the query; callers pass
+ * any secondary action (a Back link, say) as children.
+ */
+export function QueryErrorState({
+  title,
+  description,
+  onRetry,
+  retryLabel = 'Retry',
+  children,
+}: QueryErrorStateProps) {
+  return (
+    <div role="alert" className="mt-10 flex flex-col items-center gap-4 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10 text-red-500">
+        <AlertTriangle size={22} />
+      </div>
+      <div>
+        <p className="font-display text-lg font-semibold">{title}</p>
+        {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button onClick={onRetry}>{retryLabel}</Button>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/app/src/shared/ui/skeleton.tsx
+++ b/app/src/shared/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+
+import { cn } from "@shared/lib/utils"
+
+/**
+ * A pulsing placeholder block. Compose several to sketch the shape of content that is still
+ * loading, so an async surface shows its layout instead of a bare "Loading…" line.
+ */
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
+}
+
+export { Skeleton }


### PR DESCRIPTION
Bundles findings **F5 + F6** from #159 — proper async-state shells on the events surfaces. Bundled because they touch the same two files; shipping separately would merge-conflict.

## F5 — event detail conflated error with empty (bug)
`routes/events/$eventId.tsx` previously did `if (!event) return "Event not found."`, so a **500/network error** (which left `event` undefined) rendered the misleading *"Event not found."*.

Now the detail renders **three distinct states**:
- **loading** → `EventDetailSkeleton` (layout skeleton, not bare text)
- **error** → `QueryErrorState` shell: *"Couldn't load this event"* + a **Retry** that `refetch()`es + a **Back to events** link
- **not-found** → the genuine *"Event not found."*, kept as its own message

To separate not-found from a real failure, `useEvent` now resolves a **404 → `null`** (a resolved-but-missing result) instead of throwing. A 500/network still throws → `isError` → the error shell. So a real failure **no longer shows "Event not found."**

## F6 — bare-text loaders → skeletons
- New shadcn **`Skeleton`** primitive in `shared/ui/skeleton.tsx` (dependency-free div + Tailwind, matches the kit).
- `$eventId.tsx` loading branch → detail skeleton (header block, response toggle, attendee rows).
- `EventListView` loading branch → a few skeleton event-card rows (was `"Loading..."`).

## Structure / testability (ADR-0017, proportionate)
No full container/View split of the detail page (out of scope). Instead the two new states are small presentational components, each story-covered per the PR gate:
- `entities/event/ui/EventDetailSkeleton.tsx` (+ story) — labelled `role="status"`.
- `shared/ui/QueryErrorState.tsx` (+ story) — reusable error shell; interactive, so its story passes an `fn()` spy for `onRetry` and asserts it fires in `play`. Back action passed as `children` (a `<Link>`), keeping the component generic.
- `EventListView.stories.tsx` Loading story updated to assert the skeleton region. Chromatic re-baselines automatically.

## Testing (PR gate)
Component states (loading/error/empty/data) live at the **Storybook layer** — the lowest that proves them; states are props-driven, no MSW. No new e2e: this introduces **no new seam** not already exercised by existing flows (same route, same query wrapper).

## Verification
- `npm test` → **304 passed (56 files)** — includes the new stories.
- `eslint .` → clean.
- `tsc -b` → clean.

Manual reasoning: with `useEvent` now returning `null` only on 404, a 500/network response throws → `isError === true` → the `QueryErrorState` shell (with Retry + Back) renders. The `!event` (not-found) branch is now reachable **only** via a real 404. The old bug — a failure rendering "Event not found." — is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcxmJxYSob3hvW8EkHQcEj
