### PR TITLE
feat: add teamName to user store and display in header

### DIFF
--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -110,6 +110,7 @@ function LogoutButton() {
 function RootLayout() {
   useViewTransitions()
   const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
+  const teamName = useUserStore((s) => s.teamName)
 
   return (
     <Providers>
@@ -120,10 +121,6 @@ function RootLayout() {
               <Link to="/" className="font-display text-xl font-bold text-blue">
                 Team<span className="text-green">Balance</span>
               </Link>
-              <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
-                <span className="h-1.5 w-1.5 rounded-full bg-green" />
-                Heren 3
-              </div>
             </div>
             <div className="flex items-center gap-4">
               {isAdmin && (
@@ -152,6 +149,12 @@ function RootLayout() {
                 Profile
               </Link>
               <LogoutButton />
+              {teamName && (
+                <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
+                  <span className="h-1.5 w-1.5 rounded-full bg-green" />
+                  {teamName}
+                </div>
+              )}
             </div>
           </div>
         </header>

--- a/app/src/shared/stores/user-store.test.ts
+++ b/app/src/shared/stores/user-store.test.ts
@@ -5,7 +5,7 @@ import { useUserStore } from './user-store'
 // Pure store logic — the setCurrentUser mapping from AuthenticatedUser onto the flat store shape.
 // No rendering (that would be Storybook's job); this is the "stores" case the strategy assigns to
 // Vitest. Reset to the initial snapshot between tests so ordering can't leak state.
-const INITIAL = { userId: null, displayName: null, email: null, role: null }
+const INITIAL = { userId: null, displayName: null, email: null, role: null, teamName: null }
 
 describe('user-store', () => {
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('user-store', () => {
       email: 'alice@example.com',
       displayName: 'Alice',
       role: 'ADMIN',
-      team: undefined,
+      team: { id: 't-1', name: 'Heren 3', slug: 'heren-3' },
     }
 
     useUserStore.getState().setCurrentUser(user)
@@ -28,7 +28,20 @@ describe('user-store', () => {
       displayName: 'Alice',
       email: 'alice@example.com',
       role: 'ADMIN',
+      teamName: 'Heren 3',
     })
+  })
+
+  it('defaults teamName to null when the user has no team', () => {
+    useUserStore.getState().setCurrentUser({
+      id: 'u-3',
+      email: 'carol@example.com',
+      displayName: 'Carol',
+      role: undefined,
+      team: undefined,
+    })
+
+    expect(useUserStore.getState().teamName).toBeNull()
   })
 
   it('defaults role to null when the user has none', () => {

--- a/app/src/shared/stores/user-store.ts
+++ b/app/src/shared/stores/user-store.ts
@@ -6,6 +6,7 @@ interface UserState {
   displayName: string | null
   email: string | null
   role: string | null
+  teamName: string | null
   setCurrentUser: (user: AuthenticatedUser | null) => void
 }
 
@@ -14,11 +15,13 @@ export const useUserStore = create<UserState>((set) => ({
   displayName: null,
   email: null,
   role: null,
+  teamName: null,
   setCurrentUser: (user) =>
     set({
       userId: user?.id ?? null,
       displayName: user?.displayName ?? null,
       email: user?.email ?? null,
       role: user?.role ?? null,
+      teamName: user?.team?.name ?? null,
     }),
 }))


### PR DESCRIPTION
## Summary

Extends the user store to track the authenticated user's team name, and moves the team badge from a hardcoded position in the header to a dynamic display in the user menu that only appears when a team is assigned.

## Changes

- **User store** (`user-store.ts`): Added `teamName: string | null` field to `UserState`, populated from `user.team.name` in `setCurrentUser()`
- **Header layout** (`__root.tsx`): Moved team badge from the logo area to the user menu (after logout button), conditionally rendered only when `teamName` is truthy
- **Store tests** (`user-store.test.ts`): Updated initial state snapshot to include `teamName: null`, changed test fixture from `team: undefined` to a real team object, added test case for `teamName` defaulting to null when user has no team

## Implementation details

- The team badge now only displays when a user is assigned to a team, improving UX for multi-tenant scenarios
- Extraction of `team.name` into a flat store field follows the existing pattern for other user properties (`role`, `email`, etc.)
- No changes to the API contract or authentication flow — purely a store and UI reorganization

https://claude.ai/code/session_01W4nSn2y2xb4pGKd6GkmY1A