### PR TITLE
feat: onboarding fork (join vs create) + /welcome → /get-started rename

### DIFF
--- a/app/e2e-real/create-team.spec.ts
+++ b/app/e2e-real/create-team.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test'
 
 // Real e2e (#158): self-service create-team across the whole seam — browser → API → DB. A teamless,
-// authenticated user enters a creation code + name + slug, becomes founding ADMIN, and lands inside
-// their new team. This is the create-team seam #154 Slice 3 justified (cross-tenant provisioning + the
-// code gate — not covered by the login or attendance flows); it lives here because #158 replaces the
-// throwaway Slice-3 tracer, so the net e2e count is unchanged.
+// authenticated user lands on the /onboarding fork, clicks through to /create-team, enters a creation
+// code + name + slug, becomes founding ADMIN, and lands inside their new team. This is the create-team
+// seam #154 Slice 3 justified (cross-tenant provisioning + the code gate — not covered by the login or
+// attendance flows); it lives here because #158 replaces the throwaway Slice-3 tracer, so the net e2e
+// count is unchanged.
 //
 // Idempotent across warm-DB re-runs: a per-run-unique founder email is always freshly teamless (the
 // magic-link verify creates the user), and the seeded code is reset to unconsumed on every backend
@@ -39,9 +40,12 @@ test('create-team: a teamless founder enters code + name + slug and lands in the
   const { token } = await tokenResponse.json()
 
   // 2. Click the emailed link → session established. The has-a-team gate routes the teamless founder
-  //    to /create-team (proving they are NOT bounced to /login by the old teamless-user behaviour).
+  //    to /onboarding (proving they are NOT bounced to /login by the old teamless-user behaviour),
+  //    from where they click through to /create-team — the rare, code-gated path.
   await page.goto(`/auth/verify?token=${token}`)
-  await expect(page.getByRole('heading', { name: 'Create your team' })).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole('heading', { name: /Welcome to TeamBalance/ })).toBeVisible({ timeout: 10_000 })
+  await page.getByRole('button', { name: 'Create a team' }).click()
+  await expect(page.getByRole('heading', { name: 'Create your team' })).toBeVisible()
 
   // 3. Fill the form — the slug auto-suggests from the name; the code is the seeded creation code.
   await page.getByLabel('Team name').fill(TEAM_NAME)

--- a/app/e2e-real/helpers.ts
+++ b/app/e2e-real/helpers.ts
@@ -27,3 +27,20 @@ export async function authenticateViaApi(request: APIRequestContext): Promise<vo
   const verified = await request.post('/api/auth/magic-link/verify', { data: { token } })
   expect(verified.ok()).toBeTruthy()
 }
+
+// Several specs open their OWN admin APIRequestContext on the shared STORAGE_STATE session (rather
+// than authenticating fresh) to act as the team's admin alongside a separately-authenticated actor.
+// The first tenant-scoped call on that session caches the resolved tenant schema as a session
+// attribute; Spring Session's JDBC store inserts (not upserts) that attribute, so two such contexts
+// racing their first tenant-scoped write on the exact same session id can collide with a transient
+// 500. One retry is sufficient: whichever request wins leaves the attribute in place, so the retry
+// (or any other concurrent request) becomes a plain update, not a colliding insert.
+export async function postAsSharedAdmin(
+  context: APIRequestContext,
+  url: string,
+  options?: Parameters<APIRequestContext['post']>[1],
+) {
+  const first = await context.post(url, options)
+  if (first.status() !== 500) return first
+  return context.post(url, options)
+}

--- a/app/e2e-real/onboarding-join.spec.ts
+++ b/app/e2e-real/onboarding-join.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, request as playwrightRequest } from '@playwright/test'
-import { STORAGE_STATE } from './helpers'
+import { STORAGE_STATE, postAsSharedAdmin } from './helpers'
 
 // Real e2e: the join-via-paste entry path introduced by the onboarding fork. Seam uniquely covered
 // (vs login/attendance/the existing magic-link invite flow): a teamless user lands on /onboarding,
@@ -20,7 +20,7 @@ test.use({ storageState: { cookies: [], origins: [] } })
 test('a teamless user joins by pasting an invite link on /onboarding/join', async ({ page, request }) => {
   // 1. As the seeded admin: mint a fresh invite link.
   const admin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
-  const inviteRes = await admin.post('/api/invitations')
+  const inviteRes = await postAsSharedAdmin(admin, '/api/invitations')
   expect(inviteRes.status()).toBe(201)
   const { token: inviteToken } = await inviteRes.json()
   await admin.dispose()

--- a/app/e2e-real/onboarding-join.spec.ts
+++ b/app/e2e-real/onboarding-join.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test'
+import { STORAGE_STATE } from './helpers'
+
+// Real e2e: the join-via-paste entry path introduced by the onboarding fork. Seam uniquely covered
+// (vs login/attendance/the existing magic-link invite flow): a teamless user lands on /onboarding,
+// chooses "I have an invite", pastes a full invite URL (not clicking the link directly) on
+// /onboarding/join, and the accept-and-continue wiring carries them onward exactly like the direct
+// /invite/$token click-through does.
+//
+// Idempotent across warm-DB re-runs: a fresh invite is minted every run, and a per-run-unique joiner
+// email is always freshly teamless (the magic-link verify creates the user).
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+const BASE_URL = 'http://localhost:5173'
+const RUN = Date.now()
+const JOINER_EMAIL = `joiner-${RUN}@example.com`
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test('a teamless user joins by pasting an invite link on /onboarding/join', async ({ page, request }) => {
+  // 1. As the seeded admin: mint a fresh invite link.
+  const admin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
+  const inviteRes = await admin.post('/api/invitations')
+  expect(inviteRes.status()).toBe(201)
+  const { token: inviteToken } = await inviteRes.json()
+  await admin.dispose()
+
+  // 2. The joiner signs in as a brand-new, teamless user via the ordinary login/magic-link path —
+  //    NOT via /invite/$token — so the has-a-team gate sends them to the /onboarding fork.
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(JOINER_EMAIL)
+  await page.getByRole('button', { name: 'Send magic link' }).click()
+  await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+  const tokenResponse = await request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email: JOINER_EMAIL },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+
+  await page.goto(`/auth/verify?token=${token}`)
+  await expect(page.getByRole('heading', { name: /Welcome to TeamBalance/ })).toBeVisible({ timeout: 10_000 })
+
+  // 3. Choose the join path and paste the full invite URL (not the bare token).
+  await page.getByRole('button', { name: 'I have an invite' }).click()
+  await expect(page).toHaveURL(/\/onboarding\/join\/?$/)
+  await page.getByLabel('Invite link').fill(`${BASE_URL}/invite/${inviteToken}`)
+  await page.getByRole('button', { name: 'Join' }).click()
+
+  // 4. Joining hands them to a team; the onboarding gate then carries the not-yet-onboarded member
+  //    on to /get-started — the same landing the direct-click invite flow reaches.
+  await expect(page.getByRole('heading', { name: 'Welcome to TeamBalance' })).toBeVisible({ timeout: 10_000 })
+  await expect(page).toHaveURL(/\/get-started\/?$/)
+})

--- a/app/e2e-real/onboarding.spec.ts
+++ b/app/e2e-real/onboarding.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, request as playwrightRequest } from '@playwright/test'
-import { STORAGE_STATE } from './helpers'
+import { STORAGE_STATE, postAsSharedAdmin } from './helpers'
 
 // Real e2e: a freshly-invited user completes onboarding — the seam this slice introduces.
 // Seam uniquely covered (vs login/attendance/invite): a member with onboarded=false is routed to
@@ -25,10 +25,10 @@ test('an invited user is routed through /get-started and lands on events once on
   // 1. As the seeded admin (separate API context, its own session): ensure the team has a position
   //    so the required-when-available picker has an option, then mint an invite link.
   const admin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
-  const positionRes = await admin.post('/api/positions', { data: { label: 'Setter' } })
+  const positionRes = await postAsSharedAdmin(admin, '/api/positions', { data: { label: 'Setter' } })
   // 201 on first run, 409 if a prior run already created it — both leave the team with a position.
   expect([201, 409]).toContain(positionRes.status())
-  const inviteRes = await admin.post('/api/invitations')
+  const inviteRes = await postAsSharedAdmin(admin, '/api/invitations')
   expect(inviteRes.status()).toBe(201)
   const { token: inviteToken } = await inviteRes.json()
   await admin.dispose()

--- a/app/e2e-real/onboarding.spec.ts
+++ b/app/e2e-real/onboarding.spec.ts
@@ -3,7 +3,7 @@ import { STORAGE_STATE } from './helpers'
 
 // Real e2e: a freshly-invited user completes onboarding — the seam this slice introduces.
 // Seam uniquely covered (vs login/attendance/invite): a member with onboarded=false is routed to
-// /welcome before any app screen, completes the one-time profile flow, is stamped onboarded, and
+// /get-started before any app screen, completes the one-time profile flow, is stamped onboarded, and
 // only then reaches the events home. Spans browser → API → DB across a brand-new identity.
 //
 // The seeded admin (STORAGE_STATE) sets up the invite + a team position over the API; the newbie
@@ -13,7 +13,7 @@ const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
 const BASE_URL = 'http://localhost:5173'
 // A unique run id keys BOTH the email and the display name so the flow always exercises a FRESH,
 // not-yet-onboarded user — otherwise a warm local DB carries a previous run's now-onboarded user
-// past the /welcome gate (email), or trips the per-team display-name uniqueness check (name).
+// past the /get-started gate (email), or trips the per-team display-name uniqueness check (name).
 const RUN_ID = Date.now()
 const NEWBIE_EMAIL = `newbie-${RUN_ID}@example.com`
 const NEWBIE_NAME = `Newbie ${RUN_ID}`
@@ -21,7 +21,7 @@ const NEWBIE_NAME = `Newbie ${RUN_ID}`
 // The newbie browser starts with no session — this spec IS the join+onboard flow.
 test.use({ storageState: { cookies: [], origins: [] } })
 
-test('an invited user is routed through /welcome and lands on events once onboarded', async ({ page }) => {
+test('an invited user is routed through /get-started and lands on events once onboarded', async ({ page }) => {
   // 1. As the seeded admin (separate API context, its own session): ensure the team has a position
   //    so the required-when-available picker has an option, then mint an invite link.
   const admin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
@@ -47,7 +47,7 @@ test('an invited user is routed through /welcome and lands on events once onboar
   const { token } = await tokenResponse.json()
 
   // 4. Click the emailed link → verify creates the user, accepts the pending invite, then the app
-  //    tries home — but the onboarding gate bounces the not-yet-onboarded member to /welcome.
+  //    tries home — but the onboarding gate bounces the not-yet-onboarded member to /get-started.
   await page.goto(`/auth/verify?token=${token}`)
   await expect(page.getByRole('heading', { name: 'Welcome to TeamBalance' })).toBeVisible({ timeout: 10_000 })
 

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -46,7 +46,7 @@ const server = setupServer(
     return HttpResponse.json(USER)
   }),
   http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
-  // The root onboarding gate reads /members/me; an onboarded member skips /welcome and lands on
+  // The root onboarding gate reads /members/me; an onboarded member skips /get-started and lands on
   // events, keeping this test focused on the invite/accept seam.
   http.get('/api/members/me', () =>
     HttpResponse.json({ userId: 'user-1', displayName: 'newbie', role: 'USER', onboarded: true }),

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -34,7 +34,7 @@ const server = setupServer(
     return HttpResponse.json(USER)
   }),
   http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
-  // The root onboarding gate reads /members/me; an onboarded member skips /welcome and lands on
+  // The root onboarding gate reads /members/me; an onboarded member skips /get-started and lands on
   // events, keeping this test focused on the verify/auth-routing seam.
   http.get('/api/members/me', () =>
     HttpResponse.json({ userId: 'user-1', displayName: 'Jan', role: 'USER', onboarded: true }),

--- a/app/src/features/join-team/lib/parse-invite-token.test.ts
+++ b/app/src/features/join-team/lib/parse-invite-token.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { parseInviteToken } from './parse-invite-token'
+
+describe('parseInviteToken', () => {
+  it('passes a bare token through unchanged', () => {
+    expect(parseInviteToken('abc123')).toBe('abc123')
+  })
+
+  it('extracts the token from a full invite URL', () => {
+    expect(parseInviteToken('https://app.teambalance.nl/invite/abc123')).toBe('abc123')
+  })
+
+  it('strips a query string after the token', () => {
+    expect(parseInviteToken('https://app.teambalance.nl/invite/abc123?utm=share')).toBe('abc123')
+  })
+
+  it('strips a hash fragment after the token', () => {
+    expect(parseInviteToken('https://app.teambalance.nl/invite/abc123#section')).toBe('abc123')
+  })
+
+  it('strips a trailing slash', () => {
+    expect(parseInviteToken('https://app.teambalance.nl/invite/abc123/')).toBe('abc123')
+  })
+
+  it('trims surrounding whitespace on a bare token', () => {
+    expect(parseInviteToken('  abc123  ')).toBe('abc123')
+  })
+
+  it('trims surrounding whitespace on a full URL', () => {
+    expect(parseInviteToken('  https://app.teambalance.nl/invite/abc123  ')).toBe('abc123')
+  })
+
+  it('returns an empty string for junk input', () => {
+    expect(parseInviteToken('   ')).toBe('')
+    expect(parseInviteToken('')).toBe('')
+  })
+})

--- a/app/src/features/join-team/lib/parse-invite-token.ts
+++ b/app/src/features/join-team/lib/parse-invite-token.ts
@@ -1,0 +1,10 @@
+// Accepts either a full invite URL or a bare token. The token is the path segment after `/invite/`,
+// with any trailing `?query`, `#hash`, or `/` stripped — or, if no `/invite/` marker is present, the
+// trimmed input itself (someone pasted just the token).
+export function parseInviteToken(input: string): string {
+  const trimmed = input.trim()
+  const marker = '/invite/'
+  const idx = trimmed.indexOf(marker)
+  const raw = idx === -1 ? trimmed : trimmed.slice(idx + marker.length)
+  return raw.split(/[?#]/)[0].replace(/\/+$/, '').trim()
+}

--- a/app/src/features/join-team/lib/use-join-team.ts
+++ b/app/src/features/join-team/lib/use-join-team.ts
@@ -1,0 +1,37 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAcceptInvitation } from '@shared/api/invitations'
+
+const INVALID_OR_EXPIRED =
+  "That invite link didn't work — it may be invalid or expired. Ask your team admin for a fresh one."
+const GENERIC = 'Something went wrong, try again.'
+
+/**
+ * Thin wiring over useAcceptInvitation for the /onboarding/join route: on success, invalidates
+ * /auth/me (same pattern as /invite/$token.tsx) and navigates home — the root gate then carries the
+ * now-teamed user on to /get-started. useAcceptInvitation throws a single generic Error for both an
+ * invalid and an expired token (the accept endpoint returns 404 for both, deliberately, so there's no
+ * oracle); anything else (network failure, unexpected status) is treated as the generic failure.
+ */
+export function useJoinTeam() {
+  const client = useQueryClient()
+  const navigate = useNavigate()
+  const acceptInvitation = useAcceptInvitation()
+
+  const join = (token: string) => {
+    acceptInvitation.mutate(token, {
+      onSuccess: async () => {
+        await client.invalidateQueries({ queryKey: ['auth', 'me'] })
+        navigate({ to: '/' })
+      },
+    })
+  }
+
+  const errorMessage = acceptInvitation.isError
+    ? acceptInvitation.error instanceof Error && acceptInvitation.error.message === 'invite link invalid or expired'
+      ? INVALID_OR_EXPIRED
+      : GENERIC
+    : null
+
+  return { join, isPending: acceptInvitation.isPending, errorMessage }
+}

--- a/app/src/features/join-team/ui/JoinTeamView.stories.tsx
+++ b/app/src/features/join-team/ui/JoinTeamView.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { JoinTeamView } from './JoinTeamView'
+
+// JoinTeamView is the presentational paste-your-invite UI behind the /onboarding/join route
+// container. It owns no state of its own (value/onChange are controlled by the container so the
+// route can hand the same raw text to a retried submit); it does own the token parsing (via the pure
+// parse-invite-token) so onSubmit always receives the bare token, never the raw pasted URL.
+const meta = {
+  title: 'features/join-team/JoinTeamView',
+  component: JoinTeamView,
+  args: { value: '', onChange: fn(), onSubmit: fn() },
+} satisfies Meta<typeof JoinTeamView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText('Invite link')).toHaveValue('')
+    // Nothing pasted yet → submit is disabled.
+    await expect(canvas.getByRole('button', { name: 'Join' })).toBeDisabled()
+    await expect(canvas.getByText("I don't have a link")).toBeInTheDocument()
+  },
+}
+
+export const TypingUpdatesTheContainer: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.type(canvas.getByLabelText('Invite link'), 'abc')
+    await expect(args.onChange).toHaveBeenCalled()
+  },
+}
+
+export const Submit: Story = {
+  args: { value: 'https://app.teambalance.nl/invite/abc123?utm=share' },
+  play: async ({ canvas, userEvent, args }) => {
+    const button = canvas.getByRole('button', { name: 'Join' })
+    await expect(button).toBeEnabled()
+    await userEvent.click(button)
+    // The view parses the pasted URL down to the bare token before calling onSubmit.
+    await expect(args.onSubmit).toHaveBeenCalledWith('abc123')
+  },
+}
+
+export const Submitting: Story = {
+  args: { value: 'abc123', submitting: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Joining…' })).toBeDisabled()
+  },
+}
+
+export const ErrorState: Story = {
+  args: {
+    value: 'abc123',
+    error: "That invite link didn't work — it may be invalid or expired. Ask your team admin for a fresh one.",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('alert')).toHaveTextContent('invalid or expired')
+  },
+}
+
+export const NoLinkFallback: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByText("I don't have a link"))
+    await expect(await canvas.findByText(/Ask your team's captain or admin/)).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Create a team' })).toBeInTheDocument()
+  },
+}

--- a/app/src/features/join-team/ui/JoinTeamView.tsx
+++ b/app/src/features/join-team/ui/JoinTeamView.tsx
@@ -1,0 +1,74 @@
+import type { FormEvent } from 'react'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import { parseInviteToken } from '../lib/parse-invite-token'
+
+interface JoinTeamViewProps {
+  value: string
+  onChange: (value: string) => void
+  onSubmit: (token: string) => void
+  submitting?: boolean
+  error?: string | null
+}
+
+/**
+ * Presentational paste-your-invite UI (the /onboarding/join fork branch). value/onChange are
+ * controlled by the route container rather than owned locally, so a failed submit can be retried
+ * without losing what was pasted. Accepts a full invite URL or a bare token — parsed via the pure
+ * parseInviteToken before onSubmit ever sees it.
+ */
+export function JoinTeamView({ value, onChange, onSubmit, submitting, error }: JoinTeamViewProps) {
+  const canSubmit = value.trim().length > 0 && !submitting
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    onSubmit(parseInviteToken(value))
+  }
+
+  return (
+    <div>
+      <h1 className="font-display text-2xl font-bold">Join your team</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Paste the invite link you were sent below — or easiest of all, just click the link directly.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+        <div>
+          <Label htmlFor="invite-token">Invite link</Label>
+          <Input
+            id="invite-token"
+            value={value}
+            disabled={submitting}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="https://app.teambalance.nl/invite/..."
+          />
+        </div>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <Button type="submit" disabled={!canSubmit}>
+          {submitting ? 'Joining…' : 'Join'}
+        </Button>
+      </form>
+
+      <details className="mt-8 text-sm text-muted-foreground">
+        <summary className="cursor-pointer font-medium text-foreground">I don't have a link</summary>
+        <p className="mt-2">
+          Ask your team's captain or admin to send you the invite link — they can generate one from the
+          team's Members page. Once you have it, paste it above.
+        </p>
+        <p className="mt-2">
+          Starting your own team instead?{' '}
+          {/* Plain anchor, not router Link — keeps this view router-free so it stays story-able. */}
+          <a href="/create-team" className="text-blue underline">
+            Create a team
+          </a>
+        </p>
+      </details>
+    </div>
+  )
+}

--- a/app/src/features/onboarding-hub/ui/OnboardingHubView.stories.tsx
+++ b/app/src/features/onboarding-hub/ui/OnboardingHubView.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { OnboardingHubView } from './OnboardingHubView'
+
+// OnboardingHubView is the presentational fork behind /onboarding: a teamless, authenticated user
+// chooses to join an existing team (the common path) or create one (rare, code-gated). Pure prop-only
+// view — the route container owns navigation.
+const meta = {
+  title: 'features/onboarding-hub/OnboardingHubView',
+  component: OnboardingHubView,
+  args: { onChooseJoin: fn(), onChooseCreate: fn() },
+} satisfies Meta<typeof OnboardingHubView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('heading', { name: /Welcome to TeamBalance/ })).toBeInTheDocument()
+    await expect(canvas.getByText(/You're signed in, but not on a team yet/)).toBeInTheDocument()
+  },
+}
+
+export const ChooseJoin: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    // The accessible name includes the helper text, so match by substring rather than exact.
+    await userEvent.click(canvas.getByRole('button', { name: /^I have an invite/ }))
+    await expect(args.onChooseJoin).toHaveBeenCalled()
+  },
+}
+
+export const ChooseCreate: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /^Create a team/ }))
+    await expect(args.onChooseCreate).toHaveBeenCalled()
+  },
+}

--- a/app/src/features/onboarding-hub/ui/OnboardingHubView.tsx
+++ b/app/src/features/onboarding-hub/ui/OnboardingHubView.tsx
@@ -1,0 +1,43 @@
+interface OnboardingHubViewProps {
+  onChooseJoin: () => void
+  onChooseCreate: () => void
+}
+
+/**
+ * Presentational onboarding fork for a signed-in, teamless user — replaces the old hard redirect
+ * onto the create-team form. Deliberately not personalized (displayName is an email-derived
+ * placeholder for new users). The route container owns navigation to /onboarding/join and
+ * /create-team.
+ */
+export function OnboardingHubView({ onChooseJoin, onChooseCreate }: OnboardingHubViewProps) {
+  return (
+    <div className="mx-auto mt-10 max-w-sm text-center">
+      <h1 className="font-display text-2xl font-bold">Welcome to TeamBalance 👋</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        You're signed in, but not on a team yet. How would you like to get started?
+      </p>
+
+      <div className="mt-8 flex flex-col gap-4">
+        <button
+          type="button"
+          onClick={onChooseJoin}
+          className="rounded-lg border border-border bg-blue/5 p-4 text-left transition-colors hover:border-blue"
+        >
+          <span className="block font-display text-lg font-bold">I have an invite</span>
+          <span className="mt-1 block text-sm text-muted-foreground">Someone shared a join link with you</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onChooseCreate}
+          className="rounded-lg border border-border p-4 text-left transition-colors hover:border-blue"
+        >
+          <span className="block font-semibold">Create a team</span>
+          <span className="mt-1 block text-sm text-muted-foreground">
+            You'll need a creation code — team owners get these from us
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AdminCreationCodesRouteImport } from './routes/admin/creation-
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
 import { Route as CreateTeamIndexRouteImport } from './routes/create-team/index'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
+import { Route as GetStartedIndexRouteImport } from './routes/get-started/index'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as MembersIndexRouteImport } from './routes/members/index'
 import { Route as OnboardingIndexRouteImport } from './routes/onboarding/index'
@@ -22,7 +23,6 @@ import { Route as OnboardingJoinRouteImport } from './routes/onboarding/join'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as TeamIndexRouteImport } from './routes/team/index'
 import { Route as TeamSettingsRouteImport } from './routes/team/settings'
-import { Route as WelcomeIndexRouteImport } from './routes/welcome/index'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -52,6 +52,11 @@ const CreateTeamIndexRoute = CreateTeamIndexRouteImport.update({
 const EventsEventIdRoute = EventsEventIdRouteImport.update({
   id: '/events/$eventId',
   path: '/events/$eventId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GetStartedIndexRoute = GetStartedIndexRouteImport.update({
+  id: '/get-started/',
+  path: '/get-started/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InviteTokenRoute = InviteTokenRouteImport.update({
@@ -89,11 +94,6 @@ const TeamSettingsRoute = TeamSettingsRouteImport.update({
   path: '/team/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
-const WelcomeIndexRoute = WelcomeIndexRouteImport.update({
-  id: '/welcome/',
-  path: '/welcome/',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -105,11 +105,11 @@ export interface FileRoutesByFullPath {
   '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
+  '/get-started/': typeof GetStartedIndexRoute
   '/members/': typeof MembersIndexRoute
   '/onboarding/': typeof OnboardingIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/team/': typeof TeamIndexRoute
-  '/welcome/': typeof WelcomeIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -121,11 +121,11 @@ export interface FileRoutesByTo {
   '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team': typeof CreateTeamIndexRoute
+  '/get-started': typeof GetStartedIndexRoute
   '/members': typeof MembersIndexRoute
   '/onboarding': typeof OnboardingIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/team': typeof TeamIndexRoute
-  '/welcome': typeof WelcomeIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -138,11 +138,11 @@ export interface FileRoutesById {
   '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
+  '/get-started/': typeof GetStartedIndexRoute
   '/members/': typeof MembersIndexRoute
   '/onboarding/': typeof OnboardingIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/team/': typeof TeamIndexRoute
-  '/welcome/': typeof WelcomeIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -156,11 +156,11 @@ export interface FileRouteTypes {
     | '/onboarding/join'
     | '/team/settings'
     | '/create-team/'
+    | '/get-started/'
     | '/members/'
     | '/onboarding/'
     | '/profile/'
     | '/team/'
-    | '/welcome/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -172,11 +172,11 @@ export interface FileRouteTypes {
     | '/onboarding/join'
     | '/team/settings'
     | '/create-team'
+    | '/get-started'
     | '/members'
     | '/onboarding'
     | '/profile'
     | '/team'
-    | '/welcome'
   id:
     | '__root__'
     | '/'
@@ -188,11 +188,11 @@ export interface FileRouteTypes {
     | '/onboarding/join'
     | '/team/settings'
     | '/create-team/'
+    | '/get-started/'
     | '/members/'
     | '/onboarding/'
     | '/profile/'
     | '/team/'
-    | '/welcome/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -205,11 +205,11 @@ export interface RootRouteChildren {
   OnboardingJoinRoute: typeof OnboardingJoinRoute
   TeamSettingsRoute: typeof TeamSettingsRoute
   CreateTeamIndexRoute: typeof CreateTeamIndexRoute
+  GetStartedIndexRoute: typeof GetStartedIndexRoute
   MembersIndexRoute: typeof MembersIndexRoute
   OnboardingIndexRoute: typeof OnboardingIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
   TeamIndexRoute: typeof TeamIndexRoute
-  WelcomeIndexRoute: typeof WelcomeIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -254,6 +254,13 @@ declare module '@tanstack/react-router' {
       path: '/events/$eventId'
       fullPath: '/events/$eventId'
       preLoaderRoute: typeof EventsEventIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/get-started/': {
+      id: '/get-started/'
+      path: '/get-started'
+      fullPath: '/get-started/'
+      preLoaderRoute: typeof GetStartedIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/invite/$token': {
@@ -305,13 +312,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TeamSettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/welcome/': {
-      id: '/welcome/'
-      path: '/welcome'
-      fullPath: '/welcome/'
-      preLoaderRoute: typeof WelcomeIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
   }
 }
 
@@ -325,11 +325,11 @@ const rootRouteChildren: RootRouteChildren = {
   OnboardingJoinRoute: OnboardingJoinRoute,
   TeamSettingsRoute: TeamSettingsRoute,
   CreateTeamIndexRoute: CreateTeamIndexRoute,
+  GetStartedIndexRoute: GetStartedIndexRoute,
   MembersIndexRoute: MembersIndexRoute,
   OnboardingIndexRoute: OnboardingIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
   TeamIndexRoute: TeamIndexRoute,
-  WelcomeIndexRoute: WelcomeIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -17,6 +17,8 @@ import { Route as CreateTeamIndexRouteImport } from './routes/create-team/index'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as MembersIndexRouteImport } from './routes/members/index'
+import { Route as OnboardingIndexRouteImport } from './routes/onboarding/index'
+import { Route as OnboardingJoinRouteImport } from './routes/onboarding/join'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as TeamIndexRouteImport } from './routes/team/index'
 import { Route as TeamSettingsRouteImport } from './routes/team/settings'
@@ -62,6 +64,16 @@ const MembersIndexRoute = MembersIndexRouteImport.update({
   path: '/members/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OnboardingIndexRoute = OnboardingIndexRouteImport.update({
+  id: '/onboarding/',
+  path: '/onboarding/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingJoinRoute = OnboardingJoinRouteImport.update({
+  id: '/onboarding/join',
+  path: '/onboarding/join',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProfileIndexRoute = ProfileIndexRouteImport.update({
   id: '/profile/',
   path: '/profile/',
@@ -90,9 +102,11 @@ export interface FileRoutesByFullPath {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
   '/members/': typeof MembersIndexRoute
+  '/onboarding/': typeof OnboardingIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/team/': typeof TeamIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -104,9 +118,11 @@ export interface FileRoutesByTo {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team': typeof CreateTeamIndexRoute
   '/members': typeof MembersIndexRoute
+  '/onboarding': typeof OnboardingIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/team': typeof TeamIndexRoute
   '/welcome': typeof WelcomeIndexRoute
@@ -119,9 +135,11 @@ export interface FileRoutesById {
   '/auth/verify': typeof AuthVerifyRoute
   '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
+  '/onboarding/join': typeof OnboardingJoinRoute
   '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
   '/members/': typeof MembersIndexRoute
+  '/onboarding/': typeof OnboardingIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/team/': typeof TeamIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -135,9 +153,11 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/onboarding/join'
     | '/team/settings'
     | '/create-team/'
     | '/members/'
+    | '/onboarding/'
     | '/profile/'
     | '/team/'
     | '/welcome/'
@@ -149,9 +169,11 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/onboarding/join'
     | '/team/settings'
     | '/create-team'
     | '/members'
+    | '/onboarding'
     | '/profile'
     | '/team'
     | '/welcome'
@@ -163,9 +185,11 @@ export interface FileRouteTypes {
     | '/auth/verify'
     | '/events/$eventId'
     | '/invite/$token'
+    | '/onboarding/join'
     | '/team/settings'
     | '/create-team/'
     | '/members/'
+    | '/onboarding/'
     | '/profile/'
     | '/team/'
     | '/welcome/'
@@ -178,9 +202,11 @@ export interface RootRouteChildren {
   AuthVerifyRoute: typeof AuthVerifyRoute
   EventsEventIdRoute: typeof EventsEventIdRoute
   InviteTokenRoute: typeof InviteTokenRoute
+  OnboardingJoinRoute: typeof OnboardingJoinRoute
   TeamSettingsRoute: typeof TeamSettingsRoute
   CreateTeamIndexRoute: typeof CreateTeamIndexRoute
   MembersIndexRoute: typeof MembersIndexRoute
+  OnboardingIndexRoute: typeof OnboardingIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
   TeamIndexRoute: typeof TeamIndexRoute
   WelcomeIndexRoute: typeof WelcomeIndexRoute
@@ -244,6 +270,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MembersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/onboarding/': {
+      id: '/onboarding/'
+      path: '/onboarding'
+      fullPath: '/onboarding/'
+      preLoaderRoute: typeof OnboardingIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding/join': {
+      id: '/onboarding/join'
+      path: '/onboarding/join'
+      fullPath: '/onboarding/join'
+      preLoaderRoute: typeof OnboardingJoinRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/profile/': {
       id: '/profile/'
       path: '/profile'
@@ -282,9 +322,11 @@ const rootRouteChildren: RootRouteChildren = {
   AuthVerifyRoute: AuthVerifyRoute,
   EventsEventIdRoute: EventsEventIdRoute,
   InviteTokenRoute: InviteTokenRoute,
+  OnboardingJoinRoute: OnboardingJoinRoute,
   TeamSettingsRoute: TeamSettingsRoute,
   CreateTeamIndexRoute: CreateTeamIndexRoute,
   MembersIndexRoute: MembersIndexRoute,
+  OnboardingIndexRoute: OnboardingIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
   TeamIndexRoute: TeamIndexRoute,
   WelcomeIndexRoute: WelcomeIndexRoute,

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -32,26 +32,35 @@ export const Route = createRootRoute({
     if (!user) throw redirect({ to: '/login' })
 
     // Has-a-team gate: an authenticated but teamless user is a first-class state — route them to
-    // /create-team, and do it BEFORE the onboarding gate's tenant-scoped /members/me probe (which
-    // would 403 NO_TEAM_MEMBERSHIP and bounce them to /login). /create-team is exempt so it can render
-    // (mirroring how /welcome is exempt from the onboarding gate below). Teamlessness is read from the
+    // /onboarding (the join-vs-create fork), and do it BEFORE the onboarding gate's tenant-scoped
+    // /members/me probe (which would 403 NO_TEAM_MEMBERSHIP and bounce them to /login). /onboarding
+    // and its /onboarding/join and /create-team branches are exempt so the fork can render (mirroring
+    // how /get-started is exempt from the onboarding gate below). Teamlessness is read from the
     // explicit team field, not inferred from role == null (permission vs membership; see #26).
-    if (location.pathname === '/create-team' || location.pathname === '/create-team/') return
-    if (!user.team) throw redirect({ to: '/create-team' })
+    if (
+      location.pathname === '/onboarding' ||
+      location.pathname === '/onboarding/' ||
+      location.pathname === '/onboarding/join' ||
+      location.pathname === '/onboarding/join/' ||
+      location.pathname === '/create-team' ||
+      location.pathname === '/create-team/'
+    )
+      return
+    if (!user.team) throw redirect({ to: '/onboarding' })
 
-    // Onboarding gate: a confirmed member who hasn't completed onboarding is routed to /welcome
-    // before any app screen mounts. /welcome itself is exempt (below) so the flow can render; the
+    // Onboarding gate: a confirmed member who hasn't completed onboarding is routed to /get-started
+    // before any app screen mounts. /get-started itself is exempt (below) so the flow can render; the
     // auth routes are already exempt (returned above). Read /members/me through the cache — race-
     // free, same pattern as the /members admin gate. Fail OPEN if the state can't be determined:
     // an onboarding-status blip shouldn't trap the user, and auth was already confirmed.
-    if (location.pathname === '/welcome' || location.pathname === '/welcome/') return
+    if (location.pathname === '/get-started' || location.pathname === '/get-started/') return
     let member = null
     try {
       member = await queryClient.ensureQueryData(currentMemberQueryOptions)
     } catch {
       // Couldn't read onboarding state — don't trap the user.
     }
-    if (member && !member.onboarded) throw redirect({ to: '/welcome' })
+    if (member && !member.onboarded) throw redirect({ to: '/get-started' })
   },
 })
 

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -28,6 +28,20 @@ function CreateTeamPage() {
       <p className="mt-2 text-sm text-muted-foreground">
         Enter your creation code and name your team — you'll be its admin.
       </p>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Starting a team is invite-only while we're getting established. Got a creation code? Enter it
+        below.
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Don't have one?{' '}
+        <a
+          href="mailto:teams@teambalance.nl?subject=Request%20a%20team%20on%20TeamBalance"
+          className="text-blue underline"
+        >
+          Email teams@teambalance.nl
+        </a>{' '}
+        and we'll help you get started.
+      </p>
       <div className="mt-6">
         <CreateTeamForm
           isPending={createTeam.isPending}

--- a/app/src/routes/get-started/index.tsx
+++ b/app/src/routes/get-started/index.tsx
@@ -4,7 +4,7 @@ import { usePositions } from '@shared/api/positions'
 import { queryClient } from '@shared/api/query-client'
 import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
 
-export const Route = createFileRoute('/welcome/')({
+export const Route = createFileRoute('/get-started/')({
   // A member who has already onboarded has no business here — bounce them home before render.
   // Reads the same cached /members/me the root gate primed (race-free, like the /members gate).
   beforeLoad: async () => {
@@ -12,11 +12,11 @@ export const Route = createFileRoute('/welcome/')({
     try {
       member = await queryClient.ensureQueryData(currentMemberQueryOptions)
     } catch {
-      // Session/member unconfirmed — let the root guard handle it; don't block the welcome screen.
+      // Session/member unconfirmed — let the root guard handle it; don't block this screen.
     }
     if (member?.onboarded) throw redirect({ to: '/' })
   },
-  component: WelcomePage,
+  component: GetStartedPage,
 })
 
 /**
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/welcome/')({
  * useCompleteOnboarding. On success the member is stamped onboarded, so navigating home no longer
  * bounces back here.
  */
-function WelcomePage() {
+function GetStartedPage() {
   const navigate = useNavigate()
   const { data: member, isLoading, error } = useCurrentMember()
   const { data: positions } = usePositions()

--- a/app/src/routes/onboarding/index.tsx
+++ b/app/src/routes/onboarding/index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { OnboardingHubView } from '@features/onboarding-hub/ui/OnboardingHubView'
+
+export const Route = createFileRoute('/onboarding/')({
+  component: OnboardingPage,
+})
+
+function OnboardingPage() {
+  const navigate = useNavigate()
+
+  return (
+    <OnboardingHubView
+      onChooseJoin={() => navigate({ to: '/onboarding/join' })}
+      onChooseCreate={() => navigate({ to: '/create-team' })}
+    />
+  )
+}

--- a/app/src/routes/onboarding/join.tsx
+++ b/app/src/routes/onboarding/join.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { useJoinTeam } from '@features/join-team/lib/use-join-team'
+import { JoinTeamView } from '@features/join-team/ui/JoinTeamView'
+
+export const Route = createFileRoute('/onboarding/join')({
+  component: JoinPage,
+})
+
+function JoinPage() {
+  const [value, setValue] = useState('')
+  const { join, isPending, errorMessage } = useJoinTeam()
+
+  return (
+    <JoinTeamView
+      value={value}
+      onChange={setValue}
+      onSubmit={join}
+      submitting={isPending}
+      error={errorMessage}
+    />
+  )
+}

--- a/app/src/shared/api/members.ts
+++ b/app/src/shared/api/members.ts
@@ -14,7 +14,7 @@ export class MemberUpdateError extends Error {
   }
 }
 
-// Shared so the router guards (root onboarding gate, /welcome) can prime this exact query
+// Shared so the router guards (root onboarding gate, /get-started) can prime this exact query
 // (ensureQueryData) and useCurrentMember reads it back from cache — no duplicate fetch, no drifting
 // key. Same pattern as authMeQueryOptions.
 export const currentMemberQueryOptions = queryOptions({
@@ -75,7 +75,7 @@ export function useUpdateMember() {
 // Applies the member's own name + position and stamps them onboarded (PUT /members/me/onboarding).
 // The request carries a role, but the backend ignores it (onboarding never changes role); we send
 // the member's current role to satisfy the contract. A 409 is a name collision, mapped like
-// useUpdateMember so the /welcome form can surface it inline.
+// useUpdateMember so the /get-started form can surface it inline.
 export function useCompleteOnboarding() {
   const queryClient = useQueryClient()
   return useMutation({
@@ -87,7 +87,7 @@ export function useCompleteOnboarding() {
     // Write the now-onboarded member straight into the cache before invalidating, so the root
     // onboarding gate reads the fresh state on the very next navigation (ensureQueryData returns
     // the cached value immediately, even while a background refetch runs) — otherwise it would see
-    // the stale onboarded=false and bounce back to /welcome.
+    // the stale onboarded=false and bounce back to /get-started.
     onSuccess: (updated) => {
       queryClient.setQueryData(currentMemberQueryOptions.queryKey, updated)
       queryClient.invalidateQueries({ queryKey: ['members'] })


### PR DESCRIPTION
## Summary

Replaces the abrupt teamless → `/create-team` hard redirect with a warm `/onboarding` fork offering **join** (common) and **create** (rare, code-gated) paths.

- **`/onboarding`** — fork hub (`OnboardingHubView`): "I have an invite" vs "Create a team".
- **`/onboarding/join`** — paste-your-invite screen (`JoinTeamView` + `useJoinTeam`). Accepts a full invite URL or a bare token (`parseInviteToken`, pure). Reuses the existing `useAcceptInvitation` mutation and the invalidate-`/auth/me`-then-navigate-home pattern already used by `/invite/$token.tsx`. Single honest error message on failure (the accept endpoint returns an identical 404 for invalid and expired — no oracle, by design); a progressive "I don't have a link" fallback with guidance + a quiet cross-link to `/create-team`.
- **`/create-team`** — unchanged behavior; added an honest invite-only line pointing people without a code at `teams@teambalance.nl` (receiving that inbox is tracked separately as #201).
- **`/welcome` → `/get-started`** — pure rename; every reference across routes/comments/tests updated.
- **Root gate (`__root.tsx`)** — teamless redirect target `/create-team` → `/onboarding`; `/onboarding`, `/onboarding/join`, and `/create-team` are all exempt from the has-a-team gate; the post-team onboarding gate now targets `/get-started`.

Frontend-only — no backend, Wirespec, or DB changes. The accept-by-token endpoint is reused as-is (previously audited safe: hashed token, parameterized lookups, never rendered).

## Test layers touched

- **Vitest unit**: `parse-invite-token.test.ts` — full URL → token, bare-token passthrough, strips query/hash/trailing-slash/whitespace, junk input.
- **Storybook stories** (headless, no network): `JoinTeamView` (default / typing / submit-parses-and-calls-onSubmit / submitting / error / no-link-fallback) and `OnboardingHubView` (default / choose-join / choose-create), with `fn()` spies asserting the wiring, not just the render.
- **Real e2e** (`make e2e`):
  - Updated `create-team.spec.ts` — the teamless founder now lands on `/onboarding` and clicks through to `/create-team` (was a direct redirect).
  - **New** `onboarding-join.spec.ts` — join-via-paste: teamless user → `/onboarding` → "I have an invite" → paste the full invite URL → joins → lands on `/get-started`. This is the one new e2e, justified because it exercises a seam not covered by login, attendance, or the existing click-the-link invite flow: a brand-new entry path (paste vs click), through the renamed post-team-onboarding route, reached via the new gate redirect.
  - Along the way, found and fixed a pre-existing race exposed by running a second spec that opens its own admin `APIRequestContext` on the shared seeded session concurrently with `onboarding.spec.ts`'s own: the first tenant-scoped call on that session caches the resolved tenant schema as a session attribute, and Spring Session's JDBC store inserts (not upserts) it, so two contexts racing their first write on the same session id occasionally collided with a transient 500. Added `postAsSharedAdmin` (one retry, documented) in `helpers.ts`, applied to both call sites — no backend change, no masked flake (verified via backend logs: same `session_primary_id` colliding on the `tenantSchema` attribute insert). `make e2e` passed cleanly across two consecutive full runs afterward.

## Verification

- `make test-app` — 60 files / 325 tests green.
- `make lint` — detekt + eslint clean.
- `npx tsc -b` — clean.
- `make e2e` — 9/9 green, run twice to confirm the session-race fix isn't order-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/24c931e8-4e44-4d89-987c-4f787fc09064

