### PR TITLE
ci(deploy): fail the deploy red unless the new image is actually serving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,13 +152,19 @@ jobs:
       - name: Resolve image tag
         id: tag
         run: |
+          echo "sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "image=${REGISTRY}/api:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "Resolved image: ${REGISTRY}/api:${GITHUB_SHA::12}"
 
       # ubuntu-latest is amd64, so --platform=linux/amd64 is native (no emulation). The Gradle build
       # (buildSrc + Java 25 toolchain) runs INSIDE the multi-stage image, so the runner needs no setup.
+      # GIT_SHA is baked into the image (Dockerfile) and surfaced on /internal/actuator/info so the
+      # post-deploy step below can confirm this exact image is the one serving traffic.
       - name: Build API image (linux/amd64)
-        run: docker build --platform=linux/amd64 -f api/Dockerfile -t "${{ steps.tag.outputs.image }}" .
+        run: |
+          docker build --platform=linux/amd64 -f api/Dockerfile \
+            --build-arg GIT_SHA="${{ steps.tag.outputs.sha }}" \
+            -t "${{ steps.tag.outputs.image }}" .
 
       - name: Configure Scaleway CLI
         uses: scaleway/action-scw@v0
@@ -180,6 +186,36 @@ jobs:
       # untouched — those are managed manually in the Scaleway console.
       - name: Update Serverless Container image
         run: scw container container update "$CONTAINER_ID" image="${{ steps.tag.outputs.image }}" region="$SCW_REGION"
+
+      # `container update` only *registers* the new image and returns immediately — Scaleway rolls it
+      # out asynchronously. Without this gate a container that crashes on boot (e.g. a Flyway validation
+      # failure) leaves the deploy job green while prod keeps serving the old revision. Poll the live
+      # actuator `info` endpoint — gated by the internal API key, so the SHA is never public — until it
+      # reports the exact SHA we just pushed. Non-200 / mismatched SHA = the new image isn't serving yet
+      # (rollout in progress, or it crashed); we keep waiting and fail red if it never becomes live.
+      # This proves the new version is actually up regardless of *why* an unhealthy image would fail.
+      - name: Verify the new image is actually serving
+        env:
+          INTERNAL_API_KEY: ${{ secrets.INTERNAL_API_KEY }}
+          EXPECTED_SHA: ${{ steps.tag.outputs.sha }}
+        run: |
+          set -euo pipefail
+          url="https://api.teambalance.nl/internal/actuator/info"
+          deadline=$(( SECONDS + 360 ))
+          attempt=0
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            attempt=$(( attempt + 1 ))
+            body="$(curl -fsS --max-time 10 -H "X-Internal-Api-Key: ${INTERNAL_API_KEY}" "$url" 2>/dev/null || true)"
+            live_sha="$(printf '%s' "$body" | jq -r '.build.sha // empty' 2>/dev/null || true)"
+            if [ "$live_sha" = "$EXPECTED_SHA" ]; then
+              echo "✓ Live build SHA ${live_sha} matches the deployed image (attempt ${attempt})."
+              exit 0
+            fi
+            echo "… awaiting rollout (attempt ${attempt}): live='${live_sha:-<none>}' expected='${EXPECTED_SHA}'"
+            sleep 10
+          done
+          echo "::error::Image ${EXPECTED_SHA} never became live within $(( 360 / 60 )) min — deployment NOT verified. The new container likely failed to boot; check Scaleway Cockpit logs for a crash (e.g. Flyway validation)."
+          exit 1
 
   deploy-frontend:
     needs: build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -109,6 +109,13 @@ USER app
 COPY --from=build --chown=app:app /workspace/app.jar app.jar
 COPY --from=bake  --chown=app:app /app/app.aot app.aot
 
+# Build SHA of this image, surfaced at runtime on /internal/actuator/info (info.build.sha) so the deploy
+# pipeline can confirm the exact pushed image is serving. Declared last: it changes every commit, and
+# only the cheap EXPOSE/ENTRYPOINT metadata layers follow, so the expensive build/bake COPYs stay cached.
+# Defaults to `unknown` for a plain local `docker build` with no --build-arg.
+ARG GIT_SHA=unknown
+ENV TEAMBALANCE_BUILD_SHA=$GIT_SHA
+
 EXPOSE 8080
 # Runtime flags combine Phase 1 (1-vCPU startup tuning) and Phase 2 (Spring AOT + AOT cache):
 #   -XX:+UseSerialGC        — no multi-threaded GC to spin up on a single core.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilter.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.util.UrlPathHelper
+import java.security.MessageDigest
 
 /**
  * Launch blocker #5: in prod the API is a public origin (api.teambalance.nl) and no Spring Security
@@ -32,6 +33,14 @@ import org.springframework.web.util.UrlPathHelper
  * tree is readable during a perf-test window; unsetting it closes the endpoint again. Spring relaxed binding
  * maps the env var TEAMBALANCE_STARTUP_ACTUATOR_ENABLED to the flag. Default: only `health` gets through. See #95.
  *
+ * The internal API key (`teambalance.internal.api-key`, env INTERNAL_API_KEY) opens the rest of the
+ * `/internal` surface — the actuator's `info`/`metrics` — to a caller that presents the matching
+ * `X-Internal-Api-Key` header. The deploy pipeline uses this to read `/internal/actuator/info` and confirm
+ * the freshly-pushed image's build SHA is actually serving before it calls the rollout a success. The key
+ * is a shared secret held only by CI and the container's env; without it (or when the key is unset) the
+ * guard stays fail-closed and info/metrics are a 403 from the internet. Health is always public — Scaleway's
+ * probe is unauthenticated. The compare is constant-time so a wrong key leaks nothing through timing.
+ *
  * Prod-only (`@Profile("prod")`): dev keeps the full actuator, and e2e needs `/internal/e2e/...`.
  * Runs first (HIGHEST_PRECEDENCE) so it gates before any context-setup filter or handler.
  */
@@ -40,6 +49,7 @@ import org.springframework.web.util.UrlPathHelper
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class InternalEndpointGuardFilter(
     @Value("\${teambalance.startup.actuator.enabled:false}") private val startupActuatorEnabled: Boolean,
+    @Value("\${teambalance.internal.api-key:}") private val apiKey: String,
 ) : OncePerRequestFilter() {
 
     private val urlPathHelper = UrlPathHelper()
@@ -55,11 +65,19 @@ class InternalEndpointGuardFilter(
         val isHealth = normalized == HEALTH_PATH
         // Perf-testing allowance: only open the startup timing endpoint while the flag is set.
         val isStartupProbe = startupActuatorEnabled && normalized == STARTUP_PATH
-        if (isInternal && !isHealth && !isStartupProbe) {
+        val isAllowed = isHealth || isStartupProbe || hasValidApiKey(request)
+        if (isInternal && !isAllowed) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN)
             return
         }
         filterChain.doFilter(request, response)
+    }
+
+    // Fail-closed: an unset key (blank) never matches, so it can't be unlocked by an empty header.
+    private fun hasValidApiKey(request: HttpServletRequest): Boolean {
+        val presented = request.getHeader(API_KEY_HEADER)
+        return apiKey.isNotEmpty() && presented != null &&
+            MessageDigest.isEqual(presented.toByteArray(), apiKey.toByteArray())
     }
 
     private companion object {
@@ -71,5 +89,8 @@ class InternalEndpointGuardFilter(
         // The buffered startup timing tree, readable from the live prod container only while the
         // teambalance.startup.actuator.enabled flag is set (perf-testing window). See #95.
         const val STARTUP_PATH = "/internal/actuator/startup"
+
+        // Shared secret carrying access to the non-health `/internal` surface (deploy-time info probe).
+        const val API_KEY_HEADER = "X-Internal-Api-Key"
     }
 }

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -34,11 +34,10 @@ management:
   endpoints:
     web:
       exposure:
-        # Blocker #5: only expose the health probe (and the startup timing endpoint) in prod.
-        # info/metrics (exposed in the base config for local use) would otherwise be publicly
-        # reachable on api.teambalance.nl. InternalEndpointGuardFilter is the real boundary: it 403s
-        # everything under /internal/actuator except `health`, and `startup` only while the
-        # teambalance.startup.actuator.enabled flag is set. `startup` is kept exposed here so the
-        # endpoint is registered and ready; the flag toggles whether the guard lets it through for a
-        # perf-test window (TEAMBALANCE_STARTUP_ACTUATOR_ENABLED=true), then unset it. See #95.
-        include: health,startup
+        # Blocker #5: expose only the health probe, the startup timing endpoint, and `info` in prod.
+        # metrics (exposed in the base config for local use) stays off. InternalEndpointGuardFilter is
+        # the real boundary: it 403s everything under /internal/actuator except `health` — `startup`
+        # only while the teambalance.startup.actuator.enabled flag is set, and `info` only for a caller
+        # presenting the X-Internal-Api-Key. `info` is registered here so the guarded deploy-verify
+        # probe can read the running image's build SHA; without the key it is a 403 from the internet.
+        include: health,startup,info

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -87,6 +87,18 @@ management:
         # 403s everything under /internal/actuator except `health` — and `startup` only while the
         # teambalance.startup.actuator.enabled flag is set (perf-test window). See #95.
         include: health,info,metrics,startup
+  info:
+    # Surface the `info.*` properties below (the deployed image's build SHA) on /internal/actuator/info.
+    # Off by default in Spring Boot, so the deploy-verify probe would otherwise see an empty payload.
+    env:
+      enabled: true
+
+info:
+  build:
+    # The git SHA of the running image, injected at container-build time (Dockerfile ARG GIT_SHA →
+    # ENV TEAMBALANCE_BUILD_SHA). The deploy pipeline reads this back from the live container to prove
+    # the exact image it pushed is actually serving. `unknown` in local/dev where nothing bakes it.
+    sha: ${TEAMBALANCE_BUILD_SHA:unknown}
 
 teambalance:
   startup:
@@ -98,6 +110,12 @@ teambalance:
       # perf-test window, then unset it. Spring relaxed binding maps the env var
       # TEAMBALANCE_STARTUP_ACTUATOR_ENABLED to this property. See issue #95.
       enabled: false
+  internal:
+    # Shared secret that opens the non-health `/internal` surface (actuator info/metrics) to a caller
+    # presenting it as the X-Internal-Api-Key header. Only the deploy pipeline and the container's env
+    # hold it; unset here (empty default) → InternalEndpointGuardFilter stays fail-closed and info is a
+    # 403 from the internet. Live environments provide it via INTERNAL_API_KEY.
+    api-key: ${INTERNAL_API_KEY:}
   # Base URL of the SPA; used to build the clickable magic-link (…/auth/verify?token=…).
   frontend-base-url: ${TEAMBALANCE_FRONTEND_BASE_URL:https://app.teambalance.nl}
   # Comma-separated platform-admin emails (PLATFORM_ADMIN_EMAILS). Empty default = fail-closed: nobody

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InternalEndpointGuardFilterTest.kt
@@ -15,15 +15,16 @@ import org.springframework.mock.web.MockHttpServletResponse
  */
 class InternalEndpointGuardFilterTest : FunSpec({
 
-    fun run(filter: InternalEndpointGuardFilter, uri: String): Pair<Boolean, Int> {
+    fun run(filter: InternalEndpointGuardFilter, uri: String, apiKeyHeader: String? = null): Pair<Boolean, Int> {
         val request = MockHttpServletRequest("GET", uri)
+        if (apiKeyHeader != null) request.addHeader("X-Internal-Api-Key", apiKeyHeader)
         val response = MockHttpServletResponse()
         var proceeded = false
         filter.doFilter(request, response) { _, _ -> proceeded = true }
         return proceeded to response.status
     }
 
-    val filter = InternalEndpointGuardFilter(startupActuatorEnabled = false)
+    val filter = InternalEndpointGuardFilter(startupActuatorEnabled = false, apiKey = "")
 
     context("lets through") {
         test("the exact health probe Scaleway uses") {
@@ -55,6 +56,34 @@ class InternalEndpointGuardFilterTest : FunSpec({
         }
     }
 
+    // Non-health actuator (info/metrics) is reachable from the internet only with the internal API key.
+    // CI reads /internal/actuator/info to confirm the deployed image's build SHA is actually serving.
+    context("the internal API key") {
+        val guarded = InternalEndpointGuardFilter(startupActuatorEnabled = false, apiKey = "s3cret-key")
+
+        test("lets the info endpoint through when the correct key is presented") {
+            run(guarded, "/internal/actuator/info", apiKeyHeader = "s3cret-key").first shouldBe true
+        }
+        test("blocks the info endpoint with 403 when no key is presented") {
+            val (proceeded, status) = run(guarded, "/internal/actuator/info")
+            proceeded shouldBe false
+            status shouldBe HttpServletResponse.SC_FORBIDDEN
+        }
+        test("blocks the info endpoint with 403 when a wrong key is presented") {
+            val (proceeded, status) = run(guarded, "/internal/actuator/info", apiKeyHeader = "wrong")
+            proceeded shouldBe false
+            status shouldBe HttpServletResponse.SC_FORBIDDEN
+        }
+        test("fails closed: a blank configured key never bypasses, even with a blank header") {
+            val (proceeded, status) = run(filter, "/internal/actuator/info", apiKeyHeader = "")
+            proceeded shouldBe false
+            status shouldBe HttpServletResponse.SC_FORBIDDEN
+        }
+        test("still lets the public health probe through without a key") {
+            run(guarded, "/internal/actuator/health").first shouldBe true
+        }
+    }
+
     // The startup timing endpoint is a perf-testing tool gated behind teambalance.startup.actuator.enabled.
     context("the startup timing endpoint") {
         test("is blocked with 403 by default (flag off)") {
@@ -63,11 +92,11 @@ class InternalEndpointGuardFilterTest : FunSpec({
             status shouldBe HttpServletResponse.SC_FORBIDDEN
         }
         test("is let through when the flag is set (perf-test window)") {
-            val enabled = InternalEndpointGuardFilter(startupActuatorEnabled = true)
+            val enabled = InternalEndpointGuardFilter(startupActuatorEnabled = true, apiKey = "")
             run(enabled, "/internal/actuator/startup").first shouldBe true
         }
         test("stays blocked even with the flag set once a traversal leaves the startup path") {
-            val enabled = InternalEndpointGuardFilter(startupActuatorEnabled = true)
+            val enabled = InternalEndpointGuardFilter(startupActuatorEnabled = true, apiKey = "")
             val (proceeded, status) = run(enabled, "/internal/actuator/startup/../env")
             proceeded shouldBe false
             status shouldBe HttpServletResponse.SC_FORBIDDEN

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/config/ProdProfileSmokeIT.kt
@@ -36,6 +36,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
         "teambalance.invitation.token-salt=prod-smoke-salt",
         "teambalance.email.api-key=prod-smoke-key",
         "teambalance.email.project-id=prod-smoke-project",
+        "teambalance.internal.api-key=prod-smoke-internal-key",
+        "info.build.sha=smoke-sha",
     ],
 )
 class ProdProfileSmokeIT : TeamBalanceIT() {
@@ -110,6 +112,25 @@ class ProdProfileSmokeIT : TeamBalanceIT() {
         test("everything else under /internal is blocked in prod") {
             mockMvc.perform(MockMvcRequestBuilders.get("/internal/actuator/metrics"))
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        // Deploy-verification seam: the actuator `info` endpoint carries the running image's build SHA
+        // (info.build.sha) and is opened only to a caller presenting the internal API key. The deploy
+        // pipeline reads it to confirm the exact image it pushed is serving. Without the key it is a 403
+        // like the rest of /internal; with the key it returns the SHA. Proves the exposure list, the
+        // guard's key bypass, and the env info contributor are all wired together in the prod profile.
+        test("the info endpoint is blocked in prod without the internal API key") {
+            mockMvc.perform(MockMvcRequestBuilders.get("/internal/actuator/info"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("the info endpoint reports the build SHA when the internal API key is presented") {
+            mockMvc.perform(
+                MockMvcRequestBuilders.get("/internal/actuator/info")
+                    .header("X-Internal-Api-Key", "prod-smoke-internal-key"),
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.build.sha").value("smoke-sha"))
         }
 
         // The startup timing endpoint is exposed in prod (application-prod.yml) but a perf-testing

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -36,7 +36,19 @@ rejects other arches), pushes to `rg.fr-par.scw.cloud/teambalance/api:<sha>`, an
 **image-only** update of Serverless Container `ec9dfda3-…` (fr-par). The container's
 cpu/memory/sandbox and its env/secret maps are left untouched — those are managed manually
 in the Scaleway console. The Gradle build runs *inside* the multi-stage image, so the
-runner needs no JDK/Gradle.
+runner needs no JDK/Gradle. The build bakes the commit SHA into the image (`--build-arg
+GIT_SHA`), surfaced at runtime on `/internal/actuator/info` (`info.build.sha`).
+
+**Post-deploy verification (this is why a bad image now goes red).** `scw container update`
+only *registers* the new image and returns immediately — Scaleway rolls it out
+asynchronously, so a container that crashes on boot (e.g. a Flyway checksum-validation
+failure) would otherwise leave the job **green** while prod keeps serving the old revision.
+The final `deploy-api` step polls `https://api.teambalance.nl/internal/actuator/info` — gated
+by the internal API key, so the SHA is never public — until it reports the exact SHA just
+pushed, and **fails the job (red) if the new version isn't live within ~6 min**. This proves
+the new image is actually up regardless of *why* an unhealthy one would fail to boot. On a red
+verify: check **Scaleway Cockpit** container logs for the boot crash, fix forward or roll back
+(below).
 
 **`deploy-frontend`** — builds the SPA (`vite build` auto-loads `app/.env.production` →
 `VITE_API_URL=https://api.teambalance.nl`), syncs `app/dist` → `s3://teambalance-spa`
@@ -63,6 +75,14 @@ Settings → Secrets and variables → Actions (names only — never commit valu
 | `SCW_DEFAULT_ORGANIZATION_ID` | scw CLI default organization. |
 | `SCW_S3_ACCESS_KEY` | Object Storage sync — dedicated `teambalance-object-storage` IAM key. |
 | `SCW_S3_SECRET_KEY` | Object Storage sync — its secret. |
+| `INTERNAL_API_KEY` | Post-deploy verify — sent as `X-Internal-Api-Key` to read `/internal/actuator/info`. **Must equal the container's `INTERNAL_API_KEY` env** (see below). |
+
+> **`INTERNAL_API_KEY` must be set in two places with the same value:** as the GitHub Actions
+> secret above **and** as an env/secret on the Serverless Container (Scaleway console → the
+> container's env variables — same place the other runtime secrets live). Without it on the
+> container, the guard fail-closes and the verify step can never read `info` → the deploy goes
+> red. Generate one with e.g. `openssl rand -hex 32`. It gates the non-health `/internal`
+> actuator surface (`info`/`metrics`); health stays public for Scaleway's probe.
 
 ## Rollback
 


### PR DESCRIPTION
## Why

The Flyway incident deployed **green** while prod was down. Root cause of the false-green: the `deploy-api` job's last step, `scw container container update … image=<sha>`, only *registers* the new image and returns `0` immediately. Scaleway rolls it out asynchronously, so when the new container crashed on boot (Flyway checksum validation), the job had already succeeded and prod silently kept serving the old revision. There was **no post-deploy verification**.

Companion to #190 (which fixes the migrations themselves): #190 stops *this* crash; this PR makes CI go **red** for *any* image that fails to come up, regardless of cause.

## What

SHA-level verification — CI confirms the exact image it pushed is the one serving live traffic:

- **Bake the commit SHA into the image** — Dockerfile `ARG GIT_SHA` → `ENV TEAMBALANCE_BUILD_SHA`, declared last so the expensive build/bake `COPY` layers stay cached.
- **Surface it on the actuator `info` endpoint** (`info.build.sha`, env info contributor), exposed in prod.
- **Keep the SHA private** — `InternalEndpointGuardFilter` gains an internal API key (`X-Internal-Api-Key`, constant-time compare, **fail-closed when unset**) that opens the non-health `/internal` surface. Health stays public for Scaleway's probe.
- **Verify step** — `deploy-api` polls `https://api.teambalance.nl/internal/actuator/info` with the key until it reports the pushed SHA, failing red if the new version isn't live within ~6 min. During a rollout the old revision 403s `info`, so the poll naturally waits for the new image.

## ⚠️ Required before this can go green in prod

`INTERNAL_API_KEY` must be set **with the same value in two places**:
1. GitHub Actions secret `INTERNAL_API_KEY`.
2. The Serverless Container's env (Scaleway console — where the other runtime secrets live).

Generate one with `openssl rand -hex 32`. Without it on the container the guard fail-closes and the verify step can never read `info` → deploy goes red (safe). Documented in `docs/ops/deploy.md`.

## Tests

- `InternalEndpointGuardFilterTest` — key-auth cases: correct key passes `info`, missing/wrong key 403, blank configured key never bypasses (fail-closed), health still public. **18/18.**
- `ProdProfileSmokeIT` — proves the prod exposure + key gate + SHA contributor are wired together against the real prod profile (`info` 403 without key; returns `build.sha` with key). **12/12.**
- Full local suite green via pre-commit hook: `:api:test` + `npm test` (308/308). detekt clean; `ci.yml` validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)