### PR TITLE
refactor(app): shared PageHeader + --header-height var (F12, #159)

### DIFF
--- a/app/src/app/styles/global.css
+++ b/app/src/app/styles/global.css
@@ -38,6 +38,18 @@
   --color-sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
+/* ── App shell metrics ──
+   The app header's height lives here and nowhere else: it *sets* the header's box height in
+   routes/__root.tsx (h-[var(--header-height)]) and *is* the offset every sticky PageHeader pins
+   itself to. Before this variable the sub-header carried a magic top-[57px] that silently drifted
+   whenever the header changed (F12, #159); now the two sides read the same number and cannot
+   disagree. Value = 1.75rem content line-height + 2 × 0.75rem vertical padding, border included
+   (the header is border-box). In rem so it scales with the root font size, exactly as its content
+   does. */
+:root {
+  --header-height: 3.25rem;
+}
+
 body {
   font-family: var(--font-body);
   background-color: var(--color-background);

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -96,12 +96,15 @@ function RootLayout() {
       <div className="min-h-dvh bg-background">
         {/* The tab bar (BottomNav) is now the single primary nav — the header carries only identity
             (wordmark + real team name, top-right), no nav links. Horizontal safe-area insets keep it
-            clear of a landscape notch now that viewport-fit=cover lets content into the inset region. */}
+            clear of a landscape notch now that viewport-fit=cover lets content into the inset region.
+            Its height is fixed to --header-height (global.css) rather than left to fall out of the
+            padding: that same variable is what every sticky PageHeader offsets by, so the sub-header
+            can no longer drift out of alignment when this header changes (F12, #159). */}
         <header
-          className="sticky top-0 z-40 border-b border-border/40 bg-card/88 backdrop-blur-lg"
+          className="sticky top-0 z-40 h-[var(--header-height)] border-b border-border/40 bg-card/88 backdrop-blur-lg"
           style={{ paddingLeft: 'env(safe-area-inset-left)', paddingRight: 'env(safe-area-inset-right)' }}
         >
-          <div className="flex items-center justify-between px-5 py-3">
+          <div className="flex h-full items-center justify-between px-5">
             <Link to="/" className="font-display text-xl font-bold text-blue">
               Team<span className="text-green">Balance</span>
             </Link>

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useState } from 'react'
-import { ArrowLeft, MapPin } from 'lucide-react'
+import { MapPin } from 'lucide-react'
 import { useEvent, useEvents, type AttendanceEntry } from '@shared/api/events'
 import { useSetAttendance } from '@shared/api/attendances'
 import { useUserStore } from '@shared/stores/user-store'
@@ -18,6 +18,7 @@ import { Avatar } from '@shared/ui/avatar'
 import { AttendanceToggle, type AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { EditEventDialog } from '@features/edit-event/ui/EditEventDialog'
 import { DeleteEventDialog } from '@features/edit-event/ui/DeleteEventDialog'
+import { PageHeader } from '@widgets/page-header/ui/PageHeader'
 
 export const Route = createFileRoute('/events/$eventId')({
   component: EventDetailPage,
@@ -89,15 +90,8 @@ function EventDetailPage() {
 
   return (
     <div>
-      {/* Sticky sub-header with back navigation — sits below the app header */}
-      <div className="sticky top-[57px] z-30 -mx-4 mb-2 flex items-center gap-2 border-b border-border/60 bg-background/95 px-4 py-2 backdrop-blur-sm">
-        <Link to="/" aria-label="Back to events">
-          <Button variant="ghost" size="icon" className="h-11 w-11 shrink-0">
-            <ArrowLeft size={18} />
-          </Button>
-        </Link>
-        <h2 className="font-display truncate text-base font-semibold">{event.title}</h2>
-      </div>
+      {/* Sticky sub-header — offset comes from --header-height via PageHeader, not a magic pixel */}
+      <PageHeader title={event.title} backTo="/" backLabel="Back to events" />
 
       {/* Event header */}
       <div className="mt-2 flex items-start gap-4">

--- a/app/src/widgets/page-header/ui/PageHeader.stories.tsx
+++ b/app/src/widgets/page-header/ui/PageHeader.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import { Button } from '@shared/ui/button'
+import { PageHeader } from './PageHeader'
+
+// PageHeader is the shared sticky sub-header: it renders a back link, a title and an optional
+// actions slot, and pins itself at `top: var(--header-height)` so it always lands flush under the
+// app header (no magic pixel offset). It is prop-only — no store, no query — so every state below
+// renders from args alone; the routes that use it stay thin wiring (ADR-0017).
+//
+// The back control is a real <Link>, so the stories run under the router decorator and assert the
+// resolved href (same contract as TeamHeader's gear). The actions slot is exercised with an fn()
+// spy: a click in `play` must reach the caller's handler, proving the slot is genuinely interactive
+// and not just rendered.
+const onAction = fn()
+
+const meta = {
+  title: 'widgets/page-header/PageHeader',
+  component: PageHeader,
+  decorators: [
+    // Mirrors the app's <main> gutter (max-w-2xl px-4) so the header's -mx-4 full-bleed edge
+    // renders faithfully in the Chromatic snapshot instead of overflowing the bare canvas.
+    (Story) => (
+      <div className="mx-auto max-w-2xl px-4">
+        <Story />
+      </div>
+    ),
+    withRouter,
+  ],
+  args: { title: 'Training — Tuesday' },
+} satisfies Meta<typeof PageHeader>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Title only: no back target, no actions — the minimal shape a page can use.
+export const TitleOnly: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('heading', { name: 'Training — Tuesday' })).toBeInTheDocument()
+    await expect(canvas.queryByRole('link')).not.toBeInTheDocument()
+  },
+}
+
+// The sticky offset is the whole point of the widget: it must be *derived* from --header-height,
+// never a hardcoded pixel value that drifts when the app header changes (the F12 defect). Overriding
+// the variable to an off-token value and reading the resolved `top` back proves the derivation
+// end-to-end — a plain class assertion would still pass if the offset were re-hardcoded to today's
+// header height.
+export const StickyOffsetFollowsHeaderHeight: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ '--header-height': '80px' } as React.CSSProperties}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const header = canvas.getByRole('heading').parentElement as HTMLElement
+    await expect(getComputedStyle(header).top).toBe('80px')
+  },
+}
+
+// The event-detail shape: back link into the parent list plus a title.
+export const WithBack: Story = {
+  args: { backTo: '/', backLabel: 'Back to events' },
+  play: async ({ canvas }) => {
+    const back = canvas.getByRole('link', { name: 'Back to events' })
+    await expect(back).toHaveAttribute('href', '/')
+    await expect(canvas.getByRole('heading', { name: 'Training — Tuesday' })).toBeInTheDocument()
+  },
+}
+
+// Back link plus a trailing actions slot — the actions are the caller's nodes, so the story proves
+// a click reaches the caller's handler rather than being swallowed by the header.
+export const WithBackAndActions: Story = {
+  args: {
+    backTo: '/',
+    backLabel: 'Back to events',
+    actions: (
+      <Button variant="outline" size="sm" onClick={() => onAction()}>
+        Edit
+      </Button>
+    ),
+  },
+  play: async ({ canvas, userEvent }) => {
+    onAction.mockClear()
+    await expect(canvas.getByRole('link', { name: 'Back to events' })).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit' }))
+    await expect(onAction).toHaveBeenCalledTimes(1)
+  },
+}
+
+// A title long enough to overrun the bar: it must truncate on one line so the back button and the
+// actions slot keep their space (the real event titles are user-authored and unbounded).
+export const LongTitle: Story = {
+  args: {
+    title: 'Volleybalvereniging Heren 3 — thuiswedstrijd tegen de allerlangste clubnaam',
+    backTo: '/',
+    backLabel: 'Back to events',
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('heading')).toHaveClass('truncate')
+  },
+}

--- a/app/src/widgets/page-header/ui/PageHeader.tsx
+++ b/app/src/widgets/page-header/ui/PageHeader.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@shared/ui/button'
+
+interface PageHeaderProps {
+  /** Page title, truncated to one line so a long user-authored title can't push the actions out. */
+  title: string
+  /** Route the back control navigates to. Omit for a page that has no parent to return to. */
+  backTo?: string
+  /** Accessible name for the back control — say where it goes ("Back to events"), not just "Back". */
+  backLabel?: string
+  /** Trailing controls (edit/delete, a gear, …), rendered right-aligned. Supplied by the caller. */
+  actions?: ReactNode
+}
+
+/**
+ * The shared sticky sub-header: back control + page title + optional actions, pinned directly
+ * beneath the app header.
+ *
+ * The offset is `top: var(--header-height)` — the same variable that sets the app header's box
+ * height in `routes/__root.tsx`. That is the point of this widget: before it, each page hardcoded
+ * its own pixel offset (`top-[57px]`) which silently drifted every time the header changed (F12,
+ * #159). One variable now drives both sides, so they cannot disagree.
+ *
+ * Prop-only (no store, no query) so every state renders from props in Storybook; the routes that
+ * use it stay thin wiring (ADR-0017).
+ */
+export function PageHeader({ title, backTo, backLabel = 'Back', actions }: PageHeaderProps) {
+  return (
+    <div className="sticky top-[var(--header-height)] z-30 -mx-4 mb-2 flex items-center gap-2 border-b border-border/60 bg-background/95 px-4 py-2 backdrop-blur-sm">
+      {backTo && (
+        // asChild so the 44px touch target (F7) is the anchor itself — a real link, not a button
+        // nested inside one.
+        <Button asChild variant="ghost" size="icon" className="h-11 w-11 shrink-0">
+          <Link to={backTo} aria-label={backLabel}>
+            <ArrowLeft size={18} />
+          </Link>
+        </Button>
+      )}
+      <h2 className="font-display truncate text-base font-semibold">{title}</h2>
+      {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes F12 of #159 — the last item in the "consistency & craft" cluster that doesn't depend on the PWA/dark-mode slices.

## The defect

`events/$eventId.tsx` pinned its sticky sub-header at a magic `top-[57px]`, hardcoded to match the app header. The header carried no height of its own — it fell out of `px-5 py-3` — so the two silently drifted. They already had: measured on `main`, the header ends at **53px** while the sub-header pins at **57px**, leaving a 4px strip of page content showing through the gap at every viewport width (B1 changed the header, the offset stayed).

## The fix — one number, read by both sides

- **`--header-height: 3.25rem`** (`app/src/app/styles/global.css`) *sets* the app header's box height in `__root.tsx` (`h-[var(--header-height)]`, border included — the header is border-box) and *is* the offset sticky sub-headers pin to. A future header change moves both ends at once; they can no longer disagree. In `rem`, so it scales with the root font size exactly as its content does (1.75rem line-height + 2 × 0.75rem padding).
- **New `widgets/page-header`** standardizes the pattern: back control, truncating title, optional actions slot, `top: var(--header-height)`, border + blur. Prop-only (no store, no query) so it is storyable; the route stays thin wiring per ADR-0017.
- **`$eventId.tsx`** drops its bespoke sub-header for `<PageHeader title={…} backTo="/" backLabel="Back to events" />`.
- Small a11y tightening carried through the extraction: the back control is now the anchor itself (`Button asChild` → `Link`) rather than a `<button>` nested inside an `<a>`, keeping the 44px touch target from F7.

`$eventId` was the only magic offset in the app (`grep` for `top-[`), so this is a one-site refactor today and a shared primitive for the pages that come next.

## Tests — PR gate

Five stories in `PageHeader.stories.tsx`, all states props-driven:

| Story | Proves |
|---|---|
| `TitleOnly` | minimal shape; no back link rendered |
| `WithBack` | back control resolves to the right href with its accessible name |
| `WithBackAndActions` | the actions slot is genuinely interactive — an `fn()` spy is clicked in `play` and asserted `toHaveBeenCalledTimes(1)` |
| `LongTitle` | an unbounded user-authored title truncates to one line |
| `StickyOffsetFollowsHeaderHeight` | overrides `--header-height` to an off-token `80px` and reads the resolved `top` back — the offset must *derive* from the variable |

That last one is the regression guard for this exact defect, and it isn't vacuous: re-hardcoding the offset to `top-[57px]` was checked to fail it (`expected '57px' to be '80px'`). Chromatic covers the visual side automatically now that the component has stories.

**No new e2e.** The change introduces no new seam — no auth path, no cross-tenant write, no external integration — and the back-navigation it standardizes is already exercised by the attendance flow.

## Verification

- `make test-app` → **62 files / 338 tests passed** (5 new).
- `npm run lint` (ESLint, incl. the FSD boundary rules for the new widget) → clean. `tsc -b` → clean. Detekt could not run in this container (no Java 25 toolchain available); no Kotlin changed.
- Manual, in a real browser against the actual `/events/:id` route at **320 / 360 / 414 / 768 / 1280px**, scrolled so the sub-header is stuck:

| | header height | sub-header `top` | gap |
|---|---|---|---|
| before (`main`) | 53px | 57px | **4px** |
| after | 52px | 52px (`var(--header-height)`) | **0px** |

Flush at every width. (The container has no Docker, so the backend was stood in for by a throwaway mock serving `/api/auth/me`, `/api/members/me` and `/api/events/e1` behind the normal Vite proxy — the route, the shell and the CSS under test are the real ones.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHfvNf9qDJA4yqyKLccqmv)_