### PR TITLE
fix(app): derive view-transition direction from history index (F8, #159)

### DIFF
--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { BottomNav } from '@shared/ui/BottomNav'
 import { authMeQueryOptions } from '@shared/api/auth'
 import { currentMemberQueryOptions } from '@shared/api/members'
 import { queryClient } from '@shared/api/query-client'
+import { directionFromIndices } from '@shared/lib/view-transition-direction'
 import { useUserStore } from '@shared/stores/user-store'
 
 // Only the sign-in routes (and the invite landing page, reachable before a joiner has any
@@ -64,25 +65,22 @@ export const Route = createRootRoute({
   },
 })
 
+// Slide direction comes from the router's history index, not the path (F8, #159): only a
+// *decreasing* index is a real pop. The href is a dependency too, so a navigation that keeps the
+// index (a replace) still re-evaluates instead of inheriting the previous move's direction. The
+// decision itself is a pure, unit-tested helper; the hook only owns the class toggle.
 function useViewTransitions() {
-  const location = useRouterState({ select: (s) => s.location })
-  const prevPathRef = useRef(location.pathname)
+  const href = useRouterState({ select: (s) => s.location.href })
+  const historyIndex = useRouterState({ select: (s) => s.location.state.__TSR_index })
+  // Starts empty on purpose: the first render (cold load or hard refresh, which keeps whatever
+  // index the entry already had) has nothing to compare against, so it slides forward.
+  const prevIndexRef = useRef<number | undefined>(undefined)
 
   useEffect(() => {
-    const prevPath = prevPathRef.current
-    const nextPath = location.pathname
-
-    // Heuristic: going to a deeper path = forward (slide right in), going shallower = back (slide left in)
-    const isBack = prevPath.length > nextPath.length || nextPath === '/'
-
-    if (isBack) {
-      document.documentElement.classList.add('vt-slide-back')
-    } else {
-      document.documentElement.classList.remove('vt-slide-back')
-    }
-
-    prevPathRef.current = nextPath
-  }, [location.pathname])
+    const direction = directionFromIndices(prevIndexRef.current, historyIndex)
+    document.documentElement.classList.toggle('vt-slide-back', direction === 'back')
+    prevIndexRef.current = historyIndex
+  }, [href, historyIndex])
 }
 
 function RootLayout() {

--- a/app/src/shared/lib/view-transition-direction.test.ts
+++ b/app/src/shared/lib/view-transition-direction.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { directionFromIndices } from './view-transition-direction'
+
+// Pure, non-rendering logic: which way the page slide should run. The router stamps a
+// monotonically increasing index on every history entry, so a *decreasing* index is the only
+// honest signal of a pop (browser Back / swipe-back). Everything else — a push, a lateral tab
+// switch at the same depth, the first mount, a hard refresh — slides forward.
+describe('directionFromIndices', () => {
+  it('reads a decreasing index as back (browser Back)', () => {
+    expect(directionFromIndices(3, 2)).toBe('back')
+  })
+
+  it('reads a multi-entry jump backwards as back (history.go(-3))', () => {
+    expect(directionFromIndices(5, 2)).toBe('back')
+  })
+
+  it('reads an increasing index as forward (drilling in)', () => {
+    expect(directionFromIndices(2, 3)).toBe('forward')
+  })
+
+  it('reads an increasing index as forward even when the path gets shorter', () => {
+    // The old length heuristic called this "back": /events/42 -> / is a *push*, not a pop.
+    expect(directionFromIndices(0, 1)).toBe('forward')
+  })
+
+  it('treats an equal index as forward (replace navigation, no pop)', () => {
+    expect(directionFromIndices(4, 4)).toBe('forward')
+  })
+
+  it('treats the first mount (no previous index) as forward', () => {
+    expect(directionFromIndices(undefined, 0)).toBe('forward')
+  })
+
+  it('treats a mid-history first mount (hard refresh) as forward', () => {
+    // A reload keeps the entry's index (say 7) but there is no previous render to compare to.
+    expect(directionFromIndices(undefined, 7)).toBe('forward')
+  })
+
+  it('falls back to forward when the next index is missing', () => {
+    // A history entry written by something other than the router carries no index.
+    expect(directionFromIndices(3, undefined)).toBe('forward')
+  })
+
+  it('falls back to forward when neither index is known', () => {
+    expect(directionFromIndices(undefined, undefined)).toBe('forward')
+  })
+})

--- a/app/src/shared/lib/view-transition-direction.ts
+++ b/app/src/shared/lib/view-transition-direction.ts
@@ -1,0 +1,22 @@
+/**
+ * Which way the page-slide view transition should run.
+ *
+ * The router stamps a monotonically increasing index on every history entry (`__TSR_index` on
+ * `window.history.state`): a push increments it, a pop (browser Back, swipe-back, `history.go(-n)`)
+ * lands on a lower one, and a replace keeps it. So a *decreasing* index is the only honest signal
+ * of a backward move. The previous heuristic compared path lengths, which mislabelled every lateral
+ * move (`/team` -> `/profile`, same depth) and every shallow push (`/events/42` -> `/`) as "back".
+ *
+ * Anything we can't read as a pop slides forward — the neutral default: the first mount and a hard
+ * refresh have no previous index to compare against, and a history entry written outside the router
+ * carries no index at all.
+ */
+export type ViewTransitionDirection = 'back' | 'forward'
+
+export function directionFromIndices(
+  prevIndex: number | undefined,
+  nextIndex: number | undefined,
+): ViewTransitionDirection {
+  if (typeof prevIndex !== 'number' || typeof nextIndex !== 'number') return 'forward'
+  return nextIndex < prevIndex ? 'back' : 'forward'
+}


### PR DESCRIPTION
Closes F8 of #159 — the last of the standalone fill-ins alongside F9/F11.

## The bug

`useViewTransitions()` in `app/src/routes/__root.tsx` inferred the page-slide direction from path length:

```ts
const isBack = prevPath.length > nextPath.length || nextPath === '/'
```

Length is not depth, and depth is not direction. Two classes of navigation were mislabelled as "back":

- **lateral moves at equal depth** — `/profile` → `/team` (8 chars → 5) animates backward, even though it's a forward push. `/team` → `/profile` happened to be right, so the tab bar animated inconsistently depending on which way you tabbed.
- **any push to a shallower path** — `/events/42` → `/` is a push, but both the length test and the explicit `nextPath === '/'` clause called it a pop.

## The fix

Direction now comes from the router's history index. TanStack Router stamps `__TSR_index` on every history entry (`window.history.state`): a push increments it, a replace keeps it, and a pop (browser Back, swipe-back, `history.go(-n)`) lands on a lower one. A *decreasing* index is the only honest signal of a backward move.

- New pure helper `directionFromIndices(prev, next): 'back' | 'forward'` in `shared/lib/view-transition-direction.ts` — back only when both indices are known and `next < prev`. Everything else is forward: the first mount, a hard refresh (the entry keeps its index but there's no previous render to compare against), a replace, and a history entry written outside the router that carries no index.
- The hook keeps only the DOM concern — one `classList.toggle('vt-slide-back', …)`.
- Both `href` and the index are effect dependencies, so a navigation that keeps the index (a replace) still re-evaluates rather than inheriting the previous move's direction.

No CSS change — `.vt-slide-back` in `global.css` is untouched; only who sets it changed.

## Testing

Per the PR gate, pure logic → a Vitest unit: `view-transition-direction.test.ts` covers back (`3→2`), a multi-entry `history.go(-3)` jump, forward (`2→3`), the forward-but-shorter-path case the old heuristic got wrong (`0→1`), equal indices (replace), first mount / hard refresh (`undefined` prev), and a missing next index.

**No story and no e2e, deliberately.** A view transition is not a storyable seam — the direction lives in a `documentElement` class consumed by `::view-transition-*` animations, which Storybook's static render and Chromatic's pixel diff can't observe. And per the e2e rule this introduces no new seam: no new auth path, no cross-tenant write, no external integration — it's a class toggle on existing routes already walked by the login and attendance flows.

- `make test-app` → **73 files, 440 tests passed**
- `npm run lint` (eslint) → clean; `tsc -b` → clean
- `make lint`'s detekt half could not run in this container (the Gradle toolchain wants JDK 25, only 21 is present). No backend files are touched by this change.

**Manual verification.** A full local stack wasn't available here (same JDK-25 constraint blocks the API), so the runtime seam was verified directly with a throwaway harness driving a real TanStack router over real browser history — not committed, and asserting the class the hook toggles:

- `__TSR_index` is in fact present on `window.history.state` (guards the whole premise),
- drilling in `/` → `/events/42` → forward,
- `router.history.back()` → back,
- lateral `/team` → `/profile` **and** `/profile` → `/team` → forward both ways (the reverse direction is the one that previously animated backward),
- shallow push `/profile` → `/` → forward (previously backward).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAz27a91PYthKsgKJ4sU6u)_