### PR TITLE
fix(app): optimistic attendance toggle + error toast (F4, #159)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,7 @@
         "lucide-react": "^1.6.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.12"
       },
@@ -8117,6 +8118,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^1.6.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, redirect, Outlet, Link, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
+import { Toaster } from 'sonner'
 import { Providers } from '@app/providers'
 import { BottomNav } from '@shared/ui/BottomNav'
 import { authMeQueryOptions, useLogout } from '@shared/api/auth'
@@ -159,6 +160,9 @@ function RootLayout() {
         </main>
         <BottomNav />
       </div>
+      {/* App-wide toast primitive. richColors gives the error toast a semantic red; the default
+          light theme matches the app surface (no dark-mode toggle is wired yet). */}
+      <Toaster position="top-center" richColors />
     </Providers>
   )
 }

--- a/app/src/shared/api/attendance-cache.test.ts
+++ b/app/src/shared/api/attendance-cache.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { AttendanceEntry, EventDetail } from './events'
+import { applyOptimisticAttendance } from './attendance-cache'
+
+const attendee = (overrides: Partial<AttendanceEntry> = {}): AttendanceEntry => ({
+  id: 'att-1',
+  userId: 'user-1',
+  displayName: 'Julius',
+  role: 'Spelverdeler',
+  state: 'ATTENDING',
+  ...overrides,
+})
+
+const makeEventDetail = (overrides: Partial<EventDetail> = {}): EventDetail => ({
+  id: 'evt-1',
+  eventType: { id: 'et-1', name: 'Training', color: '#249E6C' },
+  title: 'Training',
+  description: undefined,
+  startTime: '2026-08-10T18:00:00Z',
+  endTime: '2026-08-10T19:30:00Z',
+  location: undefined,
+  references: [],
+  recurringGroup: undefined,
+  attendanceSummary: {
+    attending: 0,
+    maybe: 0,
+    absent: 0,
+    notResponded: 0,
+    roleBreakdown: [],
+  },
+  attendances: [],
+  ...overrides,
+})
+
+describe('applyOptimisticAttendance', () => {
+  it("sets the current user's attendance entry to the new state", () => {
+    const event = makeEventDetail({
+      attendances: [
+        attendee({ userId: 'user-1', state: 'ATTENDING' }),
+        attendee({ id: 'att-2', userId: 'user-2', state: 'MAYBE' }),
+      ],
+    })
+
+    const next = applyOptimisticAttendance(event, 'user-1', 'ABSENT')
+    if (!next) throw new Error('expected a patched event')
+
+    expect(next.attendances.find((a) => a.userId === 'user-1')?.state).toBe('ABSENT')
+    // Other attendees are untouched.
+    expect(next.attendances.find((a) => a.userId === 'user-2')?.state).toBe('MAYBE')
+  })
+
+  it('is a no-op when the user has no entry (a first-time responder carries no row to patch)', () => {
+    const event = makeEventDetail({
+      attendances: [attendee({ userId: 'user-2', state: 'MAYBE' })],
+    })
+
+    const next = applyOptimisticAttendance(event, 'unknown-user', 'ATTENDING')
+    if (!next) throw new Error('expected the event back unchanged')
+
+    expect(next.attendances).toEqual(event.attendances)
+  })
+
+  it('does not mutate the original event or its attendance entry (immutable update)', () => {
+    const original = makeEventDetail({
+      attendances: [attendee({ userId: 'user-1', state: 'ATTENDING' })],
+    })
+    const originalEntry = original.attendances[0]
+
+    const next = applyOptimisticAttendance(original, 'user-1', 'ABSENT')
+    if (!next) throw new Error('expected a patched event')
+
+    expect(next).not.toBe(original)
+    expect(next.attendances).not.toBe(original.attendances)
+    // The original entry object is left exactly as it was.
+    expect(originalEntry.state).toBe('ATTENDING')
+    expect(original.attendances[0].state).toBe('ATTENDING')
+  })
+
+  it('returns null unchanged (nothing cached yet)', () => {
+    expect(applyOptimisticAttendance(undefined, 'user-1', 'ABSENT')).toBeUndefined()
+  })
+})

--- a/app/src/shared/api/attendance-cache.ts
+++ b/app/src/shared/api/attendance-cache.ts
@@ -1,0 +1,26 @@
+import type { AttendanceEntry, EventDetail } from './events'
+
+type AttendanceState = AttendanceEntry['state']
+
+/**
+ * Returns a copy of the cached event detail with the given user's attendance entry set to
+ * `state` — the optimistic patch behind an instant-feeling attendance toggle.
+ *
+ * Only an existing entry is patched: a first-time responder has no row in `attendances`, and the
+ * mutation carries no `displayName`/`role` to synthesise a complete one, so an unknown user is a
+ * no-op (the server reconciliation on `onSettled` fills that case in). The update is immutable —
+ * the original event and its entries are never touched, so a rollback can restore the snapshot.
+ */
+export function applyOptimisticAttendance(
+  event: EventDetail | undefined,
+  userId: string,
+  state: AttendanceState,
+): EventDetail | undefined {
+  if (!event) return event
+  if (!event.attendances.some((a) => a.userId === userId)) return event
+
+  return {
+    ...event,
+    attendances: event.attendances.map((a) => (a.userId === userId ? { ...a, state } : a)),
+  }
+}

--- a/app/src/shared/api/attendances.ts
+++ b/app/src/shared/api/attendances.ts
@@ -1,17 +1,45 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { api } from './wirespec-client'
+import { applyOptimisticAttendance } from './attendance-cache'
+import type { AttendanceEntry, EventDetail } from './events'
+
+type AttendanceState = AttendanceEntry['state']
+
+interface SetAttendanceVars {
+  eventId: string
+  userId: string
+  state: AttendanceState
+}
 
 export function useSetAttendance() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ eventId, userId, state }: { eventId: string; userId: string; state: string }) => {
+    mutationFn: async ({ eventId, userId, state }: SetAttendanceVars) => {
       const res = await api.SetAttendance({ eventId, userId, body: { state } })
       if (res.status === 404) throw new Error('Attendance not found')
       return res.body
     },
-    onSuccess: (_data, variables) => {
+    // Optimistic update: the toggle reflects the tap instantly. Snapshot the cached event so a
+    // failure can roll it back, then reconcile with the server on settle.
+    onMutate: async ({ eventId, userId, state }) => {
+      const eventKey = ['events', eventId]
+      await queryClient.cancelQueries({ queryKey: eventKey })
+      const previousEvent = queryClient.getQueryData<EventDetail>(eventKey)
+      queryClient.setQueryData<EventDetail | undefined>(eventKey, (current) =>
+        applyOptimisticAttendance(current, userId, state),
+      )
+      return { eventKey, previousEvent }
+    },
+    onError: (_error, _variables, context) => {
+      // Restore the pre-tap snapshot so the toggle returns to its real state, then surface the
+      // failure. The re-enabled toggle is the recovery path — tapping again retries.
+      if (context) queryClient.setQueryData(context.eventKey, context.previousEvent)
+      toast.error("Couldn't save your response — tap to try again.")
+    },
+    onSettled: (_data, _error, { eventId }) => {
       queryClient.invalidateQueries({ queryKey: ['events'] })
-      queryClient.invalidateQueries({ queryKey: ['events', variables.eventId] })
+      queryClient.invalidateQueries({ queryKey: ['events', eventId] })
     },
   })
 }


### PR DESCRIPTION
Fixes finding **F4** (P0) from #159 — the attendance toggle failed silently.

## Problem
`useSetAttendance()` had `onSuccess` invalidation but **no optimistic update and no `onError`**. On a failed tap nothing happened — the toggle just re-enabled with no feedback, and even a successful tap only reflected after the refetch round-trip.

## Change
Reworked `useSetAttendance` into an optimistic mutation and added an app-wide toast primitive:

- **`onMutate`** — `cancelQueries(['events', eventId])`, snapshot the cached event detail, and optimistically patch the current user's attendance state in `['events', eventId]` so the toggle reflects the choice **instantly**. Returns the snapshot for rollback.
- **`onError`** — roll back to the snapshot (the toggle returns to its real state) and `toast.error("Couldn't save your response — tap to try again.")`. The re-enabled toggle is the recovery path.
- **`onSettled`** — invalidate `['events']` + `['events', eventId]` to reconcile with the server (the old `onSuccess` invalidation folded in here).
- **No success toast** — the optimistic UI *is* the success feedback; a toast per toggle would be noise.
- Added **`sonner`** and mounted `<Toaster position="top-center" richColors />` **once** in `__root.tsx` inside `<Providers>`. Default light theme matches the app surface (no dark-mode toggle is wired yet); `richColors` gives the error toast a semantic red.

`AttendanceToggle`'s contract (`value` / `onToggle` / `disabled`) and its story are unchanged; `$eventId.tsx` render is untouched (it already passes `disabled={isPending}`). The optimism + toast live entirely in the hook + root Toaster, to avoid colliding with the F5/F6 branch that edits `$eventId.tsx`.

## Testing (lowest layer that proves it)
Per the PR gate + the "Sanctioned MSW/RTL exception" note, **no new RTL/MSW render test and no new e2e** (no new seam; the happy path is already covered by the existing attendance e2e flow).

The meaningful logic — the cache patch — was extracted into a **pure** helper `applyOptimisticAttendance(event, userId, state)` (`shared/api/attendance-cache.ts`) and unit-tested (`attendance-cache.test.ts`, TDD — test written first, watched fail, then implemented):
- patches the current user's entry to the new state, leaving others untouched;
- **unknown user → no-op** (a first-time responder has no row, and the mutation carries no `displayName`/`role` to synthesise one — the `onSettled` refetch fills that case in);
- **immutable** — original event and entries are never mutated (so rollback restores the snapshot);
- `undefined` cache → returned unchanged (the `onMutate` empty-cache case).

### Evidence (all green)
```
tsc -b            → clean
make test-app     → Test Files 55 passed | Tests 305 passed (incl. 4 new)
make lint         → :api:detekt BUILD SUCCESSFUL + eslint clean
vite build        → ✓ built (sonner bundles cleanly)
pre-commit hook   → gradle build + :api:test + npm test all green
```

## Manual verification
Runtime behaviour is established by the pure-unit test (the cache patch) plus the standard TanStack Query optimistic lifecycle traced above, and the static/build gates. A live full-stack click-through was **not** run in this change (needs infra + backend + magic-link login); the recommended reviewer check:
- Toggling attendance updates the toggle **instantly** (optimistic patch of `['events', eventId]`), before the request resolves.
- On a forced failure (e.g. a 5xx / network error from `SetAttendance`), the toggle **rolls back** to its previous state and a **red error toast** appears top-center; tapping again retries.
- No toast appears on a successful toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmZ61mc8dCrvkxLb62ofxt


https://github.com/user-attachments/assets/27bcd140-24f2-4de4-9346-c43ae67a5bc2


