### PR TITLE
feat(app): 3-tab nav shell + safe-area (B1, F1, F3, #159)

### DIFF
--- a/app/e2e-real/auth-guard.spec.ts
+++ b/app/e2e-real/auth-guard.spec.ts
@@ -29,6 +29,10 @@ test.describe('logout', () => {
     await page.goto('/')
     await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
 
+    // The header no longer carries nav — the tab bar is the primary nav and Log out lives on the
+    // Profile page. Route there via the Profile tab, then tear the session down.
+    await page.getByRole('link', { name: 'Profile' }).click()
+    await expect(page).toHaveURL('/profile')
     await page.getByRole('button', { name: 'Log out' }).click()
     await expect(page).toHaveURL('/login')
     await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>TeamBalance</title>
     <!--
       Cold-start wake-up. The prod backend scales to zero, so kick it awake as early as possible —

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -1,10 +1,9 @@
-import { createRootRoute, redirect, Outlet, Link, useNavigate, useRouterState } from '@tanstack/react-router'
-import { useQueryClient } from '@tanstack/react-query'
+import { createRootRoute, redirect, Outlet, Link, useRouterState } from '@tanstack/react-router'
 import { useEffect, useRef } from 'react'
 import { Toaster } from 'sonner'
 import { Providers } from '@app/providers'
 import { BottomNav } from '@shared/ui/BottomNav'
-import { authMeQueryOptions, useLogout } from '@shared/api/auth'
+import { authMeQueryOptions } from '@shared/api/auth'
 import { currentMemberQueryOptions } from '@shared/api/members'
 import { queryClient } from '@shared/api/query-client'
 import { useUserStore } from '@shared/stores/user-store'
@@ -77,88 +76,37 @@ function useViewTransitions() {
   }, [location.pathname])
 }
 
-function LogoutButton() {
-  const userId = useUserStore((s) => s.userId)
-  const setCurrentUser = useUserStore((s) => s.setCurrentUser)
-  const logout = useLogout()
-  const queryClient = useQueryClient()
-  const navigate = useNavigate()
-
-  if (!userId) return null
-
-  const handleLogout = () => {
-    logout.mutate(undefined, {
-      onSuccess: () => {
-        setCurrentUser(null)
-        queryClient.setQueryData(['auth', 'me'], null)
-        navigate({ to: '/login' })
-      },
-    })
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleLogout}
-      className="text-xs font-semibold text-muted-foreground hover:text-foreground"
-    >
-      Log out
-    </button>
-  )
-}
-
 function RootLayout() {
   useViewTransitions()
-  const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
   const teamName = useUserStore((s) => s.teamName)
 
   return (
     <Providers>
-      <div className="min-h-screen bg-background">
-        <header className="sticky top-0 z-40 border-b border-border/40 bg-card/88 backdrop-blur-lg">
+      {/* min-h-dvh (not min-h-screen/100vh) so the layout measures the *visible* viewport on mobile —
+          the dynamic unit accounts for browser chrome and pairs with viewport-fit=cover. */}
+      <div className="min-h-dvh bg-background">
+        {/* The tab bar (BottomNav) is now the single primary nav — the header carries only identity
+            (wordmark + real team name, top-right), no nav links. Horizontal safe-area insets keep it
+            clear of a landscape notch now that viewport-fit=cover lets content into the inset region. */}
+        <header
+          className="sticky top-0 z-40 border-b border-border/40 bg-card/88 backdrop-blur-lg"
+          style={{ paddingLeft: 'env(safe-area-inset-left)', paddingRight: 'env(safe-area-inset-right)' }}
+        >
           <div className="flex items-center justify-between px-5 py-3">
-            <div className="flex items-center gap-3">
-              <Link to="/" className="font-display text-xl font-bold text-blue">
-                Team<span className="text-green">Balance</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-4">
-              {isAdmin && (
-                <Link
-                  to="/members"
-                  className="text-xs font-semibold text-muted-foreground hover:text-foreground"
-                  activeProps={{ className: 'text-foreground' }}
-                >
-                  Members
-                </Link>
-              )}
-              {isAdmin && (
-                <Link
-                  to="/team/settings"
-                  className="text-xs font-semibold text-muted-foreground hover:text-foreground"
-                  activeProps={{ className: 'text-foreground' }}
-                >
-                  Settings
-                </Link>
-              )}
-              <Link
-                to="/profile"
-                className="text-xs font-semibold text-muted-foreground hover:text-foreground"
-                activeProps={{ className: 'text-foreground' }}
-              >
-                Profile
-              </Link>
-              <LogoutButton />
-              {teamName && (
-                <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
-                  <span className="h-1.5 w-1.5 rounded-full bg-green" />
-                  {teamName}
-                </div>
-              )}
-            </div>
+            <Link to="/" className="font-display text-xl font-bold text-blue">
+              Team<span className="text-green">Balance</span>
+            </Link>
+            {teamName && (
+              <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
+                <span className="h-1.5 w-1.5 rounded-full bg-green" />
+                {teamName}
+              </div>
+            )}
           </div>
         </header>
-        <main className="mx-auto max-w-2xl px-4 py-6 pb-24">
+        {/* Bottom padding clears the fixed nav (~6rem) plus the home-indicator inset, so the last
+            row of content is never hidden behind the bar on notched devices. */}
+        <main className="mx-auto max-w-2xl px-4 py-6 pb-[calc(6rem+env(safe-area-inset-bottom))]">
           <Outlet />
         </main>
         <BottomNav />

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -5,7 +5,6 @@ import {useEventTypes} from '@shared/api/event-types'
 import {useUserStore} from '@shared/stores/user-store'
 import {EventListView} from '@entities/event/ui/EventListView'
 import {CreateEventSheet} from '@widgets/create-event/ui/CreateEventSheet'
-import {GenerateInviteDialog} from '@features/generate-invite/ui/GenerateInviteDialog'
 import {toggleTypeSelection} from '@features/filter-event-types/model/toggleTypeSelection'
 
 export const Route = createFileRoute('/')({
@@ -61,12 +60,9 @@ function EventListPage() {
         <div>
             <div className="flex items-center justify-between">
                 <h2 className="font-display text-2xl font-bold">Events</h2>
-                {isAdmin && (
-                    <div className="flex items-center gap-2">
-                        <GenerateInviteDialog/>
-                        <CreateEventSheet/>
-                    </div>
-                )}
+                {/* The invite link moved to the Team page (team-management action); Events keeps
+                    only event creation for admins. */}
+                {isAdmin && <CreateEventSheet/>}
             </div>
 
             {/* Segmented pill toggle */}

--- a/app/src/routes/profile/index.tsx
+++ b/app/src/routes/profile/index.tsx
@@ -1,11 +1,48 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCurrentMember, useUpdateMember, MemberUpdateError } from '@shared/api/members'
 import { usePositions } from '@shared/api/positions'
+import { useLogout } from '@shared/api/auth'
+import { useUserStore } from '@shared/stores/user-store'
 import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
 
 export const Route = createFileRoute('/profile/')({
   component: ProfilePage,
 })
+
+/**
+ * Log out lives on the Profile page now that the header carries no nav (the tab bar is the primary
+ * nav). Same logic as before: clear the session, drop the cached /me, and route to /login.
+ */
+function LogoutButton() {
+  const userId = useUserStore((s) => s.userId)
+  const setCurrentUser = useUserStore((s) => s.setCurrentUser)
+  const logout = useLogout()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  if (!userId) return null
+
+  const handleLogout = () => {
+    logout.mutate(undefined, {
+      onSuccess: () => {
+        setCurrentUser(null)
+        queryClient.setQueryData(['auth', 'me'], null)
+        navigate({ to: '/login' })
+      },
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleLogout}
+      className="text-sm font-semibold text-muted-foreground hover:text-foreground"
+    >
+      Log out
+    </button>
+  )
+}
 
 /**
  * Container for the profile screen: wires the current-member query and the update mutation to the
@@ -39,6 +76,10 @@ function ProfilePage() {
           />
         </div>
       )}
+
+      <div className="mt-10 border-t border-border/40 pt-6">
+        <LogoutButton />
+      </div>
     </div>
   )
 }

--- a/app/src/routes/team/index.tsx
+++ b/app/src/routes/team/index.tsx
@@ -1,18 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
+import { TeamHeader } from '@widgets/team-header/ui/TeamHeader'
+import { useUserStore } from '@shared/stores/user-store'
 
 // The team roster for every authenticated member — no admin gate (the root route already guarantees
-// authenticated + onboarded). Read-only for everyone, admins included: this is the view surface;
-// all member management lives on the admin-gated /team/settings. The heading stays a literal "Team";
-// showing the real team name is deferred (F14).
+// authenticated + onboarded). Read-only for everyone, admins included: this is the view surface.
+// Member management lives on the admin-gated /team/settings, reached via the gear in the header
+// (below, admin-only) — the entry point under the new tab-bar nav.
 export const Route = createFileRoute('/team/')({
   component: TeamPage,
 })
 
 function TeamPage() {
+  const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
+
   return (
     <div className="flex flex-col gap-6">
-      <h2 className="font-display text-2xl font-bold">Team</h2>
+      <TeamHeader isAdmin={isAdmin} />
       <MemberRoster canManage={false} />
     </div>
   )

--- a/app/src/routes/team/index.tsx
+++ b/app/src/routes/team/index.tsx
@@ -1,12 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
+import { GenerateInviteDialog } from '@features/generate-invite/ui/GenerateInviteDialog'
 import { TeamHeader } from '@widgets/team-header/ui/TeamHeader'
 import { useUserStore } from '@shared/stores/user-store'
 
 // The team roster for every authenticated member — no admin gate (the root route already guarantees
 // authenticated + onboarded). Read-only for everyone, admins included: this is the view surface.
-// Member management lives on the admin-gated /team/settings, reached via the gear in the header
-// (below, admin-only) — the entry point under the new tab-bar nav.
+// Admins additionally get the invite link + the gear in the header (below) linking into
+// /team/settings, where member management lives — the team actions on the team screen, under the
+// new tab-bar nav.
 export const Route = createFileRoute('/team/')({
   component: TeamPage,
 })
@@ -16,7 +18,7 @@ function TeamPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <TeamHeader isAdmin={isAdmin} />
+      <TeamHeader isAdmin={isAdmin} actions={<GenerateInviteDialog />} />
       <MemberRoster canManage={false} />
     </div>
   )

--- a/app/src/shared/testing/router-decorator.tsx
+++ b/app/src/shared/testing/router-decorator.tsx
@@ -11,19 +11,19 @@ import {
 
 // A catch-all splat child so a <Link to="/anything"> resolves regardless of the target — the
 // decorator stays generic instead of accreting one route per linking component.
-function buildRouter(Story: FunctionComponent) {
+function buildRouter(Story: FunctionComponent, initialEntries: string[]) {
   const rootRoute = createRootRoute({ component: Story })
   const catchAll = createRoute({ getParentRoute: () => rootRoute, path: '$', component: () => null })
   return createRouter({
     routeTree: rootRoute.addChildren([catchAll]),
-    history: createMemoryHistory({ initialEntries: ['/'] }),
+    history: createMemoryHistory({ initialEntries }),
   })
 }
 
-function StoryRouter({ Story }: { Story: FunctionComponent }) {
+function StoryRouter({ Story, initialEntries }: { Story: FunctionComponent; initialEntries: string[] }) {
   // Build the router once per mount, not on every render, so interaction (play) re-renders don't
   // discard the live router and reset its state mid-story.
-  const router = useMemo(() => buildRouter(Story), [Story])
+  const router = useMemo(() => buildRouter(Story, initialEntries), [Story, initialEntries])
   return <RouterProvider router={router} />
 }
 
@@ -32,5 +32,11 @@ function StoryRouter({ Story }: { Story: FunctionComponent }) {
  * render a <Link> (e.g. EventCard's link to /events/$eventId) need a router in context; the root
  * route renders the story and a catch-all child resolves any link target — without pulling in the
  * app's full generated route tree.
+ *
+ * Route-aware components (BottomNav derives its active tab from the current path) can start the
+ * router at a specific path via `parameters.router.initialEntries` — defaults to `['/']`.
  */
-export const withRouter: Decorator = (Story) => <StoryRouter Story={Story} />
+export const withRouter: Decorator = (Story, context) => {
+  const initialEntries: string[] = context.parameters?.router?.initialEntries ?? ['/']
+  return <StoryRouter Story={Story} initialEntries={initialEntries} />
+}

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -4,8 +4,9 @@ import { withRouter } from '@shared/testing/router-decorator'
 import { BottomNav } from './BottomNav'
 
 // BottomNav renders TanStack Router <Link>s, so it needs a router in context — supplied by the
-// shared withRouter decorator. It is stateless: Events is the active tab, Money Pool and Team are
-// disabled (rendered but non-interactive). One story pins that fixed layout.
+// shared withRouter decorator. It is now a live three-tab bar (Events · Team · Profile) with no
+// disabled tabs; the active tab is derived from the current route. Each story starts the router at
+// a different path (via parameters.router.initialEntries) to pin the active-state wiring.
 const meta = {
   title: 'shared/ui/BottomNav',
   component: BottomNav,
@@ -16,13 +17,58 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
+// Every tab routes to a real destination — assert the href wiring holds regardless of which is active.
+async function expectTabTargets(canvas: Parameters<NonNullable<Story['play']>>[0]['canvas']) {
+  await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('href', '/')
+  await expect(canvas.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/team')
+  await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/profile')
+  // No dead tabs: nothing is disabled/non-interactive anymore.
+  await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('pointer-events-none')
+  await expect(canvas.getByRole('link', { name: 'Team' })).not.toHaveClass('pointer-events-none')
+  await expect(canvas.getByRole('link', { name: 'Profile' })).not.toHaveClass('pointer-events-none')
+  // Money Pool is gone entirely.
+  await expect(canvas.queryByRole('link', { name: 'Money Pool' })).not.toBeInTheDocument()
+}
+
+export const EventsActive: Story = {
+  parameters: { router: { initialEntries: ['/'] } },
   play: async ({ canvas }) => {
-    // Every tab points at "/" (the other sections don't exist yet), so the router marks them all
-    // aria-current — the active/disabled split lives in the styling instead: Events is the live
-    // blue tab; Money Pool and Team are rendered but non-interactive.
+    await expectTabTargets(canvas)
     await expect(canvas.getByRole('link', { name: 'Events' })).toHaveClass('text-blue')
-    await expect(canvas.getByRole('link', { name: 'Money Pool' })).toHaveClass('pointer-events-none')
-    await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('pointer-events-none')
+    await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('aria-current', 'page')
+    await expect(canvas.getByRole('link', { name: 'Team' })).not.toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Profile' })).not.toHaveClass('text-blue')
+  },
+}
+
+export const TeamActive: Story = {
+  parameters: { router: { initialEntries: ['/team'] } },
+  play: async ({ canvas }) => {
+    await expectTabTargets(canvas)
+    await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Team' })).toHaveAttribute('aria-current', 'page')
+    // Events must not stay active on a nested route — an exact-match seam, not a prefix match.
+    await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Profile' })).not.toHaveClass('text-blue')
+  },
+}
+
+// The Team tab stays active on nested team routes (e.g. the admin settings sub-page).
+export const TeamSettingsActive: Story = {
+  parameters: { router: { initialEntries: ['/team/settings'] } },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')
+  },
+}
+
+export const ProfileActive: Story = {
+  parameters: { router: { initialEntries: ['/profile'] } },
+  play: async ({ canvas }) => {
+    await expectTabTargets(canvas)
+    await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('aria-current', 'page')
+    await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')
+    await expect(canvas.getByRole('link', { name: 'Team' })).not.toHaveClass('text-blue')
   },
 }

--- a/app/src/shared/ui/BottomNav.tsx
+++ b/app/src/shared/ui/BottomNav.tsx
@@ -1,48 +1,55 @@
-import { Link } from '@tanstack/react-router'
-import { Calendar, Wallet, Users, type LucideIcon } from 'lucide-react'
+import { Link, useRouterState } from '@tanstack/react-router'
+import { Calendar, Users, User, type LucideIcon } from 'lucide-react'
 
 interface TabConfig {
   icon: LucideIcon
   label: string
-  to: '/'
-  active: boolean
-  disabled: boolean
+  to: string
+  // How to match the current path to this tab. Events is exact ('/' would prefix-match everything);
+  // Team also owns its nested routes (e.g. /team/settings), so it matches by prefix.
+  isActive: (pathname: string) => boolean
 }
 
 const TABS: TabConfig[] = [
-  { icon: Calendar, label: 'Events', to: '/', active: true, disabled: false },
-  { icon: Wallet, label: 'Money Pool', to: '/', active: false, disabled: true },
-  { icon: Users, label: 'Team', to: '/', active: false, disabled: true },
+  { icon: Calendar, label: 'Events', to: '/', isActive: (p) => p === '/' },
+  { icon: Users, label: 'Team', to: '/team', isActive: (p) => p === '/team' || p.startsWith('/team/') },
+  { icon: User, label: 'Profile', to: '/profile', isActive: (p) => p === '/profile' || p.startsWith('/profile/') },
 ]
 
 export function BottomNav() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border/40 bg-card/88 backdrop-blur-lg">
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border/40 bg-card/88 backdrop-blur-lg"
+      // Fixed to the viewport bottom, so pad past the home-indicator inset (viewport-fit=cover) to
+      // keep the tabs tappable above it. Zero on devices without an inset.
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
       <div className="mx-auto flex max-w-2xl items-center justify-around px-2 py-1">
-        {TABS.map(({ icon: Icon, label, to, active, disabled }) => (
-          <Link
-            key={label}
-            to={to}
-            className={[
-              'flex flex-col items-center gap-0.5 px-4 py-2 text-xs transition-colors',
-              disabled
-                ? 'pointer-events-none select-none text-muted-foreground/40'
-                : active
-                  ? 'text-blue'
-                  : 'text-muted-foreground hover:text-foreground',
-            ].join(' ')}
-            aria-current={active ? 'page' : undefined}
-          >
-            <span className="relative flex items-center justify-center">
-              <span
-                className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-7 w-11 rounded-full transition-transform duration-300 bg-blue/10 ${active ? 'scale-100' : 'scale-0'}`}
-                style={{ transitionTimingFunction: 'cubic-bezier(0.34, 1.56, 0.64, 1)' }}
-              />
-              <Icon size={22} strokeWidth={active ? 2.5 : 1.75} className="relative z-10" />
-            </span>
-            <span className={active ? 'font-medium' : ''}>{label}</span>
-          </Link>
-        ))}
+        {TABS.map(({ icon: Icon, label, to, isActive }) => {
+          const active = isActive(pathname)
+          return (
+            <Link
+              key={label}
+              to={to}
+              className={[
+                'flex flex-col items-center gap-0.5 px-4 py-2 text-xs transition-colors',
+                active ? 'text-blue' : 'text-muted-foreground hover:text-foreground',
+              ].join(' ')}
+              aria-current={active ? 'page' : undefined}
+            >
+              <span className="relative flex items-center justify-center">
+                <span
+                  className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-7 w-11 rounded-full transition-transform duration-300 bg-blue/10 ${active ? 'scale-100' : 'scale-0'}`}
+                  style={{ transitionTimingFunction: 'cubic-bezier(0.34, 1.56, 0.64, 1)' }}
+                />
+                <Icon size={22} strokeWidth={active ? 2.5 : 1.75} className="relative z-10" />
+              </span>
+              <span className={active ? 'font-medium' : ''}>{label}</span>
+            </Link>
+          )
+        })}
       </div>
     </nav>
   )

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
+import { Button } from '@shared/ui/button'
 import { TeamHeader } from './TeamHeader'
 
 // TeamHeader renders a TanStack Router <Link> for the admin gear, so it needs a router in context.
@@ -15,9 +16,12 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-// A stand-in for the real GenerateInviteDialog trigger (a container that needs a QueryClient);
-// the story only needs to prove the slot renders in the admin actions area.
-const inviteAction = <button type="button">Invite Link</button>
+// A stand-in for the real GenerateInviteDialog trigger (a container that needs a QueryClient).
+// It mirrors the real trigger's markup exactly — `<Button variant="outline">Invite Link</Button>`
+// — so the Chromatic snapshot of the admin header is visually faithful (an actual button, not
+// bare text). The story only needs the slot to render; the dialog behaviour is covered by the
+// generate-invite feature's own stories.
+const inviteAction = <Button variant="outline">Invite Link</Button>
 
 export const Admin: Story = {
   args: { isAdmin: true, actions: inviteAction },

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -15,20 +15,28 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+// A stand-in for the real GenerateInviteDialog trigger (a container that needs a QueryClient);
+// the story only needs to prove the slot renders in the admin actions area.
+const inviteAction = <button type="button">Invite Link</button>
+
 export const Admin: Story = {
-  args: { isAdmin: true },
+  args: { isAdmin: true, actions: inviteAction },
   play: async ({ canvas }) => {
     const gear = canvas.getByRole('link', { name: 'Team settings' })
     await expect(gear).toBeInTheDocument()
     await expect(gear).toHaveAttribute('href', '/team/settings')
+    // The admin actions slot (invite link) renders alongside the gear.
+    await expect(canvas.getByRole('button', { name: 'Invite Link' })).toBeInTheDocument()
   },
 }
 
 export const Member: Story = {
-  args: { isAdmin: false },
+  args: { isAdmin: false, actions: inviteAction },
   play: async ({ canvas }) => {
-    // Title still renders; the settings gear is the only admin-gated element and must be absent.
+    // Title still renders; the gear and the admin actions are the only admin-gated elements and
+    // must both be absent — a non-admin never sees the invite link even when one is passed.
     await expect(canvas.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
     await expect(canvas.queryByRole('link', { name: 'Team settings' })).not.toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Invite Link' })).not.toBeInTheDocument()
   },
 }

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import { TeamHeader } from './TeamHeader'
+
+// TeamHeader renders a TanStack Router <Link> for the admin gear, so it needs a router in context.
+// The two stories pin the only behaviour that matters: admins see the settings entry, members don't.
+const meta = {
+  title: 'widgets/team-header/TeamHeader',
+  component: TeamHeader,
+  decorators: [withRouter],
+} satisfies Meta<typeof TeamHeader>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Admin: Story = {
+  args: { isAdmin: true },
+  play: async ({ canvas }) => {
+    const gear = canvas.getByRole('link', { name: 'Team settings' })
+    await expect(gear).toBeInTheDocument()
+    await expect(gear).toHaveAttribute('href', '/team/settings')
+  },
+}
+
+export const Member: Story = {
+  args: { isAdmin: false },
+  play: async ({ canvas }) => {
+    // Title still renders; the settings gear is the only admin-gated element and must be absent.
+    await expect(canvas.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    await expect(canvas.queryByRole('link', { name: 'Team settings' })).not.toBeInTheDocument()
+  },
+}

--- a/app/src/widgets/team-header/ui/TeamHeader.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.tsx
@@ -1,0 +1,29 @@
+import { Link } from '@tanstack/react-router'
+import { Settings } from 'lucide-react'
+
+interface TeamHeaderProps {
+  /** Only admins get the entry into /team/settings; the page itself is read-only for everyone. */
+  isAdmin: boolean
+}
+
+/**
+ * Presentational header for the /team page: the "Team" title plus, for admins only, a gear that
+ * links to /team/settings. Prop-only (no store/query access) so both visibility states render from
+ * props in Storybook — the container (routes/team/index.tsx) reads the role and passes isAdmin.
+ */
+export function TeamHeader({ isAdmin }: TeamHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="font-display text-2xl font-bold">Team</h2>
+      {isAdmin && (
+        <Link
+          to="/team/settings"
+          aria-label="Team settings"
+          className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-blue/8 hover:text-foreground"
+        >
+          <Settings size={20} />
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/app/src/widgets/team-header/ui/TeamHeader.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.tsx
@@ -1,28 +1,38 @@
+import type { ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Settings } from 'lucide-react'
 
 interface TeamHeaderProps {
   /** Only admins get the entry into /team/settings; the page itself is read-only for everyone. */
   isAdmin: boolean
+  /**
+   * Admin-only actions rendered to the left of the settings gear (e.g. the invite-link dialog).
+   * Passed in by the container so this stays prop-only/network-free — never rendered for non-admins.
+   */
+  actions?: ReactNode
 }
 
 /**
- * Presentational header for the /team page: the "Team" title plus, for admins only, a gear that
- * links to /team/settings. Prop-only (no store/query access) so both visibility states render from
- * props in Storybook — the container (routes/team/index.tsx) reads the role and passes isAdmin.
+ * Presentational header for the /team page: the "Team" title plus, for admins only, an actions
+ * area (invite link + gear into /team/settings). Prop-only (no store/query access) so both
+ * visibility states render from props in Storybook — the container (routes/team/index.tsx) reads
+ * the role and supplies isAdmin and the admin actions.
  */
-export function TeamHeader({ isAdmin }: TeamHeaderProps) {
+export function TeamHeader({ isAdmin, actions }: TeamHeaderProps) {
   return (
     <div className="flex items-center justify-between">
       <h2 className="font-display text-2xl font-bold">Team</h2>
       {isAdmin && (
-        <Link
-          to="/team/settings"
-          aria-label="Team settings"
-          className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-blue/8 hover:text-foreground"
-        >
-          <Settings size={20} />
-        </Link>
+        <div className="flex items-center gap-2">
+          {actions}
+          <Link
+            to="/team/settings"
+            aria-label="Team settings"
+            className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-blue/8 hover:text-foreground"
+          >
+            <Settings size={20} />
+          </Link>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## What & why

Slice **B1** — the nav shell + safe-area — for findings **F1** and **F3** of #159 (wave-2 sequencing: https://github.com/ZzAve/teambalance-app/issues/159#issuecomment-5220950575).

### F1 — real 3-tab nav shell
- **`BottomNav.tsx`** was split-brain: 2 of 3 tabs `disabled`, all three `to="/"`. Replaced with a live three-tab bar **Events · Team · Profile** routing to `/`, `/team`, `/profile`. Active state is now **derived from the current route** (`useRouterState`) rather than hardcoded `active` flags — no `disabled` tabs. Events matches exactly (`/`), Team matches its subtree (so `/team/settings` keeps Team lit). The active-pill animation is preserved unchanged. The **"Money Pool" tab is dropped** entirely (no dead tabs until the Bunq feature exists).
- **`__root.tsx`** — the tab bar is now the single primary nav. Removed the top-header admin links (`Members`, `Settings`), the `Profile` link, and the `Log out` button; kept the wordmark + team badge. **Log out relocated to the Profile page** (`routes/profile/index.tsx`), same logic as before.
- **Admin gear on `/team`** — admins (`useUserStore(s => s.role) === 'ADMIN'`) get a settings gear in the page header linking to `/team/settings`; non-admins don't. Implemented as a new **`widgets/team-header`** presentational View (container/View split per ADR-0017) so both visibility states are storyable.

### F3 — safe-area (bundled into this slice)
- `app/index.html`: `viewport-fit=cover` added to the viewport meta.
- `BottomNav.tsx`: `env(safe-area-inset-bottom)` padding so the fixed nav clears the home indicator.
- `__root.tsx`: `min-h-screen` → `min-h-dvh`; `main` bottom padding is now `calc(6rem + env(safe-area-inset-bottom))` (nav height + inset); left/right insets applied to the sticky top header now that content can enter the inset region.
- (There is no `100vh` in the codebase — only `min-h-screen` — so nothing else to change.)

## Testing (PR gate)
- **Story-first (TDD).** `BottomNav.stories.tsx` rewritten: per-route active-state stories (`EventsActive`, `TeamActive`, `TeamSettingsActive`, `ProfileActive`), asserting href wiring, `aria-current`, active class, and **no disabled tabs / no Money Pool**. Driven by a new, backward-compatible `parameters.router.initialEntries` hook on the shared `withRouter` decorator (defaults to `['/']`).
- **Admin-gear visibility** covered by `widgets/team-header/TeamHeader.stories.tsx` (`Admin` sees the gear → `/team/settings`; `Member` does not).
- **No new e2e** — the nav is not a new seam; the existing login/attendance flows already exercise the shell (per the gate).
- `make lint` (eslint) ✅ · clean `tsc -b` ✅ · full `make test-app` ✅ (58 files / 314 tests).
- Story tests were run against the environment's Chromium build; no config change is committed for that.

## Dependencies & notes
- **Stacked on #183 (B2, still OPEN).** This branch is based on `claude/b2-team-page`, so the diff will show #183's `/team` route until #183 merges — expected. This PR does **not** re-create the `/team` route.
- **Known B2 fork (not fixed here):** the wave-2 decision makes `/team` read-only for everyone with member management moving to `/team/settings`, but #183 currently keeps admins editing inline on `/team`. The admin gear added here is correct under either outcome, and the nav/shell diff is independent of that fork — flagging per the handoff, not resolving it in B1.

Refs #159. Depends on #183.


---
_Generated by [Claude Code](https://claude.ai/code/session_016iGGyhkHutmovua7NHs6Nq)_