### PR TITLE
refactor(app): /team read-only for everyone; member management in /team/settings (B2, #159)

### DIFF
--- a/app/src/features/manage-members/ui/MemberRoster.tsx
+++ b/app/src/features/manage-members/ui/MemberRoster.tsx
@@ -1,18 +1,27 @@
 import { MemberUpdateError, useMembers, useRemoveMember, useUpdateMember } from '@shared/api/members'
 import { usePositions } from '@shared/api/positions'
-import { useUserStore } from '@shared/stores/user-store'
 import { toggleRole } from '../lib/roster'
 import { MemberRosterView } from './MemberRosterView'
+
+interface MemberRosterProps {
+  /**
+   * Whether this surface may edit the roster. The caller decides, not the user's role: `/team`
+   * renders it read-only for everyone (`false`, the default), `/team/settings` (already admin-gated)
+   * renders it manageable (`true`). Off by default so a bare `<MemberRoster />` is never accidentally
+   * editable.
+   */
+  canManage?: boolean
+}
 
 /**
  * Container for the roster: wires the members query and the update/remove mutations to the
  * presentational MemberRosterView. Pure wiring — the load/error/data shells live in the View
- * (props-driven), so this seam is covered by e2e, not a story. Every authenticated member can read
- * the roster; `canManage` (admin only) gates the per-row edit controls. Promote/demote reuses the
- * update mutation with the toggled role and the unchanged display name. See ADR-0017.
+ * (props-driven), so this seam is covered by e2e, not a story. Manage-capability is passed in by the
+ * route (`canManage`), not derived from the user's role here — view (`/team`) vs. manage
+ * (`/team/settings`). Promote/demote reuses the update mutation with the toggled role and the
+ * unchanged display name. See ADR-0017.
  */
-export function MemberRoster() {
-  const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
+export function MemberRoster({ canManage = false }: MemberRosterProps) {
   const { data: members, isLoading, error } = useMembers()
   const { data: positions } = usePositions()
   const updateMember = useUpdateMember()
@@ -34,7 +43,7 @@ export function MemberRoster() {
   return (
     <MemberRosterView
       members={members}
-      canManage={isAdmin}
+      canManage={canManage}
       positions={positions ?? []}
       isLoading={isLoading}
       isError={!!error}

--- a/app/src/routes/team/index.tsx
+++ b/app/src/routes/team/index.tsx
@@ -2,8 +2,9 @@ import { createFileRoute } from '@tanstack/react-router'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
 
 // The team roster for every authenticated member — no admin gate (the root route already guarantees
-// authenticated + onboarded). MemberRoster reads the user's role and renders read-only rows for
-// non-admins. The heading stays a literal "Team"; showing the real team name is deferred (F14).
+// authenticated + onboarded). Read-only for everyone, admins included: this is the view surface;
+// all member management lives on the admin-gated /team/settings. The heading stays a literal "Team";
+// showing the real team name is deferred (F14).
 export const Route = createFileRoute('/team/')({
   component: TeamPage,
 })
@@ -12,7 +13,7 @@ function TeamPage() {
   return (
     <div className="flex flex-col gap-6">
       <h2 className="font-display text-2xl font-bold">Team</h2>
-      <MemberRoster />
+      <MemberRoster canManage={false} />
     </div>
   )
 }

--- a/app/src/routes/team/settings.tsx
+++ b/app/src/routes/team/settings.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { authMeQueryOptions } from '@shared/api/auth'
 import { queryClient } from '@shared/api/query-client'
+import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
 import { TeamSettings } from '@features/team-settings/ui/TeamSettings'
 import { ManagePositions } from '@features/manage-positions/ui/ManagePositions'
 
@@ -20,10 +21,13 @@ export const Route = createFileRoute('/team/settings')({
 })
 
 function TeamSettingsPage() {
+  // Admin manage surface: member management (the editable roster), then positions, then team
+  // settings. The read-only view of the same roster lives on /team.
   return (
     <div className="flex flex-col gap-10">
-      <TeamSettings />
+      <MemberRoster canManage />
       <ManagePositions />
+      <TeamSettings />
     </div>
   )
 }


### PR DESCRIPTION
## What & why

Conforms slice **B2** (#159) to the [wave-2 decision](https://github.com/ZzAve/teambalance-app/issues/159#issuecomment-5220950575). The merged PR #183 made `/team` read-only **only for non-admins** (admins still edited the roster inline). The decision is a clean **view-vs-manage split**:

- **`/team` is the read-only roster for _everyone_, admins included** — the view surface.
- **All member-management mutations move to `/team/settings`** (already admin-gated), alongside the existing `ManagePositions` + `TeamSettings` — the manage surface.

> #183 is already merged, so this couldn't be pushed onto it — it lands as a follow-up on `claude/b2-team-page-ynsz19`.

## Changes

- **`MemberRoster`** — manage-capability is now an explicit `canManage?: boolean` prop (default `false`), decided by the route rather than derived from the user's role internally (dropped the `useUserStore` role read).
- **`/team`** (`routes/team/index.tsx`) — renders `<MemberRoster canManage={false} />`: read-only rows for all roles, no rename input / role toggle / position picker / remove. The role/admin badge stays visible.
- **`/team/settings`** (`routes/team/settings.tsx`, already admin-only via `beforeLoad`) — renders `<MemberRoster canManage />` first, then `ManagePositions`, then `TeamSettings`.
- **No admin gear** added to the `/team` header — that belongs to slice B1 (separate in-flight branch off `claude/b2-team-page`). The `/team` header stays the minimal "Team" heading to avoid conflicting with B1.

Everything else from #183 is unchanged: `/members` still redirects to `/team`, `create-team` still lands on `/team`, avatar handling untouched.

## Testing (PR gate)

- **Stories reused, not added:** `MemberRosterView` already carries `canManage: true` (`Default`) and `canManage: false` (`ReadOnly`) stories asserting the two states; both still hold. The route wiring (which route passes which `canManage`) is thin container wiring → covered by manual verification + e2e, not a new story.
- **No new e2e** — no new seam; the login/attendance flows already exercise the app shell.
- `make test-app` → **57 files, 309 tests passed**.
- `eslint` clean; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFKmasCr7Uge2jhthAm9Sf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha9Cgq6gh4915P5oChsBrV)_