### PR TITLE
chore(hooks): quiet the pre-commit gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,4 +6,27 @@
 # Fast-builds and runs the unit/IT test suite before allowing a commit.
 # (e2e, lint and auto-format are left to CI / pre-push — they need a running
 # stack or mutate files, which makes a per-commit gate slow and flaky.)
-exec make yolo test
+#
+# Output is captured to a temp log to keep commits quiet: on success the log is
+# removed silently; on failure the last lines are printed inline and the full
+# log is kept for inspection.
+
+log="$(mktemp "${TMPDIR:-/tmp}/teambalance-precommit.XXXXXX")"
+
+printf 'pre-commit: running "make yolo test" (quiet — log: %s)\n' "$log"
+
+make yolo test >"$log" 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+    rm -f "$log"
+    echo 'pre-commit: ✓ passed'
+else
+    echo 'pre-commit: ✗ FAILED — last 20 lines:' >&2
+    echo '----------------------------------------------------------------------' >&2
+    tail -n 20 "$log" >&2
+    echo '----------------------------------------------------------------------' >&2
+    printf 'pre-commit: full log kept at %s\n' "$log" >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
## Why

The pre-commit hook was `exec make yolo test` — the full build + unit/IT suite with **all output streamed straight to the terminal**, so every commit dumped thousands of lines (a recent one was 2.2 MB). The signal (did it pass?) was buried.

## What

Capture the suite's output to a temp log and stay quiet unless it matters:

- **Success** → the log is deleted, and the hook prints a single `✓ passed` line.
- **Failure** → the **last 20 lines** are printed inline (enough to see the actual error), the full log is **kept** with its path shown, and the suite's **exit status is preserved** so the commit is still blocked.

Nothing about *what* runs changes (`make yolo test`), only how its output is surfaced.

## Validated

- Ran the real hook with a fake `make`: exit 0 → quiet + log removed; exit 3 with 25 lines of output → last 20 lines shown, log kept, exit 3 propagated.
- Dogfooded: this very commit was made with the new hook installed — its entire output was the two-line quiet form, and the suite still ran green.

File mode (755) preserved; installed the same way as before via the `installGitHooks` Gradle task / `make hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)