### PR TITLE
docs(#154): ADR-0019 self-service onboarding + rewritten runbook (Slice 5)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,8 +110,10 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 - **Invite Link** — A single shareable link an admin generates to onboard members into
   an existing Team. Clicking it → enter email → Magic Link → joined. One link, many
   joiners; can expire/rotate.
-- **Team creation** — Provisioning a new Team. In v1 this is a manual/back-office step
-  (DB/API); self-service team creation is deferred.
+- **Team creation** — Provisioning a new Team. Self-service: a logged-in, teamless user
+  creates their Team from a name + slug + one-time **creation code**, which provisions the
+  tenant schema inline (see [ADR-0019](docs/adr/0019-self-service-team-onboarding.md)).
+  Back-office onboarding is now just minting a creation code.
 
 ### Platform & integrations
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 data class CreatedTeam(val id: UUID, val name: String, val slug: String)
 
 /**
- * Self-service team creation (issue #154, ADR-0015). A logged-in, teamless user creates a team from a
+ * Self-service team creation (issue #154, ADR-0019). A logged-in, teamless user creates a team from a
  * name + a one-time creation code and becomes its founding admin.
  *
  * Ordering is deliberately provision-first so a partial failure never strands a consumed code:

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamCreationCode.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/TeamCreationCode.kt
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * A platform-level one-time code that gates self-service team creation (#154, ADR-0015). The
+ * A platform-level one-time code that gates self-service team creation (#154, ADR-0019). The
  * read-side projection surfaced by the codes-admin CRUD (Slice 4); consumption itself is the atomic
  * UPDATE inside team registration, not modelled here.
  *

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -8,7 +8,7 @@ import com.github.zzave.teambalance.api.interfaces.generated.model.Team
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Self-service team creation (#154, ADR-0015). The caller is authenticated but, by definition, has no
+ * Self-service team creation (#154, ADR-0019). The caller is authenticated but, by definition, has no
  * team yet — so this only resolves the current *user* (never `requireCurrentTeamId`, which would
  * fail-closed with 403 for a teamless user). Error mapping (bad name → 400, invalid code → opaque 403,
  * already-in-team / slug clash → 409) is handled by the thrown domain exceptions via

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -102,7 +102,7 @@ teambalance:
   frontend-base-url: ${TEAMBALANCE_FRONTEND_BASE_URL:https://app.teambalance.nl}
   # Comma-separated platform-admin emails (PLATFORM_ADMIN_EMAILS). Empty default = fail-closed: nobody
   # is a platform admin. Gates the creation-codes admin surface (#154 Slice 4) and receives the
-  # "code consumed → team created" audit notifications. See ADR-0015.
+  # "code consumed → team created" audit notifications. See ADR-0019.
   platform-admins: ${PLATFORM_ADMIN_EMAILS:}
   session:
     # Absolute session lifetime, enforced by SessionUserContextFilter (Spring Session itself only does

--- a/api/src/main/resources/db/migration/V006__team_creation_codes.sql
+++ b/api/src/main/resources/db/migration/V006__team_creation_codes.sql
@@ -1,4 +1,4 @@
--- Platform-level one-time codes that gate self-service team creation (issue #154, ADR-0015).
+-- Platform-level one-time codes that gate self-service team creation (issue #154, ADR-0019).
 -- A code is redeemable while consumed_at IS NULL and (expires_at IS NULL OR expires_at > now());
 -- create-team consumes it atomically (single conditional UPDATE) so a code can be spent at most once.
 CREATE TABLE team_creation_codes (

--- a/api/src/main/resources/db/migration/V007__drop_teams_sport.sql
+++ b/api/src/main/resources/db/migration/V007__drop_teams_sport.sql
@@ -1,4 +1,4 @@
--- Self-service onboarding (ADR-0015) creates teams from a name + creation code only — no sport is
+-- Self-service onboarding (ADR-0019) creates teams from a name + creation code only — no sport is
 -- collected. The column was never surfaced in the API or UI and carried a single placeholder value,
 -- so drop it. Auto-pinned to `public` by spring.flyway.schemas (application.yml).
 --

--- a/docs/adr/0001-product-ambition-hobby-tool-built-to-grow.md
+++ b/docs/adr/0001-product-ambition-hobby-tool-built-to-grow.md
@@ -1,6 +1,6 @@
 # ADR-0001: Product ambition — hobby tool, built to grow
 
-- Status: Accepted
+- Status: Accepted (self-service onboarding amended by [ADR-0019](0019-self-service-team-onboarding.md))
 - Date: 2026-06-23
 
 ## Context

--- a/docs/adr/0019-self-service-team-onboarding.md
+++ b/docs/adr/0019-self-service-team-onboarding.md
@@ -1,0 +1,161 @@
+# ADR-0019: Self-service team onboarding — startup migration runner + code-gated create-team
+
+- Status: Accepted
+- Date: 2026-08-03
+- Amends: [ADR-0001](0001-product-ambition-hobby-tool-built-to-grow.md) (team creation is back-office in v1)
+- Relates to: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (magic-link auth, invite onboarding), [ADR-0013](0013-member-profile-position-role-management.md) (member/position/role)
+
+> Numbering note: the originating PRD (#154) named this ADR-0015. By the time it was written, 0015
+> was already taken (session lifetime), so it lands at **0019**. Shipped code that referenced
+> "ADR-0015" for onboarding was corrected to point here.
+
+## Context
+
+ADR-0001 deferred self-service team creation: teams were born from back-office SQL
+(`docs/ops/provision-team.md`), and each tenant schema was migrated **by hand** through the Flyway
+docker CLI. Nothing in prod ever called the (already idempotent) `TenantSchemaManager.provisionTenantSchema`
+— only the dev seeder and the e2e initializer did. Two gaps followed from that:
+
+- **Onboarding didn't scale past the owner.** Every new team was a manual psql + docker-Flyway ritual.
+- **Tenant schemas could silently drift.** A new tenant migration only reached a schema if someone
+  remembered to run the CLI against it; restarting the app migrated `public` only.
+
+We want authenticated, abuse-resistant **self-service team creation**, with **every tenant schema
+kept migrated automatically** at startup. This reverses ADR-0001's "back-office in v1" stance while
+keeping the schema-per-team multitenancy model unchanged.
+
+Opening team creation to logged-in users also opens an abuse surface (an authenticated stranger
+spinning up schemas at will), so creation is gated behind one-time **creation codes** minted by a
+platform admin.
+
+## Decision
+
+### 1. Startup tenant-migration runner
+
+`StartupTenantMigrationRunner` (`infrastructure/multitenancy`) iterates `public.teams`
+(`TeamRepository.findAllSchemaNames()`) and calls the idempotent `provisionTenantSchema` for each,
+bringing every tenant schema to head at boot. It is an `InitializingBean` (mirroring
+`PlatformSchemaInitializer`) with `@DependsOn("platformSchemaInitializer")`, so it runs during context
+refresh, **after** `public.teams` exists and **before** boot is "done" — closing the startup race.
+This retires the manual docker-Flyway step for existing teams.
+
+- **Idempotent:** `CREATE SCHEMA IF NOT EXISTS` + Flyway `migrate` against `db/tenant-migration`
+  (history in `flyway_tenant_schema_history`, separate from the platform `flyway_schema_history`).
+  Re-running against an already-current schema is a no-op.
+- **No distributed lock.** Prod is effectively single-instance; concurrent boots would rely on
+  Flyway's history-table lock. Documented limitation, not engineered around.
+- **Shipped failure behaviour — fail-fast:** the runner iterates straight through; a per-tenant
+  migration failure propagates out of `afterPropertiesSet` and **fails boot**. The PRD's
+  isolate-and-continue + a base/prod fail-open config flag was **not** built — the current runner is
+  always fail-closed. This is acceptable for the current single-team prod but is the first thing to
+  revisit before onboarding many tenants (a bad tenant migration would down the whole app). Tracked
+  as a follow-up, not part of this ADR's shipped scope.
+
+### 2. Code-gated create-team endpoint
+
+`POST /api/teams` (Wirespec `teams.ws`; **never hand-edit generated code**). A logged-in, teamless
+user becomes the founding admin of a new team.
+
+- **Request `{ name, slug, creationCode }` → `201 { id, name, slug }`.** `schema_name` is never
+  exposed.
+- **User-editable, validated-not-derived slug (amends #154's original derived-slug design; from the
+  #158 create-team-screen grill).** The caller owns the address; the backend **validates** it
+  (`TeamNaming.validate`) rather than deriving it: format `^[a-z0-9]+(-[a-z0-9]+)*$`, length **≤ 58**.
+  `schema_name = "team_" + slug.replace('-','_')` is the one thing still server-computed and hidden,
+  and the 58-cap keeps it within Postgres' **63-byte** identifier limit. Over-long slugs are
+  **rejected, never truncated** — a truncated `schema_name` would no longer match the schema actually
+  created and would break `SET search_path` routing. The slug whitelist is the injection boundary:
+  `team_` + slug can only ever be `[a-z0-9_]`.
+- **`name` is non-unique; `slug` is unique.** The only naming collision is the slug.
+- **Error contract (machine-readable `code` on each):**
+  - `400 INVALID_NAME` — blank or > 100 chars (placed on the name field).
+  - `400 INVALID_SLUG` — bad format or > 58 chars (placed on the slug field).
+  - `403 INVALID_CREATION_CODE` — **opaque**: unknown, consumed, and expired codes are
+    indistinguishable, so a caller can't enumerate codes or probe their state.
+  - `409 ALREADY_IN_TEAM` vs `409 TEAM_SLUG_TAKEN` — **two distinct codes the frontend depends on**
+    (different copy, different behaviour): already a member of a team, vs the slug is taken. No
+    auto-suffixing on collision — the caller picks another slug.
+
+### 3. Provision-first ordering
+
+`TeamService.createTeam` orders the steps so a partial failure never strands a consumed code:
+
+1. reject if the caller already belongs to a team (`409 ALREADY_IN_TEAM`; v1 one-team-per-user);
+2. validate name + slug, derive `schema_name` (`400` on bad input);
+3. pre-check slug uniqueness (`409`) and code redeemability (opaque `403`) — clean rejects before any write;
+4. **provision** the tenant schema (idempotent, own connection, commits independently);
+5. **atomically** consume the code and insert `teams` + founding `team_members` in one transaction
+   (`TeamRegistrar`). The consume is a single conditional `UPDATE … WHERE consumed_at IS NULL AND
+   (expires_at IS NULL OR expires_at > now())` requiring 1 row affected — so a code is spendable at
+   most once even under a race.
+
+If step 4 fails, nothing is consumed and the user simply retries. If step 5 loses a race, the only
+residue is a **harmless empty orphan schema**, self-healed long-term by the startup runner.
+
+### 4. Creation codes + platform-admin identity
+
+- **`public.team_creation_codes`** (`code` unique, `created_at`, nullable `expires_at`,
+  `consumed_at`, `consumed_by_user_id`, `created_team_id`). One-time; `created_team_id` records which
+  team a spent code produced (for the admin surface).
+- **Platform-admin allowlist** `teambalance.platform-admins: ${PLATFORM_ADMIN_EMAILS:}` —
+  **empty default = fail-closed** (nobody is an admin). `PlatformAdminGateway` reads it. This is the
+  v1 platform-admin model (config, not a DB role); a DB-backed model is out of scope.
+
+### 5. Founder & tenant starting state
+
+The creator becomes a `team_members` **ADMIN** with `onboarded_at = now()` (skips `/welcome`) and
+`position_id NULL`. The new team starts with an **empty** position vocabulary (the admin curates it
+at `/members`). The tenant schema needs nothing extra beyond the standard `db/tenant-migration`
+baseline (event types seeded by tenant `V002`, `team_settings` by its migration).
+
+### 6. `/auth/me` gains `team`
+
+`AuthenticatedUser` now carries `team: TeamRef?` (`{ id, name, slug } | null`, via `auth.ws`). The
+frontend's has-a-team route gate reads **this** — it must **not** infer teamlessness from
+`role == null`.
+
+### 7. Notifications — fire-and-forget
+
+On successful creation, `TeamNotifier` (backed by the existing Scaleway TEM adapter) sends the founder
+a "your team `<name>` is ready" mail and the platform admins a "code consumed → team `<name>` created
+by `<founder email>`" audit mail. Both are best-effort behind a broad catch: a mail failure is logged
+and **never** fails a committed creation.
+
+### 8. `sport` dropped
+
+Self-service creation collects only name + slug + code. `teams.sport` (never surfaced in API/UI,
+single placeholder value) is dropped in platform migration `V007__drop_teams_sport.sql` (auto-pinned
+`public`). Post-drop insert sites (dev/e2e seeds, ITs, the runbook) omit it; the test-only seed
+`V1_1__seed_demo_data.sql` still sets it because it runs at v1.1, before the drop.
+
+### 9. Owner codes-admin surface (Slice 4)
+
+`GET/POST/DELETE /api/admin/creation-codes` (Wirespec `creation-codes.ws`), behind
+`PlatformAdminGateway`. List/mint/revoke codes. Revoking an unknown code → `404`; revoking a
+**consumed** code → `409 CREATION_CODE_CONSUMED` (a consumed code is an audit record, not a pending
+invite to withdraw). Frontend at `features/manage-creation-codes`.
+
+### 10. Slice 3 (plain-HTML tracer) dropped
+
+The PRD's throwaway plain-HTML create-team tracer was dropped: the polished #158 React/FSD screen
+(`features/create-team`, PR #173) replaces it and carries the **single** create-team e2e itself
+(the cross-tenant-provisioning + code-gate seam — the one new seam not covered by the login/attendance
+flows). Net e2e count unchanged.
+
+## Consequences
+
+- **Onboarding a new team is now:** mint a creation code (codes-admin UI, or back-office SQL) → the
+  user self-creates via the create-team screen. Existing teams' schemas stay at head automatically.
+  The runbook (`docs/ops/provision-team.md`) is rewritten around this; the manual per-team
+  docker-Flyway step is retired.
+- **One-team-per-user** matches routing's `ORDER BY … LIMIT 1`. Multi-team membership + a team
+  switcher are deferred to **#143**. Public/www marketing signup + a resetting demo team are **#152**.
+- **Boot cost rises slightly** (tenant migrations run at startup). Kept cheap by idempotency, but see
+  §1: the runner is currently fail-fast, so a broken tenant migration downs the app — revisit the
+  isolate-and-continue design before scaling tenant count. A prior prod outage was a scale-to-zero DB
+  boot-wedge, so startup DB work stays a watched cost.
+- **Guardrail preserved:** platform Flyway stays pinned to `spring.flyway.schemas:[public]` and its
+  own `flyway_schema_history`; tenant Flyway uses `flyway_tenant_schema_history`. Regressing the pin
+  previously misplaced a migration into a tenant schema (incident PR #120).
+</content>
+</invoke>

--- a/docs/ops/provision-team.md
+++ b/docs/ops/provision-team.md
@@ -1,84 +1,99 @@
-# Back-office: Provisioning a Team
+# Back-office: Onboarding a Team
 
-> **When to use this:** Self-service Team creation is deferred (ADR-0001, ADR-0008).
-> Until that is built, the owner provisions new Teams manually using this procedure.
+> **What changed (ADR-0019):** team creation is now **self-service**. A logged-in, teamless user
+> creates their team from a **name + slug + one-time creation code** via the create-team screen
+> (`POST /api/teams`), which provisions the tenant schema itself. Back-office onboarding is now just
+> **minting a creation code** and handing it over.
 >
-> **Prod reality check (read this first):** there is **no** provisioning API. Nothing in
-> prod triggers `TenantSchemaManager` — it's called only by `DemoDataSeeder` (`@Profile("dev")`)
-> and the e2e initializer. A `/internal/admin/.../provision` endpoint was never built and is
-> now blocked by the prod `/internal/*` lockdown (PR #86). So the tenant schema must be
-> migrated **directly against the database** (Step 2). Restarting the app migrates only the
-> `public` schema, never a tenant schema.
+> Two manual rituals from the old procedure are **retired**:
+> - **Per-team tenant migration by hand is gone.** The `StartupTenantMigrationRunner` brings *every*
+>   `public.teams` schema to head on every boot (idempotent), and create-team provisions a brand-new
+>   schema inline. You no longer run the Flyway docker CLI per team. See the emergency fallback below
+>   only if the app can't boot.
+> - **Inserting `teams` / `team_members` rows by hand is no longer the happy path** — the founder's
+>   self-service create does it, atomically, in the right order.
 
-## Prerequisites
+## Onboarding a new team (happy path)
 
-- Psql access to the database.
-  - Local: `make db` starts Postgres on `localhost:5432`.
-  - Prod: Scaleway Serverless SQL — database name `teambalance`, JDBC needs `?sslmode=require`.
-    Credentials are secrets (container env `SPRING_DATASOURCE_*` / Secret Manager). Never print them.
-- **Docker** (for Step 2 — the tenant migration runs via the Flyway CLI image; no local `flyway`/`psql` needed).
-- A local checkout of this repo (Step 2 mounts `api/src/main/resources/db/tenant-migration/`).
-- The team's: name, slug (URL-safe).
-- The owner's email + display name. (Positions are optional up front — see Step 3.)
+### Step 1 — Mint a creation code
 
-## Step 1 — Insert the Team + owner (one transaction)
+**Preferred: the codes-admin UI (ADR-0019 Slice 4).** A platform admin (an email in
+`PLATFORM_ADMIN_EMAILS` / `teambalance.platform-admins`) opens the creation-codes admin surface and
+mints a code (optionally with an expiry). List/revoke live there too.
 
-The schema name must be a valid Postgres identifier (lowercase, underscores, no spaces).
-Convention: `team_<slug_with_underscores>`, and it must be **unique** (can't reuse `public`).
-
-This one transaction creates the team, the owner's platform identity, an initial position,
-and the owner's admin membership — CTEs thread the generated ids so nothing is copy-pasted.
-No `ON CONFLICT` (its `DO NOTHING` silently no-ops on *any* constraint clash, not just the
-intended key — misleading for a first insert).
+**Fallback: back-office SQL** (if the UI isn't reachable). One row in `public.team_creation_codes`:
 
 ```sql
-BEGIN;
-
-WITH t AS (
-    INSERT INTO public.teams (name, slug, schema_name)
-    VALUES ('Setpoint VT', 'setpoint-vt', 'team_setpoint_vt')
-    RETURNING id
-),
-u AS (
-    INSERT INTO public.users (email, display_name)
-    VALUES ('owner@example.com', 'Jan de Vries')
-    RETURNING id
-),
-p AS (
-    -- Optional: seed one position so /welcome has something to pick (see Step 3).
-    INSERT INTO public.team_positions (team_id, label)
-    SELECT t.id, 'Setter' FROM t
-    RETURNING id
-)
-INSERT INTO public.team_members (team_id, user_id, role, position_id, onboarded_at)
-SELECT t.id, u.id, 'ADMIN', p.id, now()   -- see Step 3 for the /welcome alternative
-FROM t, u, p;
-
--- Eyeball before committing (ROLLBACK; instead if anything looks wrong):
-SELECT tm.role, tm.onboarded_at, u.email, u.display_name, tp.label AS position,
-       t.slug, t.schema_name
-FROM public.team_members tm
-JOIN public.users u  ON u.id = tm.user_id
-JOIN public.teams t  ON t.id = tm.team_id
-LEFT JOIN public.team_positions tp ON tp.id = tm.position_id
-WHERE t.slug = 'setpoint-vt';
-
-COMMIT;
+-- code: any unguessable string you hand to the founder. NULL expires_at = never expires;
+-- set a timestamptz to make it time-boxed. consumed_* stay NULL until the founder redeems it.
+INSERT INTO public.team_creation_codes (code, expires_at)
+VALUES ('choose-an-unguessable-code', NULL)   -- or now() + interval '7 days'
+RETURNING code, created_at, expires_at;
 ```
 
-Note the `schema_name` (`team_setpoint_vt`) — you need it in Step 2.
+Hand the `code` to the founder over a trusted channel. It is single-use: the create-team endpoint
+consumes it atomically (`consumed_at IS NULL AND (expires_at IS NULL OR expires_at > now())`), so it
+can be spent at most once.
 
-> **Schema shape (post-#90 / ADR-0013):** `team_members` has **no** `team_role` column.
-> Permission is `role` (CHECK `'USER' | 'ADMIN'`, default `'USER'`). Playing **position** is
-> `position_id` → FK `public.team_positions` (per-team vocabulary; labels unique
-> case-insensitively per team). `onboarded_at` (nullable) drives the `/welcome` flow.
+### Step 2 — The founder self-creates
 
-## Step 2 — Provision + migrate the tenant schema
+The founder logs in (magic link → their `users.email` is the identity key), and — while **teamless**
+— the has-a-team route gate (driven by `/auth/me`'s `team` field) lands them on the create-team
+screen. They enter:
 
-The tenant schema holds events, attendances, transactions, and event types for this Team.
-Run Flyway directly against the DB via the Flyway CLI docker image — this mirrors
-`TenantSchemaManager` exactly (creates the schema, applies `db/tenant-migration/`, and records
-a proper `flyway_schema_history`). Running raw DDL instead would leave the history table empty.
+- **Team name** — free text, ≤ 100 chars, **not** required to be unique.
+- **Slug** — the URL address, **user-editable and validated**: `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤ 58 chars,
+  **unique**. `schema_name = "team_" + slug` (hyphens → underscores) is computed server-side and never
+  shown.
+- **Creation code** — from Step 1.
+
+`POST /api/teams` then, in order: rejects a caller who already has a team (`409 ALREADY_IN_TEAM`);
+validates name/slug (`400 INVALID_NAME` / `400 INVALID_SLUG`); rejects a taken slug
+(`409 TEAM_SLUG_TAKEN`) or a bad/expired/consumed code (opaque `403 INVALID_CREATION_CODE`);
+**provisions the tenant schema** (`db/tenant-migration`, recorded in `flyway_tenant_schema_history`);
+then **atomically** consumes the code and inserts the `teams` row + the founder's `team_members`
+row (ADMIN, `onboarded_at = now()`, `position_id NULL`). The founder lands straight in the new,
+empty team.
+
+The founder is now the team's admin. From there, onboarding the rest of the team is the ordinary
+in-app flow (unchanged, ADR-0008 / ADR-0013):
+
+1. At **`/members`**, add the team's real **positions** (Libero, Middenaanvaller, …) first — otherwise
+   invitees have nothing meaningful to pick.
+2. Share the **Invite Link**. Each joiner enters their email → magic link → joins as `role='USER'`,
+   `onboarded_at=NULL` → `/welcome` captures their name + position.
+3. Promote co-admins from the `/members` roster (symmetric promote/demote, last-admin floor).
+
+## Verification
+
+```sql
+-- The code was consumed and points at the new team:
+SELECT code, consumed_at, consumed_by_user_id, created_team_id
+FROM public.team_creation_codes WHERE code = 'choose-an-unguessable-code';
+
+-- Team row + founding admin (note: schema_name is server-derived from the slug; sport is gone, ADR-0019):
+SELECT t.name, t.slug, t.schema_name, u.email, tm.role, tm.onboarded_at
+FROM public.teams t
+JOIN public.team_members tm ON tm.team_id = t.id
+JOIN public.users u ON u.id = tm.user_id
+WHERE t.slug = '<slug>';
+
+-- Tenant schema exists and is migrated:
+SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'team_<slug_underscored>';
+SELECT table_name FROM information_schema.tables
+WHERE table_schema = 'team_<slug_underscored>' ORDER BY table_name;   -- events, attendances, transactions, event_types, …
+```
+
+The real proof is the founder landing in the team with an empty events list and no error on the
+events view — confirming the tenant schema is wired correctly.
+
+## Emergency fallback — manual tenant provisioning
+
+You should not need this: the startup runner keeps existing schemas at head and create-team
+provisions new ones. Reach for it only if the app **can't boot** (so the runner never runs) and a
+tenant schema must be migrated out-of-band. It mirrors `TenantSchemaManager.provisionTenantSchema`
+exactly — creates the schema, applies `db/tenant-migration/`, and records
+`flyway_tenant_schema_history`. Running raw DDL instead would leave the history table empty.
 
 ```bash
 docker run --rm \
@@ -87,80 +102,29 @@ docker run --rm \
   flyway/flyway:11 \
   -url="jdbc:postgresql://<HOST>:5432/<DB>?sslmode=require" \
   -user="<DB_USER>" \
-  -schemas="team_setpoint_vt" \
-  -table="flyway_schema_history" \
+  -schemas="team_<slug_underscored>" \
+  -table="flyway_tenant_schema_history" \
   -baselineOnMigrate=true -baselineVersion=0 \
   migrate
 ```
 
-- Fill `<HOST>/<DB>/<DB_USER>` from your DB connection (prod `<DB>` is `teambalance`).
-- Pass the password via `FLYWAY_PASSWORD` to keep it out of shell history.
-- Flyway creates the schema itself (no separate `CREATE SCHEMA` needed) and applies the tenant
-  migrations (currently `V001__tenant_baseline`, `V002__seed_event_types`,
-  `V003__attendance_changed_by`). Expect *"Successfully applied N migrations"*.
+- Fill `<HOST>/<DB>/<DB_USER>` from your DB connection (prod `<DB>` is `teambalance`); pass the
+  password via `FLYWAY_PASSWORD` to keep it out of shell history.
+- Note `-table="flyway_tenant_schema_history"` — the **tenant** history table, kept separate from the
+  platform `flyway_schema_history` (ADR-0019 guardrail; regressing the split misplaced a migration in
+  prod once, PR #120).
 
-> This **must** run before the owner logs in — the app resolves the tenant from the team
-> context and queries `events` in the tenant schema; if the schema/tables don't exist yet, the
-> events view errors.
-
-## Step 3 — The owner's position & onboarding: two options
-
-`team_members.onboarded_at` gates the post-login `/welcome` flow (ADR-0013): a member with
-`onboarded_at IS NULL` is routed to `/welcome` to set their own display name + position.
-
-- **Option A — seed fully (used in Step 1 above):** set `position_id` and stamp
-  `onboarded_at = now()`. The owner skips `/welcome` and lands straight in the team. Use this
-  when the SPA isn't yet on the member-management build, or you just want them fully set up.
-- **Option B — let them self-onboard:** insert the membership with `position_id = NULL` and
-  `onboarded_at = NULL` (drop the `p` CTE and those two values in Step 1). On first login the
-  owner goes through `/welcome`. Note: `/welcome` only lets a member *pick* an existing
-  position — it can't create one, and if the team has **zero** positions the picker is hidden
-  (member stays unassigned). So seed at least one position first if you want them to choose.
-
-## Step 4 — Add the remaining Members
-
-Preferred path is **self-service via the Invite Link** (ADR-0008 / ADR-0013), not back-office SQL:
-
-1. As an admin, open **`/members`** and add the team's real **positions** first (Libero,
-   Middenaanvaller, etc.) — otherwise every invitee is forced to pick the single seeded one.
-2. Generate the **Invite Link** and share it. Each joiner enters their email → magic link →
-   joins as `role='USER'` with `onboarded_at=NULL` → `/welcome` captures their name + position.
-3. Promote any co-admins from the `/members` roster (symmetric promote/demote, last-admin floor).
-
-Back-office SQL for a member is still possible (same shape as Step 1's `users` + `team_members`
-inserts, `role='USER'`), but prefer the invite flow so people set their own name/position.
-
-## Verification
-
-```sql
--- Team row (exactly 1)
-SELECT name, slug, schema_name FROM public.teams WHERE slug = 'setpoint-vt';
-
--- Members: 1 Admin + N Users, with their positions
-SELECT u.email, u.display_name, tm.role, tp.label AS position, tm.onboarded_at
-FROM public.team_members tm
-JOIN public.users u ON u.id = tm.user_id
-JOIN public.teams t ON t.id = tm.team_id
-LEFT JOIN public.team_positions tp ON tp.id = tm.position_id
-WHERE t.slug = 'setpoint-vt'
-ORDER BY tm.role DESC, u.display_name;
-
--- Tenant schema exists and is migrated
-SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'team_setpoint_vt';
-SELECT table_name FROM information_schema.tables
-WHERE table_schema = 'team_setpoint_vt' ORDER BY table_name;   -- events, attendances, transactions, event_types, ...
-SELECT name FROM team_setpoint_vt.event_types ORDER BY name;   -- Match, Other, Training (baseline seed)
-SELECT count(*) AS events FROM team_setpoint_vt.events;         -- 0 (fresh team)
-```
-
-**The real proof** is a login: the owner requests a magic link (their `users.email` is the
-identity key), clicks it, and lands in the team with an empty events list — no error on the
-events view confirms the tenant schema is wired correctly.
+> **Never** point platform Flyway (`db/migration`) at a tenant schema, and never unpin
+> `spring.flyway.schemas:[public]`. Platform migrations belong in `public` only.
 
 ## References
 
-- [ADR-0001](../adr/0001-product-ambition-hobby-tool-built-to-grow.md) — hobby tool, built to grow; team creation is back-office in v1
+- [ADR-0019](../adr/0019-self-service-team-onboarding.md) — self-service onboarding: startup migration
+  runner, code-gated create-team, `sport` dropped (amends ADR-0001)
+- [ADR-0001](../adr/0001-product-ambition-hobby-tool-built-to-grow.md) — hobby tool, built to grow (the
+  "team creation is back-office in v1" stance this reverses)
 - [ADR-0008](../adr/0008-auth-magic-link-and-shareable-invite.md) — magic-link auth, invite onboarding
-- [ADR-0009](../adr/0009-attendance-model-roles-in-audience-deferred.md) — roles/audience model in v1
-- [ADR-0013](../adr/0013-member-profile-position-role-management.md) — member profile, position vocabulary & role management (`/welcome`, `/members`); supersedes the "back-office only" parts of ADR-0009
+- [ADR-0013](../adr/0013-member-profile-position-role-management.md) — member profile, position
+  vocabulary & role management (`/welcome`, `/members`)
 - [CONTEXT.md](../../CONTEXT.md) — vocabulary: Team, Member, Role, Admin, User, Position
+</content>


### PR DESCRIPTION
Closes the **Docs** slice (Slice 5) of #154. Slices 1–4 shipped; this commits the record.

## What's in here

- **New ADR — `docs/adr/0019-self-service-team-onboarding.md`** (amends ADR-0001). Records the shipped design: startup tenant-migration runner, code-gated `POST /api/teams`, provision-first ordering, creation codes, platform-admin allowlist, founder-as-admin, one-team-per-user (→#143), `sport` drop, fire-and-forget notifications, and the Slice-4 codes-admin surface. Captures the **#158 slug deviation as the shipped truth** (user-editable *validated-not-derived* slug, `name` non-unique / `slug` unique, the two distinct `409`s, `auth.me.team`) — not the PRD's original derived-slug shape.
- **Rewrote `docs/ops/provision-team.md`** around self-service: onboarding a team is now *mint a creation code → founder self-creates*; the manual per-team docker-Flyway step is retired to an emergency-only fallback (the startup runner keeps existing schemas at head).

## Two honest reconciliations

1. **ADR renumbered 0015 → 0019.** The PRD named it "ADR-0015", but that number was taken by the session-lifetime ADR before this landed. Used the next free number and **fixed 6 stale `ADR-0015` references** in shipped onboarding code (`TeamService`, `TeamController`, `TeamCreationCode`, `V006`, `V007`, `application.yml`), left the 3 genuine session-lifetime refs alone, added a forward-pointer in ADR-0001, and corrected a now-false line in `CONTEXT.md`.
2. ⚠️ **Documented a real Slice-1 deviation:** the shipped `StartupTenantMigrationRunner` is a straight `forEach` — it has **no isolate-and-continue and no fail-fast config flag** as the PRD's Slice 1 described; in practice it is *always* fail-fast (any tenant migration failure fails app boot). Recorded faithfully in the ADR (§1 + Consequences) as the thing to revisit before scaling tenant count. Not fixed here (out of scope for a docs slice) — follow-up to be filed separately.

## Testing

Docs + code-comment only; no logic changed. Landed through the full pre-commit gate (`make yolo test`): backend `:api:test` green, frontend `npm run yolo` build + `npm test` (301 passed). Per the PR gate in CLAUDE.md, no new test layer applies to a docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)