### PR TITLE
ci: guard Flyway migrations as append-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,35 @@ jobs:
             app/test-results/
           retention-days: 7
 
+  # Editing an already-merged migration breaks its frozen Flyway checksum and fails validation on boot.
+  migration-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Migrations are append-only
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha || github.event.before }}"
+          # No usable baseline (e.g. a branch's first push): nothing to diff against, so pass.
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base commit to diff against — skipping append-only check."
+            exit 0
+          fi
+          changed="$(git diff --diff-filter=MDR --name-only "$base" HEAD -- \
+            'api/src/main/resources/db/migration' \
+            'api/src/main/resources/db/tenant-migration')"
+          if [ -n "$changed" ]; then
+            echo "::error::Applied Flyway migrations were modified/deleted/renamed — migrations are append-only."
+            echo "Offending files:"
+            echo "$changed" | sed 's/^/  - /'
+            echo "Fix: revert the change to these files. Correct docs in the ADR, and make schema changes in a NEW migration."
+            exit 1
+          fi
+          echo "✓ No already-merged migration files were modified."
+
   # MANUAL deploy gate: runs only on push to `main`/`deploy*`, after `build`; each pauses for
   # approval via the `production` environment. Deploys the exact commit CI validated (tag = SHA).
   deploy-api:


### PR DESCRIPTION
## Why

Editing an already-merged migration file — **even a comment** — changes its Flyway checksum and makes `flyway validate` fail the app's boot against any database that already applied the old version. That is exactly what took prod down: a comment-only `ADR-0015` → `ADR-0019` renumber in `V006`/`V007`. CI's fresh-DB tests can't catch it, because an empty database just re-applies whatever the files currently say.

This is the PR-time complement to #191: that verify step catches a bad *image* at deploy time; this catches the bad *commit* before it merges.

## What

A fast `migration-guard` job (no JDK/DB, ~seconds, parallel to `build`) that fails a PR or push if any already-merged file under `db/migration` or `db/tenant-migration` is **Modified / Deleted / Renamed**:

```
git diff --diff-filter=MDR --name-only "$base" HEAD -- \
  api/src/main/resources/db/migration \
  api/src/main/resources/db/tenant-migration
```

Adding a **new** migration is allowed (that's the whole point). `base` is the PR base SHA (or the push's `before`); a missing baseline (branch's first push) passes. Test-resource migrations are intentionally out of scope — they never touch prod.

On a violation the job prints the offending files and the fix: *revert the change; correct docs in the ADR; make schema changes in a new migration.*

## Validated against real history

- **Red** on `3cfc9c8` — the comment-edit incident commit — flags `V006`/`V007`.
- **Green** on `fb9af8a` — which only *added* `V006`/`V007` — passes.
- `ci.yml` confirmed well-formed YAML; full local suite green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)