### PR TITLE
fix(build): tolerate missing git binary when resolving hooks dir

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,14 +21,18 @@ allprojects {
 // so the pre-commit gate is enforced for every contributor. The destination is 
 // resolved via `git rev-parse --git-path hooks` rather than
 // hardcoded to `.git/hooks` to support worktrees
-val resolvedHooksDir: String = providers.exec {
-    isIgnoreExitValue = true
-    workingDir = layout.projectDirectory.asFile
-    commandLine("git", "rev-parse", "--git-path", "hooks")
-}.standardOutput.asText.get().trim()
+val resolvedHooksDir: String = runCatching {
+    providers.exec {
+        isIgnoreExitValue = true
+        workingDir = layout.projectDirectory.asFile
+        commandLine("git", "rev-parse", "--git-path", "hooks")
+    }.standardOutput.asText.get().trim()
+}.getOrDefault("")
 
-// Blank output means no git binary or not a git repo (e.g. a source archive
-// build): skip wiring the task entirely rather than fabricating a `.git` dir.
+// Blank output means not a git repo (git present, non-zero exit) or no git
+// binary at all (process fails to start → runCatching yields ""), e.g. the
+// Docker/source-archive build. Either way, skip wiring the task entirely
+// rather than fabricating a `.git` dir.
 if (resolvedHooksDir.isNotBlank()) {
     val installGitHooks by tasks.registering(Copy::class) {
         description = "Installs git hooks from .githooks into the git-resolved hooks dir"


### PR DESCRIPTION
## Problem

The Docker API image build (`deploy-api`) failed with:

```
A problem occurred configuring root project 'teambalance'.
> A problem occurred starting process 'command 'git''
```

The `eclipse-temurin:25-jdk` build image has no `git` binary. The top-level `providers.exec` that resolves the hooks dir runs at **configuration time**; `isIgnoreExitValue = true` only tolerates a non-zero exit (git present, not a repo), **not** a process that fails to start. So the container build died before the existing blank-output guard could skip the task.

`-x installGitHooks` does not help: the failure is at configuration, not task execution, and `:api:bootJar` doesn't even depend on the task.

## Fix

Wrap the exec in `runCatching { … }.getOrDefault("")` so a start failure falls through to the same empty-string/skip path — fixing every gitless build (Docker, source archive, CI) while leaving the happy path unchanged.

## Verification

Reproduced in a git-less sandbox PATH (all coreutils symlinked except `git`):
- **Before:** reproduces the exact CI failure → BUILD FAILED.
- **After:** root-project configuration completes cleanly.
- Happy path unchanged: with git present, hooks still install (pre-commit hook ran the full build + 301 tests on this very commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)