### PR TITLE
refactor(api): make the team-creation services framework-free (#184)

### DIFF
--- a/api/detekt-baseline.xml
+++ b/api/detekt-baseline.xml
@@ -13,10 +13,8 @@
     <ID>ApiCannotDependOnAdapters:AuthController.kt:import com.github.zzave.teambalance.api.infrastructure.identity.SessionKeys</ID>
     <ID>ApiCannotDependOnPorts:AuthController.kt:AuthController$private val teamMemberRepository: TeamMemberRepository</ID>
     <ID>DomainMustBeImmutable:Recurrence.kt:Recurrence$var cursor = startDate</ID>
-    <ID>DomainNoFrameworkImports:CreationCodeAdminService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.context.annotation.Profile</ID>
     <ID>DomainNoFrameworkImports:E2eMagicLinkTokenRecorder.kt:import org.springframework.stereotype.Component</ID>
-    <ID>DomainNoFrameworkImports:TeamService.kt:import org.springframework.stereotype.Service</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val description: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val location: String?</ID>
     <ID>DomainNoPrimitiveObsession:Event.kt:Event$val title: String</ID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CreationCodeAdminService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/CreationCodeAdminService.kt
@@ -6,7 +6,6 @@ import com.github.zzave.teambalance.api.domain.model.TeamCreationCode
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.PlatformAdminGateway
 import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
-import org.springframework.stereotype.Service
 import java.security.SecureRandom
 import java.time.Clock
 import java.time.Instant
@@ -19,7 +18,6 @@ import java.time.Instant
  * SECURITY CONTRACT: [callerId] MUST be the authenticated principal (resolved from the session by the
  * controller), never a request-supplied id.
  */
-@Service
 class CreationCodeAdminService(
     private val creationCodeRepository: TeamCreationCodeRepository,
     private val platformAdminGateway: PlatformAdminGateway,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -13,7 +13,6 @@ import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.TenantProvisioner
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
@@ -36,7 +35,6 @@ data class CreatedTeam(val id: UUID, val name: String, val slug: String)
  * or slug collision) the only residue is a harmless empty orphan schema, self-healed by the startup
  * migration runner. Notifications are best-effort and can never fail a committed creation.
  */
-@Service
 class TeamService(
     private val teamMemberRepository: TeamMemberRepository,
     private val teamRepository: TeamRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
@@ -1,0 +1,57 @@
+package com.github.zzave.teambalance.api.infrastructure.config
+
+import com.github.zzave.teambalance.api.application.CreationCodeAdminService
+import com.github.zzave.teambalance.api.application.TeamService
+import com.github.zzave.teambalance.api.domain.port.PlatformAdminGateway
+import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TeamNotifier
+import com.github.zzave.teambalance.api.domain.port.TeamRegistrar
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.TenantProvisioner
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Composition root for the **team-creation** area (ADR-0018), sibling to [AuthCompositionRoot]: the
+ * two ends of one lifecycle. A platform admin mints a creation code ([CreationCodeAdminService]) and
+ * a teamless user redeems it into a team ([TeamService]); they meet on [TeamCreationCodeRepository],
+ * which no other area touches.
+ */
+@Configuration
+class TeamCompositionRoot {
+
+    @Bean
+    fun teamService(
+        teamMemberRepository: TeamMemberRepository,
+        teamRepository: TeamRepository,
+        creationCodeRepository: TeamCreationCodeRepository,
+        tenantProvisioner: TenantProvisioner,
+        teamRegistrar: TeamRegistrar,
+        userRepository: UserRepository,
+        teamNotifier: TeamNotifier,
+        clock: Clock,
+    ) = TeamService(
+        teamMemberRepository = teamMemberRepository,
+        teamRepository = teamRepository,
+        creationCodeRepository = creationCodeRepository,
+        tenantProvisioner = tenantProvisioner,
+        teamRegistrar = teamRegistrar,
+        userRepository = userRepository,
+        teamNotifier = teamNotifier,
+        clock = clock,
+    )
+
+    @Bean
+    fun creationCodeAdminService(
+        creationCodeRepository: TeamCreationCodeRepository,
+        platformAdminGateway: PlatformAdminGateway,
+        clock: Clock,
+    ) = CreationCodeAdminService(
+        creationCodeRepository = creationCodeRepository,
+        platformAdminGateway = platformAdminGateway,
+        clock = clock,
+    )
+}


### PR DESCRIPTION
Part of #184 (final sweep of violations introduced by concurrent `main` growth) — **not** the #24 ArchUnit retirement, despite this branch's name.

Makes the two team-creation-era services framework-free and removes their two `DomainNoFrameworkImports` baseline entries:
- `TeamService` and `CreationCodeAdminService` lose `@Service`; they are now constructed by a new `TeamCompositionRoot` (infrastructure).
- Baseline: 54 → 52 entries (the two service entries removed).

Rebased onto current `main`. The real #24 finale (retire ArchUnit + zero the remaining ~52 baseline, moving deliberate display-string exemptions to rule config) is still open and separate.

Refs #184, #24.