### PR TITLE
feat(app): events list top-of-page redesign — Next Up hero, date-block cards, filter popover

### DIFF
--- a/app/src/entities/event/lib/next-event.test.ts
+++ b/app/src/entities/event/lib/next-event.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { Event } from '@shared/api/events'
+import { makeEvent } from '@shared/testing/event-fixtures'
+import { selectHeroEvent } from './next-event'
+
+const at = (y: number, m: number, d: number, h = 12, min = 0) =>
+  new Date(y, m - 1, d, h, min, 0, 0)
+
+const event = (id: string, start: Date): Event =>
+  makeEvent({ id, startTime: start.toISOString() })
+
+// 2026-08-10, a Monday, is "now" throughout.
+const NOW = at(2026, 8, 10, 9, 0)
+
+describe('selectHeroEvent', () => {
+  it('returns nothing for an empty list', () => {
+    expect(selectHeroEvent([], NOW)).toBeNull()
+  })
+
+  it('returns nothing when every event is in the past', () => {
+    const events = [event('a', at(2026, 8, 3)), event('b', at(2026, 8, 9))]
+    expect(selectHeroEvent(events, NOW)).toBeNull()
+  })
+
+  it('picks the most imminent upcoming event', () => {
+    const events = [event('later', at(2026, 8, 13)), event('sooner', at(2026, 8, 11))]
+    expect(selectHeroEvent(events, NOW)?.id).toBe('sooner')
+  })
+
+  it('picks the earliest future event regardless of list order or past entries', () => {
+    // "Show past events" hands the list back newest-first with history mixed in.
+    const events = [
+      event('past-recent', at(2026, 8, 9)),
+      event('future-far', at(2026, 8, 14)),
+      event('past-old', at(2026, 7, 1)),
+      event('future-near', at(2026, 8, 12)),
+    ]
+    expect(selectHeroEvent(events, NOW)?.id).toBe('future-near')
+  })
+
+  it('takes an event still to start today', () => {
+    expect(selectHeroEvent([event('tonight', at(2026, 8, 10, 20, 0))], NOW)?.id).toBe('tonight')
+  })
+
+  it('takes an event on the far edge of the window', () => {
+    // 7 calendar days out — the last day RELATIVE_WINDOW_DAYS admits.
+    expect(selectHeroEvent([event('edge', at(2026, 8, 17))], NOW)?.id).toBe('edge')
+  })
+
+  it('returns nothing when the next event is beyond the window — no hero, no placeholder', () => {
+    expect(selectHeroEvent([event('far', at(2026, 8, 18))], NOW)).toBeNull()
+    expect(selectHeroEvent([event('very-far', at(2026, 12, 1))], NOW)).toBeNull()
+  })
+
+  it('does not fall through to a later event when the nearest one is out of the window', () => {
+    // The nearest event decides. A hero is never "the next event that happens to qualify".
+    const events = [event('far', at(2026, 8, 18)), event('further', at(2026, 8, 25))]
+    expect(selectHeroEvent(events, NOW)).toBeNull()
+  })
+})

--- a/app/src/entities/event/lib/next-event.ts
+++ b/app/src/entities/event/lib/next-event.ts
@@ -1,0 +1,31 @@
+import type { Event } from '@shared/api/events'
+import { RELATIVE_WINDOW_DAYS, calendarDaysUntil } from './relative-event-label'
+
+/**
+ * The event the Next Up hero should render, or `null` when there should be no hero at all.
+ *
+ * Two rules, in order:
+ *  1. The hero is the *most imminent* upcoming event — it is never "the next event that happens to
+ *     qualify". If the nearest one is too far out, the page simply has no hero.
+ *  2. It renders only within `RELATIVE_WINDOW_DAYS` calendar days, measured the same way the card
+ *     label measures it, so hero visibility and "Today / in N days" never disagree.
+ *
+ * There is deliberately no "nothing this week" placeholder: when this returns `null` the page goes
+ * straight to the list (or the list's empty state). Callers pass the *filtered* list, so the hero
+ * follows what the user has chosen to look at, and must drop the returned event from the list below
+ * so it is not rendered twice.
+ *
+ * The input may be unsorted and may contain past events (it does when "Show past events" is on).
+ */
+export function selectHeroEvent(events: Event[], now: Date): Event | null {
+  const next = events
+    .filter((event) => new Date(event.startTime).getTime() >= now.getTime())
+    .reduce<Event | null>(
+      (nearest, event) =>
+        nearest === null || new Date(event.startTime) < new Date(nearest.startTime) ? event : nearest,
+      null,
+    )
+
+  if (next === null) return null
+  return calendarDaysUntil(next.startTime, now) <= RELATIVE_WINDOW_DAYS ? next : null
+}

--- a/app/src/entities/event/lib/relative-event-label.test.ts
+++ b/app/src/entities/event/lib/relative-event-label.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RELATIVE_WINDOW_DAYS,
+  calendarDaysUntil,
+  relativeEventLabel,
+} from './relative-event-label'
+
+// All dates are built with the local-time Date constructor and handed to the function as ISO
+// strings, so these tests assert the same behaviour in any runner timezone: the function reads
+// calendar days in the viewer's local zone, which is exactly what "Today"/"Tomorrow" mean to a user.
+const at = (y: number, m: number, d: number, h = 12, min = 0) =>
+  new Date(y, m - 1, d, h, min, 0, 0)
+const iso = (d: Date) => d.toISOString()
+
+const label = (start: Date, now: Date) => relativeEventLabel(iso(start), now)
+
+// 2026-08-10 is a Monday; the week runs Mon 10 → Sun 16, so Sat 15 / Sun 16 are "this weekend".
+const MON = at(2026, 8, 10)
+const TUE = at(2026, 8, 11)
+const THU = at(2026, 8, 13)
+const FRI = at(2026, 8, 14)
+const SAT = at(2026, 8, 15)
+const SUN = at(2026, 8, 16)
+
+describe('RELATIVE_WINDOW_DAYS', () => {
+  it('ships at 7', () => {
+    expect(RELATIVE_WINDOW_DAYS).toBe(7)
+  })
+})
+
+describe('calendarDaysUntil', () => {
+  it('counts midnight boundaries crossed, not 24-hour blocks', () => {
+    // 30 minutes apart, but across midnight — one calendar day.
+    expect(calendarDaysUntil(iso(at(2026, 8, 11, 0, 15)), at(2026, 8, 10, 23, 45))).toBe(1)
+    // 23 hours apart, same calendar day — zero.
+    expect(calendarDaysUntil(iso(at(2026, 8, 10, 23, 30)), at(2026, 8, 10, 0, 30))).toBe(0)
+  })
+
+  it('is negative for past days', () => {
+    expect(calendarDaysUntil(iso(at(2026, 8, 9)), MON)).toBe(-1)
+  })
+
+  it('crosses month and year boundaries', () => {
+    expect(calendarDaysUntil(iso(at(2026, 9, 2)), at(2026, 8, 30))).toBe(3)
+    expect(calendarDaysUntil(iso(at(2027, 1, 2)), at(2026, 12, 30))).toBe(3)
+  })
+
+  it('accepts a Date as well as an ISO string', () => {
+    expect(calendarDaysUntil(at(2026, 8, 12), MON)).toBe(2)
+  })
+})
+
+describe('relativeEventLabel', () => {
+  describe('same calendar day → Today (solid)', () => {
+    it('labels an event later today', () => {
+      expect(label(at(2026, 8, 10, 20, 0), at(2026, 8, 10, 9, 0))).toEqual({
+        text: 'Today',
+        emphasis: 'solid',
+      })
+    })
+
+    it('still labels an event that already started today', () => {
+      expect(label(at(2026, 8, 10, 9, 0), at(2026, 8, 10, 20, 0))).toEqual({
+        text: 'Today',
+        emphasis: 'solid',
+      })
+    })
+
+    it('says Today — not Tomorrow — for a late-evening event seen in the morning', () => {
+      expect(label(at(2026, 8, 10, 23, 30), at(2026, 8, 10, 0, 30))?.text).toBe('Today')
+    })
+  })
+
+  describe('next calendar day → Tomorrow (solid)', () => {
+    it('labels an event just after midnight tonight', () => {
+      // Only 45 minutes away, but it is tomorrow to a human reading a calendar.
+      expect(label(at(2026, 8, 11, 0, 15), at(2026, 8, 10, 23, 30))).toEqual({
+        text: 'Tomorrow',
+        emphasis: 'solid',
+      })
+    })
+
+    it('labels an event 30 hours out — calendar days, not 24-hour blocks', () => {
+      expect(label(at(2026, 8, 11, 18, 0), at(2026, 8, 10, 12, 0))).toEqual({
+        text: 'Tomorrow',
+        emphasis: 'solid',
+      })
+    })
+  })
+
+  describe('the coming Sat/Sun → This weekend', () => {
+    it('is quiet when the weekend is more than 2 days out', () => {
+      expect(label(SAT, TUE)).toEqual({ text: 'This weekend', emphasis: 'quiet' })
+      expect(label(SUN, TUE)).toEqual({ text: 'This weekend', emphasis: 'quiet' })
+    })
+
+    it('is solid when the weekend is 2 days out', () => {
+      expect(label(SAT, THU)).toEqual({ text: 'This weekend', emphasis: 'solid' })
+      expect(label(SUN, FRI)).toEqual({ text: 'This weekend', emphasis: 'solid' })
+    })
+
+    it('loses to Today and Tomorrow, which are more precise', () => {
+      expect(label(SAT, FRI)?.text).toBe('Tomorrow')
+      expect(label(SAT, SAT)?.text).toBe('Today')
+      expect(label(SUN, SAT)?.text).toBe('Tomorrow')
+    })
+
+    it('does not call NEXT weekend "this weekend"', () => {
+      // Seen on Sunday, the Saturday six days out belongs to the following week.
+      expect(label(at(2026, 8, 22), SUN)).toEqual({ text: 'in 6 days', emphasis: 'quiet' })
+    })
+  })
+
+  describe('within the window → in N days', () => {
+    it('is solid at 2 days', () => {
+      expect(label(at(2026, 8, 12), MON)).toEqual({ text: 'in 2 days', emphasis: 'solid' })
+    })
+
+    it('is quiet from 3 days to the edge of the window', () => {
+      expect(label(at(2026, 8, 13), MON)).toEqual({ text: 'in 3 days', emphasis: 'quiet' })
+      expect(label(at(2026, 8, 17), MON)).toEqual({ text: 'in 7 days', emphasis: 'quiet' })
+    })
+  })
+
+  describe('outside the window → no label', () => {
+    it('drops the label one day past the window', () => {
+      expect(label(at(2026, 8, 18), MON)).toBeNull()
+    })
+
+    it('drops the label for past events', () => {
+      expect(label(at(2026, 8, 9), MON)).toBeNull()
+      expect(label(at(2026, 7, 1), MON)).toBeNull()
+    })
+  })
+})

--- a/app/src/entities/event/lib/relative-event-label.ts
+++ b/app/src/entities/event/lib/relative-event-label.ts
@@ -1,0 +1,81 @@
+/**
+ * How far ahead a relative-time label is worth showing, in calendar days.
+ *
+ * Past this, the card's date chit already says everything ("in 9 days" is just the chit in weaker
+ * words), so no label is rendered. The same constant gates the Next Up hero — the hero and the
+ * label share one idea of "near". Kept as a single named constant so the window can be re-tuned
+ * (7 vs 10) in one edit; we ship 7 because a volleyball team thinks in weeks.
+ */
+export const RELATIVE_WINDOW_DAYS = 7
+
+export type RelativeLabelEmphasis = 'solid' | 'quiet'
+
+export interface RelativeLabel {
+  text: string
+  /** `solid` renders a hue-neutral ink pill; `quiet` is muted grey text with no pill. */
+  emphasis: RelativeLabelEmphasis
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const SATURDAY = 6
+const SUNDAY = 0
+
+const toDate = (value: string | Date) => (value instanceof Date ? value : new Date(value))
+
+/** Local midnight of the day `value` falls on. */
+const startOfDay = (value: Date) => new Date(value.getFullYear(), value.getMonth(), value.getDate())
+
+/**
+ * Calendar days from `now` to `startTime`, counted in the viewer's local zone: how many midnights
+ * sit between them, not how many 24-hour blocks. An event 45 minutes away is "1" when those 45
+ * minutes cross midnight, which is what "Tomorrow" means to the person reading the card.
+ *
+ * Rounding absorbs the 23- and 25-hour days a DST transition produces.
+ */
+export function calendarDaysUntil(startTime: string | Date, now: Date): number {
+  const diff = startOfDay(toDate(startTime)).getTime() - startOfDay(now).getTime()
+  return Math.round(diff / MS_PER_DAY)
+}
+
+/**
+ * Days from `now` until the Saturday and Sunday that close the current week (Mon–Sun). On a Sunday
+ * both are behind us, so nothing is "this weekend" — the Saturday six days out belongs to the
+ * following week and gets a plain "in 6 days" instead.
+ */
+function daysToComingWeekend(now: Date): number[] {
+  const weekday = now.getDay()
+  const daysToSaturday = SATURDAY - weekday
+  return weekday === SUNDAY ? [] : [daysToSaturday, daysToSaturday + 1]
+}
+
+/**
+ * The graduated relative-time label for an event, or `null` when the date alone should carry it.
+ *
+ * Rules are evaluated top-down, first match wins:
+ *
+ * | Condition                                            | Text            | Emphasis         |
+ * |------------------------------------------------------|-----------------|------------------|
+ * | Same calendar day                                     | `Today`         | solid            |
+ * | Next calendar day                                     | `Tomorrow`      | solid            |
+ * | Coming Sat/Sun, ≥2 days away, within the window       | `This weekend`  | quiet (solid ≤2) |
+ * | Within the window, ≤2 days away                       | `in N days`     | solid            |
+ * | Within the window, 3–7 days away                      | `in N days`     | quiet            |
+ * | Beyond the window (or in the past)                    | —               | —                |
+ *
+ * Pure: `now` is a parameter, never `Date.now()`, so the label is a function of its inputs and
+ * every branch above is unit-testable.
+ */
+export function relativeEventLabel(startTime: string | Date, now: Date): RelativeLabel | null {
+  const days = calendarDaysUntil(startTime, now)
+
+  if (days < 0) return null
+  if (days === 0) return { text: 'Today', emphasis: 'solid' }
+  if (days === 1) return { text: 'Tomorrow', emphasis: 'solid' }
+  if (days > RELATIVE_WINDOW_DAYS) return null
+
+  const emphasis: RelativeLabelEmphasis = days <= 2 ? 'solid' : 'quiet'
+
+  if (daysToComingWeekend(now).includes(days)) return { text: 'This weekend', emphasis }
+
+  return { text: `in ${days} days`, emphasis }
+}

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -6,10 +6,17 @@ import { EventCard } from './EventCard'
 
 // EventCard renders a TanStack Router <Link to="/events/$eventId">, which needs a router in context.
 // The shared withRouter decorator supplies a minimal in-memory router so the link target resolves.
+//
+// `now` is a prop, so every relative-label state is a fixed render rather than a function of when
+// the story happens to run — which is also what keeps the Chromatic snapshots stable.
+const NOW = new Date(2026, 7, 10, 9, 0) // Monday 10 August 2026, 09:00 local
+const on = (day: number, hour = 20, minute = 0) => new Date(2026, 7, day, hour, minute).toISOString()
+
 const meta = {
   title: 'entities/event/EventCard',
   component: EventCard,
   decorators: [withRouter],
+  args: { now: NOW },
 } satisfies Meta<typeof EventCard>
 
 export default meta
@@ -17,33 +24,89 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Populated: Story = {
-  args: { event: makeEvent() },
+  args: {
+    event: makeEvent({ startTime: on(13, 14, 30), location: 'Sportcentrum Noord' }),
+  },
   play: async ({ canvas }) => {
+    // The date chit leads with weekday / day number / month, so the meta line needs no date.
+    await expect(canvas.getByText('13')).toBeInTheDocument()
+    await expect(canvas.getByText('14:30')).toBeInTheDocument()
+    // The type text label stays alongside the chit's colour.
+    await expect(canvas.getByText('Match')).toBeInTheDocument()
     await expect(canvas.getByText(/5 going/)).toBeInTheDocument()
-    await expect(canvas.getByText('2 Outside Hitter')).toBeInTheDocument()
-    await expect(canvas.getByText('1 Libero')).toBeInTheDocument()
-    await expect(canvas.getByText('1 Opposite')).toBeInTheDocument()
-    await expect(canvas.getByText('1 Setter')).toBeInTheDocument()
+    await expect(canvas.getByText(/of 8/)).toBeInTheDocument()
+  },
+}
+
+// Three days out: inside the window, past the imminent band — a quiet grey label, no pill.
+export const WithQuietRelativeLabel: Story = {
+  args: { event: makeEvent({ startTime: on(13) }) },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('in 3 days')).toBeInTheDocument()
+  },
+}
+
+// Tomorrow: the imminent band, so the label is the solid ink pill.
+export const WithSolidRelativeLabel: Story = {
+  args: { event: makeEvent({ startTime: on(11) }) },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Tomorrow')).toBeInTheDocument()
+  },
+}
+
+// Beyond RELATIVE_WINDOW_DAYS the chit's date says it better than "in 21 days" would.
+export const WithoutRelativeLabel: Story = {
+  args: { event: makeEvent({ startTime: on(31) }) },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('31')).toBeInTheDocument()
+    await expect(canvas.queryByText(/^in \d+ days$/)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/^(Today|Tomorrow|This weekend)$/)).not.toBeInTheDocument()
+  },
+}
+
+// A social event: a different type colour tints the chit, and the text tag still names the type.
+export const SocialEvent: Story = {
+  args: {
+    event: makeEvent({
+      eventType: { id: 'et-4', name: 'Social', color: '#F4B400' },
+      title: 'Season kick-off drinks',
+      startTime: on(15, 21, 0),
+      location: 'Café De Hoek',
+      attendanceSummary: {
+        attending: 11,
+        maybe: 0,
+        absent: 2,
+        notResponded: 2,
+        roleBreakdown: [],
+      },
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Social')).toBeInTheDocument()
+    await expect(canvas.getByText('Season kick-off drinks')).toBeInTheDocument()
+    await expect(canvas.getByText(/11 going/)).toBeInTheDocument()
+    // The 15th is the Saturday of the current week.
+    await expect(canvas.getByText('This weekend')).toBeInTheDocument()
   },
 }
 
 export const NoResponses: Story = {
   args: {
     event: makeEvent({
+      startTime: on(13),
       attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
     }),
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText(/0 going/)).toBeInTheDocument()
-    await expect(
-      canvas.queryByText(/\d+\s+(Setter|Libero|Outside Hitter|Opposite)/),
-    ).not.toBeInTheDocument()
+    await expect(canvas.getByText(/of 0/)).toBeInTheDocument()
   },
 }
 
 export const WithReferences: Story = {
   args: {
     event: makeEvent({
+      startTime: on(13),
       references: [
         { title: 'Nevobo', url: 'https://api.nevobo.nl/permalink/wedstrijd/2018133' },
         { title: 'Match form', url: 'https://dwf.volleybal.nl/match/42' },
@@ -62,7 +125,7 @@ export const WithReferences: Story = {
 }
 
 export const WithLocation: Story = {
-  args: { event: makeEvent({ location: 'Sporthal De Boog' }) },
+  args: { event: makeEvent({ startTime: on(13), location: 'Sporthal De Boog' }) },
   play: async ({ canvas, canvasElement }) => {
     // The location renders as a real maps link that opens in a new tab...
     const maps = canvas.getByRole('link', { name: 'Sporthal De Boog' })

--- a/app/src/entities/event/ui/EventCard.tsx
+++ b/app/src/entities/event/ui/EventCard.tsx
@@ -1,16 +1,33 @@
 import { Link } from '@tanstack/react-router'
-import { Calendar, MapPin } from 'lucide-react'
+import { Clock, MapPin } from 'lucide-react'
 import { Card } from '@shared/ui/card'
 import type { Event } from '@shared/api/events'
+import { relativeEventLabel } from '../lib/relative-event-label'
+import { EventDateChit } from './EventDateChit'
 import { EventTypeBadge } from './EventTypeBadge'
-import { EventTypeIcon } from './EventTypeIcon'
 import { ReferenceChips } from './ReferenceChips'
+import { RelativeTimeLabel } from './RelativeTimeLabel'
 
+interface EventCardProps {
+  event: Event
+  index?: number
+  /** Injected so the relative label is deterministic in stories; defaults to the real clock. */
+  now?: Date
+}
 
-export function EventCard({ event, index = 0 }: { event: Event; index?: number }) {
+/**
+ * Date-block event card. The type-tinted calendar chit leads, carrying the date on its own, which
+ * is what lets the list stay flat and chronological with no This Week / Later headings. The type
+ * text tag stays next to it — colour alone is not a label.
+ *
+ * The divider above the attendance row is a child of the card, not of the text column, so it runs
+ * edge-to-edge under the chit and the whole thing reads as one card rather than two panes.
+ */
+export function EventCard({ event, index = 0, now = new Date() }: EventCardProps) {
   const date = new Date(event.startTime)
   const { attendanceSummary: s } = event
-  // const relativeChip = getRelativeTimeChip(date)
+  const invited = s.attending + s.maybe + s.absent + s.notResponded
+  const label = relativeEventLabel(event.startTime, now)
 
   return (
     // Stretched-link pattern: the card itself is not an anchor. The title <Link> carries an
@@ -18,13 +35,18 @@ export function EventCard({ event, index = 0 }: { event: Event; index?: number }
     // anchor rather than a nested one (an <a> inside the card's <a> is invalid HTML).
     <Card
       style={{ animationDelay: `${index * 60}ms` }}
-      className="card-enter card-shadow relative p-4 transition-[box-shadow] hover:card-shadow-hover"
+      className="card-enter card-shadow relative p-3.5 transition-[box-shadow] hover:card-shadow-hover"
     >
-      {/* Top: icon + badge/title */}
-      <div className="flex items-start gap-3.5">
-        <EventTypeIcon type={event.eventType} size="sm" />
+      <div className="flex gap-3.5">
+        <EventDateChit date={date} type={event.eventType} />
+
         <div className="min-w-0 flex-1">
-          <EventTypeBadge type={event.eventType} />
+          {/* Tag row: type label left, relative time right */}
+          <div className="flex items-center gap-2">
+            <EventTypeBadge type={event.eventType} />
+            {label && <RelativeTimeLabel label={label} />}
+          </div>
+
           <Link
             to="/events/$eventId"
             params={{ eventId: event.id }}
@@ -32,61 +54,53 @@ export function EventCard({ event, index = 0 }: { event: Event; index?: number }
           >
             {event.title}
           </Link>
-        </div>
-      </div>
 
-      {/* Meta: date · time · location — indented to align with title */}
-      <div className="mt-2.5 flex flex-wrap items-center gap-1 pl-[50px] text-[13px] text-muted-foreground">
-        <Calendar size={13} className="shrink-0 text-muted-foreground/60" />
-        {date.toLocaleDateString('nl-NL', { weekday: 'long', day: 'numeric', month: 'short' })}
-        {' · '}
-        {date.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit' })}
-        {event.location && (
-          <>
-            <span className="text-muted-foreground/40">·</span>
-            <MapPin size={13} className="shrink-0 text-muted-foreground/60" />
-            {/* relative z-10 lifts this above the card link's stretched overlay so it stays clickable */}
-            <a
-              href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="relative z-10 hover:text-blue hover:underline"
-            >
-              {event.location}
-            </a>
-          </>
-        )}
-      </div>
-
-      {/* Reference chips — up to 2, then "+N"; indented to align with the meta row */}
-      {event.references.length > 0 && (
-        <div className="mt-2 pl-[50px]">
-          <ReferenceChips references={event.references} max={2} />
-        </div>
-      )}
-
-      {/* Bottom: status + attendance summary */}
-      <div className="mt-3 border-t border-border/40 pt-3">
-        <div className="flex items-center gap-2">
-          <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
-            ✓ {s.attending} going
-          </span>
-          <span className="text-xs text-muted-foreground">
-            of {s.attending + s.maybe + s.absent + s.notResponded}
-            {s.notResponded > 0 && (
-              <> · <span className="opacity-60">{s.notResponded} pending</span></>
+          {/* Meta: time · location — the chit already carries the date */}
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[12.5px] text-muted-foreground">
+            <Clock size={13} className="shrink-0 text-muted-foreground/60" />
+            <span className="font-semibold text-foreground">
+              {date.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit' })}
+            </span>
+            {event.location && (
+              <>
+                <span className="text-muted-foreground/40">·</span>
+                <MapPin size={13} className="shrink-0 text-muted-foreground/60" />
+                {/* relative z-10 lifts this above the card link's stretched overlay so it stays clickable */}
+                <a
+                  href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative z-10 hover:text-blue hover:underline"
+                >
+                  {event.location}
+                </a>
+              </>
             )}
-          </span>
-        </div>
-        {s.roleBreakdown.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {s.roleBreakdown.map(({ role, attending }) => (
-              <span key={role} className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                {attending} {role}
-              </span>
-            ))}
           </div>
-        )}
+
+          {/* Reference chips — up to 2, then "+N" */}
+          {event.references.length > 0 && (
+            <div className="mt-2">
+              <ReferenceChips references={event.references} max={2} />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Attendance row. Sibling of the chit+body row, so its rule spans the full card width. */}
+      <div className="mt-3 flex items-center gap-2 border-t border-border/40 pt-3">
+        <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
+          ✓ {s.attending} going
+        </span>
+        <span className="text-xs text-muted-foreground">
+          of {invited}
+          {s.notResponded > 0 && (
+            <>
+              {' · '}
+              <span className="opacity-60">{s.notResponded} pending</span>
+            </>
+          )}
+        </span>
       </div>
     </Card>
   )

--- a/app/src/entities/event/ui/EventDateChit.tsx
+++ b/app/src/entities/event/ui/EventDateChit.tsx
@@ -1,0 +1,29 @@
+import type { EventTypeSummary } from '@shared/api/events'
+
+/**
+ * The calendar "chit" that leads every event card: weekday, a big Grandstander day number, month —
+ * tinted with the event type's colour so the block doubles as the type marker. It is the card's
+ * date anchor, which is what lets the flat list drop the This Week / Later headings.
+ *
+ * The colour alone never carries the type: the card keeps a text tag next to it.
+ */
+export function EventDateChit({ date, type }: { date: Date; type: EventTypeSummary }) {
+  const color = type.color ?? '#888'
+
+  return (
+    <div
+      className="flex w-[54px] shrink-0 flex-col items-center self-start rounded-[15px] px-1 pb-2 pt-2.5 text-white"
+      style={{ backgroundColor: color }}
+    >
+      <span className="text-[10px] font-bold uppercase leading-none tracking-[0.1em] opacity-90">
+        {date.toLocaleDateString('nl-NL', { weekday: 'short' }).replace('.', '')}
+      </span>
+      <span className="font-display my-0.5 text-2xl font-extrabold leading-none">
+        {date.getDate()}
+      </span>
+      <span className="text-[9px] font-bold uppercase leading-none tracking-[0.12em] opacity-80">
+        {date.toLocaleDateString('nl-NL', { month: 'short' }).replace('.', '')}
+      </span>
+    </div>
+  )
+}

--- a/app/src/entities/event/ui/EventListView.stories.tsx
+++ b/app/src/entities/event/ui/EventListView.stories.tsx
@@ -7,10 +7,14 @@ import { EventListView } from './EventListView'
 // EventListView is the presentational list region of the events page: it renders one of four
 // states (loading / error / empty / data) from props the container hands down. Each state is a
 // story. The data state renders EventCards (which link out), so the router decorator is applied.
+const NOW = new Date(2026, 7, 10, 9, 0) // Monday 10 August 2026, 09:00 local
+const on = (day: number) => new Date(2026, 7, day, 20, 0).toISOString()
+
 const meta = {
   title: 'entities/event/EventListView',
   component: EventListView,
   decorators: [withRouter],
+  args: { now: NOW },
 } satisfies Meta<typeof EventListView>
 
 export default meta
@@ -18,51 +22,61 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Loading: Story = {
-  args: { groups: [], isLoading: true },
+  args: { events: [], isLoading: true },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('status', { name: /loading events/i })).toBeInTheDocument()
   },
 }
 
 export const ErrorState: Story = {
-  args: { groups: [], error: new Error('boom') },
+  args: { events: [], error: new Error('boom') },
   play: async ({ canvas }) => {
     await expect(canvas.getByText(/couldn't load events/i)).toBeInTheDocument()
   },
 }
 
+// The page-level "no hero" case bottoms out here: with nothing upcoming there is no hero and no
+// placeholder in its place — just this message. (The ≤7-day boundary itself is proven by the
+// selectHeroEvent unit test.)
 export const Empty: Story = {
-  args: { groups: [] },
+  args: { events: [] },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('No events yet.')).toBeInTheDocument()
+    await expect(canvas.getByText('No upcoming events.')).toBeInTheDocument()
   },
 }
 
+export const EmptyWhenFiltered: Story = {
+  args: { events: [], emptyMessage: 'No events for this type.' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('No events for this type.')).toBeInTheDocument()
+  },
+}
+
+// A flat, chronological list — no This Week / Later headings; each card's chit carries its date.
 export const WithEvents: Story = {
   args: {
-    groups: [
-      {
-        label: 'This Week',
-        events: [
-          makeEvent({ id: 'evt-1', title: 'League Match' }),
-          makeEvent({ id: 'evt-2', title: 'Training' }),
-        ],
-      },
+    events: [
+      makeEvent({ id: 'evt-1', title: 'League Match', startTime: on(11) }),
+      makeEvent({ id: 'evt-2', title: 'Training', startTime: on(13) }),
+      makeEvent({ id: 'evt-3', title: 'Regio-toernooi', startTime: on(29) }),
     ],
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('This Week')).toBeInTheDocument()
     await expect(canvas.getByText('League Match')).toBeInTheDocument()
     await expect(canvas.getByText('Training')).toBeInTheDocument()
+    await expect(canvas.getByText('Regio-toernooi')).toBeInTheDocument()
+    // The old section headings are gone for good.
+    await expect(canvas.queryByText('This Week')).not.toBeInTheDocument()
+    await expect(canvas.queryByText('Later')).not.toBeInTheDocument()
   },
 }
 
 // A background refetch can fail while react-query still holds cached data: `error` is set but
-// `groups` is non-empty. The list must keep showing the cached events, not blank them out.
+// `events` is non-empty. The list must keep showing the cached events, not blank them out.
 export const DataDespiteBackgroundError: Story = {
   args: {
     error: new Error('refetch failed'),
-    groups: [{ label: 'This Week', events: [makeEvent({ id: 'evt-1', title: 'League Match' })] }],
+    events: [makeEvent({ id: 'evt-1', title: 'League Match', startTime: on(11) })],
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('League Match')).toBeInTheDocument()

--- a/app/src/entities/event/ui/EventListView.tsx
+++ b/app/src/entities/event/ui/EventListView.tsx
@@ -2,72 +2,63 @@ import type { Event } from '@shared/api/events'
 import { Skeleton } from '@shared/ui/skeleton'
 import { EventCard } from './EventCard'
 
-export interface EventGroup {
-  label: string
-  events: Event[]
-}
-
 interface EventListViewProps {
-  groups: EventGroup[]
+  /** Already filtered, already sorted, and with the hero event removed by the container. */
+  events: Event[]
   isLoading?: boolean
   error?: unknown
   emptyMessage?: string
+  /** Injected so relative labels are deterministic in stories; defaults to the real clock. */
+  now?: Date
 }
 
 /**
  * Presentational list region of the events page. Renders one of four states from props the
- * container (the route) hands down — loading / error / empty / grouped data — so each state is
- * testable in isolation (see EventListView.stories.tsx). Date-based grouping and filtering stay in
- * the container; this component only renders the groups it is given.
+ * container (the route) hands down — loading / error / empty / data — so each state is testable in
+ * isolation (see EventListView.stories.tsx).
+ *
+ * The list is flat and chronological: the date chit on each card carries the date, so the old
+ * This Week / Later grouping headings are gone. Sorting, filtering and hero extraction stay in the
+ * container; this component renders exactly the events it is given, in the order it is given them.
  */
 export function EventListView({
-  groups,
+  events,
   isLoading = false,
   error,
-  emptyMessage = 'No events yet.',
+  emptyMessage = 'No upcoming events.',
+  now,
 }: EventListViewProps) {
   // Data wins: keep showing cached events even when a background refetch is loading or has errored,
   // so a transient failure never blanks a list the user is already looking at.
-  if (groups.length === 0) {
+  if (events.length === 0) {
     if (isLoading) return <EventListSkeleton />
     if (error) return <p className="mt-4 text-sm text-red-500">Couldn&apos;t load events.</p>
     return <p className="mt-4 text-muted-foreground">{emptyMessage}</p>
   }
 
   return (
-    <>
-      {groups.map((group, gi) => (
-        <div key={group.label || 'past'} className={gi === 0 ? 'mt-4' : 'mt-6'}>
-          {group.label && (
-            <h3 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
-              {group.label}
-            </h3>
-          )}
-          <div className="flex flex-col gap-3">
-            {group.events.map((event, idx) => (
-              <EventCard key={event.id} event={event} index={idx} />
-            ))}
-          </div>
-        </div>
+    <div className="mt-4 flex flex-col gap-3">
+      {events.map((event, idx) => (
+        <EventCard key={event.id} event={event} index={idx} now={now} />
       ))}
-    </>
+    </div>
   )
 }
 
-/** A few skeleton cards mirroring EventCard's layout, shown while the first page of events loads. */
+/** A few skeleton cards mirroring EventCard's date-block layout, shown while the first load runs. */
 function EventListSkeleton() {
   return (
     <div className="mt-4 flex flex-col gap-3" role="status" aria-label="Loading events">
       {[0, 1, 2].map((i) => (
-        <div key={i} className="rounded-2xl border border-border/40 bg-card p-4 shadow-sm">
-          <div className="flex items-start gap-3.5">
-            <Skeleton className="h-10 w-10 shrink-0 rounded-xl" />
+        <div key={i} className="rounded-2xl border border-border/40 bg-card p-3.5 shadow-sm">
+          <div className="flex gap-3.5">
+            <Skeleton className="h-[62px] w-[54px] shrink-0 rounded-[15px]" />
             <div className="min-w-0 flex-1 space-y-2">
               <Skeleton className="h-4 w-16 rounded-full" />
               <Skeleton className="h-5 w-2/3" />
+              <Skeleton className="h-3.5 w-1/2" />
             </div>
           </div>
-          <Skeleton className="mt-3 ml-[50px] h-3.5 w-1/2" />
           <div className="mt-3 border-t border-border/40 pt-3">
             <Skeleton className="h-6 w-40 rounded-full" />
           </div>

--- a/app/src/entities/event/ui/EventTypeBadge.tsx
+++ b/app/src/entities/event/ui/EventTypeBadge.tsx
@@ -4,7 +4,7 @@ export function EventTypeBadge({ type }: { type: EventTypeSummary }) {
   const color = type.color ?? '#888'
   return (
     <span
-      className="rounded-md px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+      className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.09em]"
       style={{ backgroundColor: color + '14', color }}
     >
       {type.name}

--- a/app/src/entities/event/ui/RelativeTimeLabel.tsx
+++ b/app/src/entities/event/ui/RelativeTimeLabel.tsx
@@ -1,0 +1,25 @@
+import type { RelativeLabel } from '../lib/relative-event-label'
+
+/**
+ * The graduated relative-time label, right-aligned on the card's tag row.
+ *
+ * `solid` is a hue-neutral ink pill — deliberately not a semantic colour, so an imminent event
+ * reads as urgent without competing with the attendance greens/golds/reds. `quiet` is muted grey
+ * text with no pill: present, but not shouting. Events past the window render nothing at all
+ * (`relativeEventLabel` returns null), so this component is never asked to render an empty state.
+ */
+export function RelativeTimeLabel({ label }: { label: RelativeLabel }) {
+  if (label.emphasis === 'solid') {
+    return (
+      <span className="ml-auto shrink-0 whitespace-nowrap rounded-full bg-[rgba(30,41,59,0.08)] px-2.5 py-0.5 text-[11px] font-bold tracking-[0.01em] text-foreground">
+        {label.text}
+      </span>
+    )
+  }
+
+  return (
+    <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] font-semibold text-muted-foreground">
+      {label.text}
+    </span>
+  )
+}

--- a/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import type { EventTypeItem } from '@shared/api/event-types'
+import { EventFiltersView } from './EventFiltersView'
+
+// EventFiltersView is the events page's single filter control — the icon button plus the popover
+// holding the type chips and the "Show past events" switch. It replaces the old Upcoming/Past tab
+// bar. Prop-only apart from the popover's open/closed state; the selection and the show-past flag
+// live in the route, so every state here renders from props with no network (ADR-0017).
+const EVENT_TYPES: EventTypeItem[] = [
+  { id: 'et-1', name: 'Training', color: '#249E6C' },
+  { id: 'et-2', name: 'Match', color: '#225C9C' },
+  { id: 'et-3', name: 'Tournament', color: '#7B5EA7' },
+]
+
+const ALL = new Set(EVENT_TYPES.map((t) => t.id))
+
+const meta = {
+  title: 'features/filter-event-types/EventFiltersView',
+  component: EventFiltersView,
+  args: {
+    eventTypes: EVENT_TYPES,
+    activeTypeIds: ALL,
+    showPast: false,
+    onToggleType: fn(),
+    onToggleShowPast: fn(),
+  },
+} satisfies Meta<typeof EventFiltersView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Closed: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Filters' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    await expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+  },
+}
+
+export const Open: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument()
+    // Both halves of the popover: the type chips and the past-events switch.
+    await expect(canvas.getByRole('button', { name: 'Training' })).toBeInTheDocument()
+    await expect(canvas.getByRole('switch', { name: 'Show past events' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    )
+    await expect(canvas.getByText('Off — upcoming only')).toBeInTheDocument()
+  },
+}
+
+// Prop-contract spy: a chip tap must report the tapped type id up to the route, which owns the
+// isolate-first selection rule (toggleTypeSelection).
+export const TogglesType: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await userEvent.click(canvas.getByRole('button', { name: 'Match' }))
+    await expect(args.onToggleType).toHaveBeenCalledWith('et-2')
+  },
+}
+
+// Prop-contract spy: the switch reports the value it is moving *to*, which is what drives
+// useEvents(showPast).
+export const TogglesShowPast: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await userEvent.click(canvas.getByRole('switch', { name: 'Show past events' }))
+    await expect(args.onToggleShowPast).toHaveBeenCalledWith(true)
+  },
+}
+
+export const ShowingPast: Story = {
+  args: { showPast: true },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.getByRole('switch', { name: 'Show past events' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await expect(canvas.getByText('On — past events included')).toBeInTheDocument()
+    // Switching back off is the same callback with the opposite value.
+    await userEvent.click(canvas.getByRole('switch', { name: 'Show past events' }))
+    await expect(args.onToggleShowPast).toHaveBeenCalledWith(false)
+  },
+}
+
+export const ClosesOnEscape: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument()
+    // Focus is still on the trigger, which is a sibling of the panel — Escape is caught on the
+    // document, so it has to work from there.
+    await userEvent.keyboard('{Escape}')
+    await expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+  },
+}
+
+// With no event types to show — a fresh tenant, or a types request that failed — the popover still
+// has to open and still has to offer the past toggle: it is the only route to past events now.
+export const WithoutEventTypes: Story = {
+  args: { eventTypes: [], activeTypeIds: new Set<string>() },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.queryByText('Event types')).not.toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('switch', { name: 'Show past events' }))
+    await expect(args.onToggleShowPast).toHaveBeenCalledWith(true)
+  },
+}
+
+// A narrowed selection has to be visible with the popover shut, or a filtered list reads as an
+// empty one.
+export const FilteredToOneType: Story = {
+  args: { activeTypeIds: new Set(['et-2']) },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.getByRole('button', { name: 'Match' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    await expect(canvas.getByRole('button', { name: 'Training' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  },
+}

--- a/app/src/features/filter-event-types/ui/EventFiltersView.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { SlidersHorizontal } from 'lucide-react'
+import type { EventTypeItem } from '@shared/api/event-types'
+
+interface EventFiltersViewProps {
+  eventTypes: EventTypeItem[]
+  /** Ids of the types currently shown. Every id active = no type filter in effect. */
+  activeTypeIds: Set<string>
+  showPast: boolean
+  onToggleType: (typeId: string) => void
+  onToggleShowPast: (showPast: boolean) => void
+}
+
+/**
+ * The events page's single filter control: an icon button that opens a popover holding the
+ * event-type chips and the "Show past events" switch. It replaces the old Upcoming/Past segmented
+ * tab bar — past events are a filter, not a mode, and the page no longer spends a band of chrome on
+ * a control that only flipped which way the same list grew.
+ *
+ * Prop-only apart from the popover's own open/closed state, which is local view state: the selected
+ * types and the show-past flag live in the route so they can drive `useEvents` and the hero.
+ */
+export function EventFiltersView({
+  eventTypes,
+  activeTypeIds,
+  showPast,
+  onToggleType,
+  onToggleShowPast,
+}: EventFiltersViewProps) {
+  const [open, setOpen] = useState(false)
+  // A dot on the trigger so an active filter is visible with the popover closed — otherwise a
+  // filtered list looks like an empty one.
+  const hasActiveFilter = showPast || activeTypeIds.size < eventTypes.length
+
+  // Escape has to be caught on the document: focus stays on the trigger, which is a sibling of the
+  // popover, so a handler on the panel itself would never see the key.
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="Filters"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        className="relative flex h-11 w-11 items-center justify-center rounded-xl border border-border/60 bg-card text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <SlidersHorizontal size={16} />
+        {hasActiveFilter && (
+          <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full border-2 border-background bg-blue" />
+        )}
+      </button>
+
+      {open && (
+        <>
+          {/* Click-outside catcher. Not focusable — Escape and the trigger are the keyboard paths. */}
+          <div
+            className="fixed inset-0 z-40 bg-black/20"
+            aria-hidden="true"
+            onClick={() => setOpen(false)}
+          />
+          <div
+            role="dialog"
+            aria-label="Filters"
+            className="card-shadow-hover absolute right-0 top-12 z-50 w-[248px] origin-top-right rounded-2xl border border-border/60 bg-card p-3.5"
+          >
+            {/* A team with no event types (or a types request that failed) still gets the past
+                toggle — it is the only way to reach past events now that the tab bar is gone. */}
+            {eventTypes.length > 0 && (
+              <>
+                <h3 className="mb-2.5 text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground">
+                  Event types
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {eventTypes.map((type) => {
+                    const isActive = activeTypeIds.has(type.id)
+                    const color = type.color ?? '#888'
+                    return (
+                      <button
+                        key={type.id}
+                        aria-pressed={isActive}
+                        onClick={() => onToggleType(type.id)}
+                        style={
+                          isActive
+                            ? { backgroundColor: color, borderColor: color, color: '#fff' }
+                            : { borderColor: color + '66', color }
+                        }
+                        className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition-all"
+                      >
+                        {type.name}
+                      </button>
+                    )
+                  })}
+                </div>
+
+                <div className="-mx-3.5 my-3.5 h-px bg-border/60" />
+              </>
+            )}
+
+            <div className="flex items-center justify-between gap-2.5">
+              <div>
+                <div className="text-[13.5px] font-semibold">Show past events</div>
+                <div className="mt-0.5 text-[11.5px] text-muted-foreground">
+                  {showPast ? 'On — past events included' : 'Off — upcoming only'}
+                </div>
+              </div>
+              <button
+                role="switch"
+                aria-checked={showPast}
+                aria-label="Show past events"
+                onClick={() => onToggleShowPast(!showPast)}
+                className={[
+                  'relative h-6 w-11 shrink-0 rounded-full transition-colors',
+                  showPast ? 'bg-green' : 'bg-muted-foreground/30',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-[left] duration-200',
+                    showPast ? 'left-[22px]' : 'left-0.5',
+                  ].join(' ')}
+                />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,38 +1,32 @@
-import {createFileRoute} from '@tanstack/react-router'
-import {useEffect, useMemo, useState} from 'react'
-import {type Event, useEvents} from '@shared/api/events'
-import {useEventTypes} from '@shared/api/event-types'
-import {useUserStore} from '@shared/stores/user-store'
-import {EventListView} from '@entities/event/ui/EventListView'
-import {CreateEventSheet} from '@widgets/create-event/ui/CreateEventSheet'
-import {toggleTypeSelection} from '@features/filter-event-types/model/toggleTypeSelection'
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useMemo, useState } from 'react'
+import { useEvents } from '@shared/api/events'
+import { useEventTypes } from '@shared/api/event-types'
+import { useUserStore } from '@shared/stores/user-store'
+import { useNow } from '@shared/lib/use-now'
+import { EventListView } from '@entities/event/ui/EventListView'
+import { selectHeroEvent } from '@entities/event/lib/next-event'
+import { NextEventHero } from '@widgets/next-event-hero/ui/NextEventHero'
+import { CreateEventSheet } from '@widgets/create-event/ui/CreateEventSheet'
+import { EventFiltersView } from '@features/filter-event-types/ui/EventFiltersView'
+import { toggleTypeSelection } from '@features/filter-event-types/model/toggleTypeSelection'
 
 export const Route = createFileRoute('/')({
     component: EventListPage,
 })
 
-type Tab = 'upcoming' | 'past'
-
-function groupUpcomingEvents(events: Event[]): { label: string; events: Event[] }[] {
-    const now = new Date()
-    const weekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-
-    const thisWeek = events.filter((e) => {
-        const d = new Date(e.startTime)
-        return d >= now && d <= weekFromNow
-    })
-    const later = events.filter((e) => new Date(e.startTime) > weekFromNow)
-
-    const groups: { label: string; events: Event[] }[] = []
-    if (thisWeek.length > 0) groups.push({label: 'This Week', events: thisWeek})
-    if (later.length > 0) groups.push({label: 'Later', events: later})
-    return groups
-}
-
+/**
+ * The events page. Composition, in order: a compact header with the filter trigger, the Next Up
+ * hero when (and only when) one is due, then one flat chronological list.
+ *
+ * All the deciding happens here so the views below stay prop-only: which events survive the type
+ * filter, whether there is a hero, and — because the hero must not appear twice — which event the
+ * list drops.
+ */
 function EventListPage() {
-    const [tab, setTab] = useState<Tab>('upcoming')
+    const [showPast, setShowPast] = useState(false)
     const [activeTypeIds, setActiveTypeIds] = useState<Set<string>>(new Set())
-    const {data: events, isLoading, error} = useEvents(tab === 'past')
+    const {data: events, isLoading, error} = useEvents(showPast)
     const {data: eventTypes} = useEventTypes()
     const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
 
@@ -43,86 +37,75 @@ function EventListPage() {
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [eventTypes])
 
+    // One ticking clock for the whole page, so the hero's countdown, the hero cut-off and every
+    // card's relative label are read off the same instant and can never disagree with each other —
+    // and so a screen left open overnight stops claiming "Tomorrow" about today.
+    const now = useNow()
+
     const filteredEvents = useMemo(() => {
         if (!events || !eventTypes) return events ?? []
         if (activeTypeIds.size === eventTypes.length) return events
         return events.filter(e => activeTypeIds.has(e.eventType.id))
     }, [events, activeTypeIds, eventTypes])
 
-    const groups =
-        tab === 'upcoming' && filteredEvents
-            ? groupUpcomingEvents(filteredEvents)
-            : filteredEvents
-                ? [{label: '', events: [...filteredEvents].reverse()}]
-                : []
+    // The API returns upcoming ascending but "all" descending, so sort here: the list is flat now,
+    // and flat only reads if it is chronological.
+    const sortedEvents = useMemo(
+        () => [...filteredEvents].sort((a, b) => a.startTime.localeCompare(b.startTime)),
+        [filteredEvents],
+    )
+
+    const heroEvent = selectHeroEvent(sortedEvents, now)
+    const listEvents = heroEvent ? sortedEvents.filter(e => e.id !== heroEvent.id) : sortedEvents
+
+    const isTypeFiltered = activeTypeIds.size < (eventTypes?.length ?? 0)
 
     return (
         <div>
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-2">
                 <h2 className="font-display text-2xl font-bold">Events</h2>
-                {/* The invite link moved to the Team page (team-management action); Events keeps
-                    only event creation for admins. */}
-                {isAdmin && <CreateEventSheet/>}
-            </div>
-
-            {/* Segmented pill toggle */}
-            <div className="mt-4 inline-flex rounded-full bg-muted p-1">
-                {(['upcoming', 'past'] as Tab[]).map((t) => (
-                    <button
-                        key={t}
-                        onClick={() => {
-                            setTab(t)
-                        }}
-                        className={[
-                            'relative rounded-full px-4 py-1 text-sm font-medium capitalize transition-all',
-                            "before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']",
-                            tab === t
-                                ? 'bg-card text-foreground shadow-sm'
-                                : 'text-muted-foreground hover:text-foreground',
-                        ].join(' ')}
-                    >
-                        {t.charAt(0).toUpperCase() + t.slice(1)}
-                    </button>
-                ))}
-            </div>
-
-            {/* T3.3: Event type filter pills */}
-            {eventTypes && eventTypes.length > 0 && (
-                <div
-                    className="-mx-4 mt-3 flex min-h-[44px] items-center gap-2 overflow-x-auto px-4 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-                    {eventTypes.map((type) => {
-                        const isActive = activeTypeIds.has(type.id)
-                        const color = type.color ?? '#888'
-                        return (
-                            <button
-                                key={type.id}
-                                onClick={() => {
-                                    setActiveTypeIds(prev =>
-                                        toggleTypeSelection(prev, eventTypes.map(t => t.id), type.id))
-                                }}
-                                style={isActive ? {
-                                    backgroundColor: color,
-                                    borderColor: color,
-                                    color: '#fff'
-                                } : {borderColor: color + '66', color}}
-                                className={[
-                                    'relative shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-all',
-                                    "before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']",
-                                    isActive ? '' : 'hover:opacity-80',
-                                ].join(' ')}
-                            >
-                                {type.name}
-                            </button>
-                        )
-                    })}
+                <div className="flex items-center gap-2">
+                    {/* The invite link moved to the Team page (team-management action); Events keeps
+                        only event creation for admins. */}
+                    {isAdmin && <CreateEventSheet/>}
+                    {/* Always mounted: the popover now owns the only route to past events, so it
+                        must not disappear with the event types it also happens to host. */}
+                    <EventFiltersView
+                        eventTypes={eventTypes ?? []}
+                        activeTypeIds={activeTypeIds}
+                        showPast={showPast}
+                        onToggleType={(typeId) =>
+                            setActiveTypeIds(prev =>
+                                toggleTypeSelection(prev, (eventTypes ?? []).map(t => t.id), typeId))
+                        }
+                        onToggleShowPast={setShowPast}
+                    />
                 </div>
-            )}
+            </div>
+
+            {/* No hero when nothing is within RELATIVE_WINDOW_DAYS — and no placeholder in its
+                place. The list carries the page. */}
+            {heroEvent && <NextEventHero event={heroEvent} now={now}/>}
 
             <EventListView
-                groups={groups}
-                isLoading={isLoading}
-                error={error}
-                emptyMessage={activeTypeIds.size < (eventTypes?.length ?? 0) ? 'No events for this type.' : 'No events yet.'}
+                events={listEvents}
+                // A rendered hero IS loaded data — it was pulled out of this very list — so an empty
+                // list beneath it means "nothing else", never a failure. Withholding the flags keeps
+                // the list from painting a skeleton or an error over a page that is plainly fine.
+                isLoading={heroEvent ? false : isLoading}
+                error={heroEvent ? undefined : error}
+                now={now}
+                emptyMessage={
+                    // With a hero on screen the page is not empty — the list just has nothing left
+                    // after the hero was pulled out of it.
+                    heroEvent
+                        ? 'Nothing else coming up.'
+                        : isTypeFiltered
+                            ? 'No events for this type.'
+                            : showPast
+                                ? 'No events yet.'
+                                : 'No upcoming events.'
+                }
             />
         </div>
     )

--- a/app/src/shared/api/attendance-cache.test.ts
+++ b/app/src/shared/api/attendance-cache.test.ts
@@ -79,4 +79,56 @@ describe('applyOptimisticAttendance', () => {
   it('returns null unchanged (nothing cached yet)', () => {
     expect(applyOptimisticAttendance(undefined, 'user-1', 'ABSENT')).toBeUndefined()
   })
+
+  // The Next Up hero shows the response and the headcount on one line, so the summary has to move
+  // with the entry or it contradicts itself until the refetch lands.
+  it('moves the summary counters with the entry', () => {
+    const event = makeEventDetail({
+      attendanceSummary: {
+        attending: 10,
+        maybe: 1,
+        absent: 2,
+        notResponded: 3,
+        roleBreakdown: [{ role: 'Setter', attending: 2 }],
+      },
+      attendances: [attendee({ userId: 'user-1', state: 'NOT_RESPONDED' })],
+    })
+
+    const next = applyOptimisticAttendance(event, 'user-1', 'ATTENDING')
+    if (!next) throw new Error('expected a patched event')
+
+    expect(next.attendanceSummary.attending).toBe(11)
+    expect(next.attendanceSummary.notResponded).toBe(2)
+    expect(next.attendanceSummary.maybe).toBe(1)
+    expect(next.attendanceSummary.absent).toBe(2)
+    // roleBreakdown is the server's to recompute; the optimistic patch leaves it alone.
+    expect(next.attendanceSummary.roleBreakdown).toEqual(event.attendanceSummary.roleBreakdown)
+    // And the original summary is untouched, so a rollback still restores the real counts.
+    expect(event.attendanceSummary.attending).toBe(10)
+  })
+
+  it('leaves the counters alone when the state does not actually change', () => {
+    const event = makeEventDetail({
+      attendanceSummary: { attending: 4, maybe: 0, absent: 0, notResponded: 1, roleBreakdown: [] },
+      attendances: [attendee({ userId: 'user-1', state: 'ATTENDING' })],
+    })
+
+    const next = applyOptimisticAttendance(event, 'user-1', 'ATTENDING')
+    if (!next) throw new Error('expected a patched event')
+
+    expect(next.attendanceSummary.attending).toBe(4)
+  })
+
+  it('never drives a counter negative when the summary is already out of step', () => {
+    const event = makeEventDetail({
+      attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
+      attendances: [attendee({ userId: 'user-1', state: 'ATTENDING' })],
+    })
+
+    const next = applyOptimisticAttendance(event, 'user-1', 'ABSENT')
+    if (!next) throw new Error('expected a patched event')
+
+    expect(next.attendanceSummary.attending).toBe(0)
+    expect(next.attendanceSummary.absent).toBe(1)
+  })
 })

--- a/app/src/shared/api/attendance-cache.ts
+++ b/app/src/shared/api/attendance-cache.ts
@@ -1,10 +1,24 @@
-import type { AttendanceEntry, EventDetail } from './events'
+import type { AttendanceEntry, AttendanceSummary, EventDetail } from './events'
 
 type AttendanceState = AttendanceEntry['state']
+
+/** Which summary counter each state feeds. `roleBreakdown` is left to the server reconciliation. */
+const SUMMARY_FIELD: Record<AttendanceState, keyof Omit<AttendanceSummary, 'roleBreakdown'>> = {
+  ATTENDING: 'attending',
+  MAYBE: 'maybe',
+  ABSENT: 'absent',
+  NOT_RESPONDED: 'notResponded',
+}
 
 /**
  * Returns a copy of the cached event detail with the given user's attendance entry set to
  * `state` — the optimistic patch behind an instant-feeling attendance toggle.
+ *
+ * The summary counters move with the entry: the old state loses one, the new state gains one. Any
+ * surface showing a response *and* a headcount together (the Next Up hero's "10 going · you're in")
+ * would otherwise contradict itself for the round-trip between the tap and `onSettled`. Counters
+ * never go below zero, so a summary that is already out of step with the entries cannot be driven
+ * negative.
  *
  * Only an existing entry is patched: a first-time responder has no row in `attendances`, and the
  * mutation carries no `displayName`/`role` to synthesise a complete one, so an unknown user is a
@@ -17,10 +31,21 @@ export function applyOptimisticAttendance(
   state: AttendanceState,
 ): EventDetail | undefined {
   if (!event) return event
-  if (!event.attendances.some((a) => a.userId === userId)) return event
+
+  const previous = event.attendances.find((a) => a.userId === userId)
+  if (!previous) return event
+
+  const summary = { ...event.attendanceSummary }
+  if (previous.state !== state) {
+    const from = SUMMARY_FIELD[previous.state]
+    const to = SUMMARY_FIELD[state]
+    summary[from] = Math.max(0, summary[from] - 1)
+    summary[to] = summary[to] + 1
+  }
 
   return {
     ...event,
+    attendanceSummary: summary,
     attendances: event.attendances.map((a) => (a.userId === userId ? { ...a, state } : a)),
   }
 }

--- a/app/src/shared/lib/use-now.ts
+++ b/app/src/shared/lib/use-now.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+const ONE_MINUTE = 60_000
+
+/**
+ * A clock that actually ticks. Reading `new Date()` during render freezes time until something
+ * unrelated re-renders, which on a screen left open overnight means yesterday's event still says
+ * "Tomorrow" and a countdown stands still. One minute is the coarsest tick that keeps a
+ * minutes-resolution countdown honest.
+ *
+ * Returns one `Date` per tick, so every consumer on the page reads the same instant and their
+ * answers cannot disagree.
+ */
+export function useNow(intervalMs: number = ONE_MINUTE): Date {
+  const [now, setNow] = useState(() => new Date())
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), intervalMs)
+    return () => clearInterval(timer)
+  }, [intervalMs])
+
+  return now
+}

--- a/app/src/widgets/next-event-hero/lib/countdown.test.ts
+++ b/app/src/widgets/next-event-hero/lib/countdown.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { heroCountdown } from './countdown'
+
+const at = (y: number, m: number, d: number, h = 12, min = 0) =>
+  new Date(y, m - 1, d, h, min, 0, 0)
+
+const NOW = at(2026, 8, 10, 9, 0)
+const countdown = (start: Date) => heroCountdown(start.toISOString(), NOW)
+
+describe('heroCountdown', () => {
+  it('counts whole days once an event is a day or more out', () => {
+    expect(countdown(at(2026, 8, 12, 9, 0))).toEqual({ value: '2d', unit: 'away' })
+    expect(countdown(at(2026, 8, 17, 9, 0))).toEqual({ value: '7d', unit: 'away' })
+  })
+
+  it('rounds down, so a countdown never overstates how long you have', () => {
+    // 35 hours out is "1d", not "2d"; 23 hours out has not earned a day yet.
+    expect(countdown(at(2026, 8, 11, 20, 0))).toEqual({ value: '1d', unit: 'away' })
+    expect(countdown(at(2026, 8, 11, 8, 0))).toEqual({ value: '23h', unit: 'away' })
+  })
+
+  it('switches to hours inside a day', () => {
+    expect(countdown(at(2026, 8, 10, 20, 0))).toEqual({ value: '11h', unit: 'away' })
+    expect(countdown(at(2026, 8, 10, 10, 30))).toEqual({ value: '1h', unit: 'away' })
+  })
+
+  it('switches to minutes inside an hour', () => {
+    expect(countdown(at(2026, 8, 10, 9, 45))).toEqual({ value: '45m', unit: 'away' })
+    expect(countdown(at(2026, 8, 10, 9, 1))).toEqual({ value: '1m', unit: 'away' })
+  })
+
+  it('says "Now" once the event has started, rather than counting backwards', () => {
+    expect(countdown(at(2026, 8, 10, 9, 0))).toEqual({ value: 'Now', unit: 'on' })
+    expect(countdown(at(2026, 8, 10, 8, 0))).toEqual({ value: 'Now', unit: 'on' })
+  })
+})

--- a/app/src/widgets/next-event-hero/lib/countdown.ts
+++ b/app/src/widgets/next-event-hero/lib/countdown.ts
@@ -1,0 +1,29 @@
+const MS_PER_MINUTE = 60 * 1000
+const MS_PER_HOUR = 60 * MS_PER_MINUTE
+const MS_PER_DAY = 24 * MS_PER_HOUR
+
+export interface HeroCountdown {
+  /** The big line: `2d`, `11h`, `45m`, or `Now`. */
+  value: string
+  /** The small line under it — `away`, or `on` once the event has started. */
+  unit: string
+}
+
+/**
+ * The hero's countdown to kick-off, in the largest unit that still says something useful.
+ *
+ * Deliberately elapsed-time, not calendar days: the card's chit and relative label already speak in
+ * calendar days, so the hero earns its place by being the one thing on the page that says "eleven
+ * hours". Rounding is always down, so "1d away" never promises time you do not have.
+ *
+ * Pure: `now` is a parameter, so the countdown is deterministic in stories and unit-testable.
+ */
+export function heroCountdown(startTime: string | Date, now: Date): HeroCountdown {
+  const start = startTime instanceof Date ? startTime : new Date(startTime)
+  const remaining = start.getTime() - now.getTime()
+
+  if (remaining <= 0) return { value: 'Now', unit: 'on' }
+  if (remaining >= MS_PER_DAY) return { value: `${Math.floor(remaining / MS_PER_DAY)}d`, unit: 'away' }
+  if (remaining >= MS_PER_HOUR) return { value: `${Math.floor(remaining / MS_PER_HOUR)}h`, unit: 'away' }
+  return { value: `${Math.max(1, Math.floor(remaining / MS_PER_MINUTE))}m`, unit: 'away' }
+}

--- a/app/src/widgets/next-event-hero/ui/NextEventHero.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHero.tsx
@@ -1,0 +1,42 @@
+import { useEvent, type Event } from '@shared/api/events'
+import { useSetAttendance } from '@shared/api/attendances'
+import { useUserStore } from '@shared/stores/user-store'
+import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
+import { NextEventHeroView } from './NextEventHeroView'
+
+/**
+ * Container for the Next Up hero. Thin wiring: the route decides *whether* there is a hero
+ * (`selectHeroEvent`) and hands the event down; this only resolves the viewer's own response and
+ * the RSVP mutation. Per ADR-0017 the View owns every rendered state, so this seam is covered by
+ * the existing attendance e2e rather than a story.
+ *
+ * The viewer's response is not on the list payload, so it comes from the event detail read — the
+ * same query the detail page already uses and the same one `useSetAttendance` updates optimistically,
+ * so a tap here reflects instantly and stays consistent with the detail page. Until it resolves the
+ * hero renders from the list row as not-yet-replied, which is the state that invites the tap anyway.
+ *
+ * Once the detail is in hand it also supplies the event itself (an EventDetail is an Event plus
+ * attendances): the response and the headcount then come from one payload, so the status line can't
+ * say "10 going · you're in" with a count that predates the tap.
+ */
+export function NextEventHero({ event, now }: { event: Event; now?: Date }) {
+  const { data: detail } = useEvent(event.id)
+  const currentUserId = useUserStore((s) => s.userId)
+  const { mutate, isPending } = useSetAttendance()
+
+  const myState: AttendanceState =
+    (detail?.attendances.find((a) => a.userId === currentUserId)?.state as AttendanceState) ??
+    'NOT_RESPONDED'
+
+  return (
+    <NextEventHeroView
+      event={detail ?? event}
+      myState={myState}
+      isSaving={isPending}
+      now={now}
+      onRespond={(state) => {
+        if (currentUserId) mutate({ eventId: event.id, userId: currentUserId, state })
+      }}
+    />
+  )
+}

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import { makeEvent } from '@shared/testing/event-fixtures'
+import { NextEventHeroView } from './NextEventHeroView'
+
+// NextEventHeroView is the prop-only Next Up hero behind the NextEventHero container: the event,
+// the viewer's own response and the RSVP callback all come in as props, so every state renders with
+// no network (ADR-0017). `now` is a prop too, which pins the countdown for the snapshot.
+//
+// There is deliberately no "nothing coming up" story: when no event qualifies the page renders no
+// hero at all. That boundary is proven by the selectHeroEvent unit test and the list's Empty story.
+const NOW = new Date(2026, 7, 10, 9, 0) // Monday 10 August 2026, 09:00 local
+
+const EVENT = makeEvent({
+  id: 'evt-hero',
+  eventType: { id: 'et-2', name: 'Training', color: '#249E6C' },
+  title: 'Training — Court 2',
+  startTime: new Date(2026, 7, 12, 20, 0).toISOString(),
+  location: 'Sporthal De Toekomst',
+  attendanceSummary: { attending: 10, maybe: 1, absent: 0, notResponded: 4, roleBreakdown: [] },
+})
+
+const meta = {
+  title: 'widgets/next-event-hero/NextEventHeroView',
+  component: NextEventHeroView,
+  decorators: [withRouter],
+  args: { event: EVENT, now: NOW, myState: 'NOT_RESPONDED', onRespond: fn() },
+} satisfies Meta<typeof NextEventHeroView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const HasNext: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Next up')).toBeInTheDocument()
+    await expect(canvas.getByText('Training — Court 2')).toBeInTheDocument()
+    await expect(canvas.getByText('Sporthal De Toekomst')).toBeInTheDocument()
+    // Two days and eleven hours out, floored to the largest useful unit.
+    await expect(canvas.getByText('2d')).toBeInTheDocument()
+  },
+}
+
+export const HaventReplied: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/10 going · you haven't replied/)).toBeInTheDocument()
+    // Neither answer is pressed yet — "I'm in" is solid because it is the invitation.
+    await expect(canvas.getByRole('button', { name: /I'm in/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    await expect(canvas.getByRole('button', { name: /Can't make it/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  },
+}
+
+export const Going: Story = {
+  args: { myState: 'ATTENDING' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/10 going · you're in/)).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: /I'm in/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  },
+}
+
+export const NotGoing: Story = {
+  args: { myState: 'ABSENT' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/10 going · you're out/)).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: /Can't make it/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  },
+}
+
+// "Maybe" can only be set from the detail page — the hero offers the two answers it offers. So it
+// shows neither button as chosen and lets the status line carry what was actually said.
+export const Maybe: Story = {
+  args: { myState: 'MAYBE' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/10 going · you said maybe/)).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: /I'm in/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    await expect(canvas.getByRole('button', { name: /Can't make it/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  },
+}
+
+// Prop-contract spies: the inline RSVP is the whole point of the hero, so prove both buttons
+// actually call onRespond with the right state — not merely that they render.
+export const RsvpIn: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /I'm in/ }))
+    await expect(args.onRespond).toHaveBeenCalledWith('ATTENDING')
+  },
+}
+
+export const RsvpOut: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /Can't make it/ }))
+    await expect(args.onRespond).toHaveBeenCalledWith('ABSENT')
+  },
+}
+
+export const Saving: Story = {
+  args: { isSaving: true },
+  play: async ({ canvas, userEvent, args }) => {
+    // Both answers are held while an RSVP is in flight, so a double-tap can't race the mutation.
+    await expect(canvas.getByRole('button', { name: /I'm in/ })).toBeDisabled()
+    await expect(canvas.getByRole('button', { name: /Can't make it/ })).toBeDisabled()
+    await userEvent.click(canvas.getByRole('button', { name: /I'm in/ }))
+    await expect(args.onRespond).not.toHaveBeenCalled()
+  },
+}
+
+// A same-day hero drops to hours, which is the one thing the card's date chit cannot say.
+export const StartingToday: Story = {
+  args: {
+    event: makeEvent({
+      ...EVENT,
+      startTime: new Date(2026, 7, 10, 20, 0).toISOString(),
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('11h')).toBeInTheDocument()
+  },
+}

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
@@ -1,0 +1,131 @@
+import { Link } from '@tanstack/react-router'
+import { Check, Clock, MapPin, X } from 'lucide-react'
+import type { Event } from '@shared/api/events'
+import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
+import { heroCountdown } from '../lib/countdown'
+
+interface NextEventHeroViewProps {
+  event: Event
+  /** The viewer's own response — drives the CTA styling and the status line. */
+  myState: AttendanceState
+  /** An RSVP is in flight; both buttons are held until it settles. */
+  isSaving?: boolean
+  onRespond: (state: AttendanceState) => void
+  /** Injected so the countdown is deterministic in stories; defaults to the real clock. */
+  now?: Date
+}
+
+/** The status line's second clause — what the viewer has (or hasn't) said. */
+const MY_STATE_TEXT: Record<AttendanceState, string> = {
+  ATTENDING: "you're in",
+  ABSENT: "you're out",
+  MAYBE: 'you said maybe',
+  NOT_RESPONDED: "you haven't replied",
+}
+
+/**
+ * The Next Up hero: the most imminent event, big, with its countdown and an inline RSVP so the
+ * commonest action on the page costs no navigation.
+ *
+ * Prop-only, and mounted conditionally — the parent decides whether there is a hero at all
+ * (`selectHeroEvent`), and drops the event from the list below so it never renders twice. There is
+ * deliberately no empty state here: when nothing is near, the page has no hero, not a hero saying
+ * nothing is near.
+ */
+export function NextEventHeroView({
+  event,
+  myState,
+  isSaving = false,
+  onRespond,
+  now = new Date(),
+}: NextEventHeroViewProps) {
+  const date = new Date(event.startTime)
+  const countdown = heroCountdown(event.startTime, now)
+  const going = myState === 'ATTENDING'
+  const out = myState === 'ABSENT'
+
+  return (
+    <section
+      aria-label="Next up"
+      className="relative mt-4 overflow-hidden rounded-3xl p-4 text-white"
+      style={{
+        background: 'linear-gradient(135deg, var(--color-green) 0%, var(--color-green-dark) 100%)',
+        boxShadow: '0 14px 34px rgba(34, 92, 156, 0.18)',
+      }}
+    >
+      {/* Soft highlight, purely decorative */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-8 -top-10 h-[150px] w-[150px] rounded-full bg-white/15 blur-sm"
+      />
+
+      <div className="absolute right-4 top-4 z-10 text-right">
+        <span className="font-display block text-[22px] font-extrabold leading-none">
+          {countdown.value}
+        </span>
+        <span className="text-[10px] uppercase tracking-[0.08em] opacity-85">{countdown.unit}</span>
+      </div>
+
+      <p className="pr-12 text-[11px] font-bold uppercase tracking-[0.14em] opacity-90">Next up</p>
+
+      <h3 className="font-display mb-1 mt-2 pr-12 text-[21px] font-extrabold leading-[1.08]">
+        {/* The hero title is the way into the event; the RSVP buttons stay separate, so no
+            stretched-link overlay here — a full-card overlay would swallow their taps. */}
+        <Link to="/events/$eventId" params={{ eventId: event.id }} className="hover:underline">
+          {event.title}
+        </Link>
+      </h3>
+
+      <p className="flex flex-wrap items-center gap-1.5 text-[13px] opacity-95">
+        <Clock size={13} className="shrink-0" />
+        {date.toLocaleDateString('nl-NL', { weekday: 'short', day: 'numeric', month: 'short' })}
+        {' · '}
+        {date.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit' })}
+      </p>
+
+      {event.location && (
+        <p className="mt-1 flex flex-wrap items-center gap-1.5 text-[13px] opacity-95">
+          <MapPin size={13} className="shrink-0" />
+          {event.location}
+        </p>
+      )}
+
+      <p className="mt-2.5 text-[13px] opacity-90">
+        {event.attendanceSummary.attending} going · {MY_STATE_TEXT[myState]}
+      </p>
+
+      {/* The answer the viewer has given is the solid button; the other one recedes. With no answer
+          yet, "I'm in" is solid because it is the invitation, not because it has been chosen. */}
+      <div className="mt-3.5 flex gap-2">
+        <button
+          aria-pressed={going}
+          disabled={isSaving}
+          onClick={() => onRespond('ATTENDING')}
+          style={out ? undefined : { color: 'var(--color-green-dark)' }}
+          className={[
+            'flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-[13.5px] font-bold transition-all active:scale-95',
+            out ? 'bg-white/20 text-white' : 'bg-white',
+            isSaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+          ].join(' ')}
+        >
+          <Check size={16} />
+          I&apos;m in
+        </button>
+        <button
+          aria-pressed={out}
+          disabled={isSaving}
+          onClick={() => onRespond('ABSENT')}
+          style={out ? { color: 'var(--color-red)' } : undefined}
+          className={[
+            'flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-[13.5px] font-bold transition-all active:scale-95',
+            out ? 'bg-white' : going ? 'bg-white/12 text-white' : 'bg-white/20 text-white',
+            isSaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+          ].join(' ')}
+        >
+          <X size={16} />
+          Can&apos;t make it
+        </button>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #214 (Phase 1).

Frontend only — no contract change. Works entirely off existing `Event` data (`startTime`, `eventType`, `title`, `location`, `references`, `attendanceSummary`).

Built to the v5 prototype as the visual/behaviour spec, with the project's real components, tokens and FSD structure — none of the prototype's markup or CSS was copied.

## Demo

https://github.com/user-attachments/assets/0f751485-0c20-47b7-bcf6-c2329f8722a6

94s walkthrough, recorded against a local stub of the API (the recording box had no Docker for Postgres):

1. **Next Up hero** — the page opens on an actual event, with a live countdown.
2. **Inline RSVP** — "I'm in" flips *you haven't replied* → *you're in*, no navigation.
3. **Date-block cards** — type-tinted chit, edge-to-edge divider, and the graduated relative label: solid `in 2 days`, quiet `in 5 days`, nothing on the event three weeks out.
4. **Filter popover** — one control replaces the Upcoming/Past tab bar. Show-past folds history into the same timeline; type chips filter, and the hero follows what you asked for.
5. **The no-hero case** — filtered to tournaments, the next one is three weeks out, so there is no hero and no placeholder in its place.

Two artefacts of the recording environment, not the app: day numbers fall back from Grandstander (Google Fonts was blocked), and the dates/counts come from stub fixtures.

## What changed

**1. Next Up hero — conditional.** `widgets/next-event-hero`. The most imminent upcoming event renders as a hero with a countdown and inline RSVP (`I'm in` / `Can't make it`), but only when it is within `RELATIVE_WINDOW_DAYS`. When it renders, that event is pulled out of the list below — no duplicate. When nothing is near there is **no hero and no placeholder**; the page goes straight to the list, or to the list's empty state.

**2. Filter popover replaces the Upcoming/Past tab bar.** `features/filter-event-types/ui/EventFiltersView`. One top-right icon opens a popover with the event-type chips and a default-off **Show past events** switch that drives `useEvents(showPast)`.

**3. Date-block `EventCard`.** A type-tinted calendar chit (weekday / big Grandstander day number / month) leads each card and carries the date on its own, which is what lets the list go flat — `This Week` / `Later` are gone and the list is sorted ascending by `startTime` (the backend returns "all" descending, so the sort is explicit). The small type text tag stays next to the chit. Meta is `time · location`. The divider above the attendance row is a **child of the card**, so it runs edge-to-edge under the chit.

**4. Graduated relative-time label.** `relativeEventLabel(startTime, now)` — pure, right-aligned on the tag row, driven by a single `RELATIVE_WINDOW_DAYS = 7` that **also** gates hero visibility. Today / Tomorrow / This weekend / `in N days`, solid ink pill inside two days, quiet grey to the edge of the window, nothing beyond it. Counted in **calendar days, not 24-hour blocks**, so an event 45 minutes away across midnight is "Tomorrow".

## Deliberate calls worth a look

- **The `roleBreakdown` chips are gone from the card.** The spec's card foot is the totals row, and Phase 2's slot-pips are the designed replacement for per-position info. The detail page still shows `RoleBreakdown` in full. Easy to put back if you'd rather keep them in the interim.
- **`showPast` on gives one ascending timeline**, so history sits above upcoming. That is what "flat and chronological" means; the hero still leads the page. Say the word if you'd rather it read newest-first.
- **The hero follows the type filter** — it is the next event *of what you're looking at*, so filtering to Match moves the hero to the next match.
- **One scope-adjacent fix:** `applyOptimisticAttendance` now moves the summary counters with the entry. The hero puts a response and a headcount on one line, so without it the tap produced "10 going · you're in" until the refetch landed. Unit-tested; it makes the detail page's counts more correct too.
- The hero reads the viewer's own response from the existing event-detail query (`useEvent`) — the list payload doesn't carry it. Same read the detail page already does, same one `useSetAttendance` patches.

## Testing

Per the PR gate, each behaviour sits at the lowest layer that proves it.

**Vitest units (pure logic)**
- `relative-event-label.test.ts` — every row of the spec table, both boundaries of the window, "next weekend is not this weekend", past events, month/year rollover, and the midnight cases that separate calendar days from 24-hour arithmetic.
- `next-event.test.ts` — hero selection: empty, all-past, unsorted, past mixed in, in-window edge (7 days), **out-of-window → no hero**, and that it never falls through to a later event that happens to qualify.
- `countdown.test.ts` — days/hours/minutes, floor-don't-round, and "Now" once started.
- `attendance-cache.test.ts` — the new summary-counter movement, incl. no-op and never-negative.

**Storybook stories** (`fn()` spies asserting `toHaveBeenCalledWith` in `play`; no MSW)
- `EventCard` — date-block, with quiet label / with solid label / **without** a label, a social event, no responses, references, location.
- `NextEventHeroView` — has-next / haven't-replied / going / not-going / maybe / saving / starting-today, plus `RsvpIn` and `RsvpOut` proving `onRespond`.
- `EventFiltersView` — closed / open / closes-on-Escape / showing-past / filtered-to-one-type / no-event-types, plus `TogglesType` and `TogglesShowPast` proving `onToggleType` and `onToggleShowPast`.
- `EventListView` — loading / error / empty / filtered-empty / data / data-despite-background-error. The **"no hero"** and empty-list cases are covered here plus the `selectHeroEvent` unit — no invented hero empty state.

Container/View split per ADR-0017: `NextEventHero` and the route are thin wiring; every rendered state lives in a prop-only `*View`.

**No new e2e.** This introduces no new auth, cross-tenant or external-integration seam — it reuses the existing events read and the existing attendance mutation, both already exercised by the login and change-attendance flows.

**Run in this session:** `npm test` → **66 files / 389 tests green**; `tsc -b` and `eslint` clean. I also drove the real page in a browser against a throwaway local stub of the API (this sandbox has no Docker, so `make run-local` couldn't bring up Postgres) and confirmed: hero shows at +2 days and **is absent at +8**, the hero event is not duplicated below, the popover's type chips and Show-past switch both drive the query, cards render the chit and the full-width divider, and the labels match the table (`Today`/`in 2 days` solid, `in 4 days`/`in 7 days` quiet, 20-days-out unlabelled).

**Not run:** `make test-api` and `detekt` — this sandbox has no JDK 25 (Gradle toolchain) and no Docker for Testcontainers. No Kotlin was touched.

## Phase 2 deferred

The slot-pips roster fill stays out, as scoped. It needs a **target count per position**, which nothing exposes today: `AttendanceSummary.roleBreakdown` carries attending counts only, and `Position` has no required count. Per the issue's resolution those targets are per event-type, so Phase 2 is wirespec-first — model + persistence for per-event-type targets, target-vs-attending in the events payload, backend tests, `make wirespec`. The card's attendance row is left as the existing "N going of M" summary.