### PR TITLE
refactor(app): route red through the --color-red token (F9, #159)

### DIFF
--- a/app/src/app/styles/global.css
+++ b/app/src/app/styles/global.css
@@ -27,6 +27,10 @@
   --color-blue: #225C9C;
   --color-green: #249E6C;
   --color-gold: #F4B400;
+  /* Brand red — the same value tokens.css binds --color-absent to. Exposed here so components can
+     say bg-red/text-red/border-red instead of reaching for Tailwind's own default red (#EF4444),
+     which is not ours (F9, #159). Keep in sync with design-tokens/tokens.css, like the three above. */
+  --color-red: #D93025;
   --radius: 0.625rem;
   --color-border: hsl(214.3 31.8% 91.4%);
   --color-input: hsl(214.3 31.8% 91.4%);
@@ -36,7 +40,11 @@
   --color-primary-foreground: hsl(210 40% 98%);
   --color-secondary: hsl(210 40% 96.1%);
   --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
-  --color-destructive: hsl(0 84.2% 60.2%);
+  /* Shadcn's destructive semantic, bound to the same brand red rather than its stock
+     hsl(0 84.2% 60.2%) (#EF4444). Without this a delete dialog paints two different reds — a
+     token-red error panel stacked on a stock-red confirm button. Bonus: white-on-red goes from
+     3.76:1 to 4.78:1, over the AA floor it used to miss. */
+  --color-destructive: var(--color-red);
   --color-destructive-foreground: hsl(210 40% 98%);
   --color-muted: hsl(210 40% 96.1%);
   --color-muted-foreground: hsl(215.4 16.3% 46.9%);

--- a/app/src/entities/event/ui/EventListView.tsx
+++ b/app/src/entities/event/ui/EventListView.tsx
@@ -32,7 +32,7 @@ export function EventListView({
   // so a transient failure never blanks a list the user is already looking at.
   if (events.length === 0) {
     if (isLoading) return <EventListSkeleton />
-    if (error) return <p className="mt-4 text-sm text-red-500">Couldn&apos;t load events.</p>
+    if (error) return <p className="mt-4 text-sm text-red">Couldn&apos;t load events.</p>
     return <p className="mt-4 text-muted-foreground">{emptyMessage}</p>
   }
 

--- a/app/src/features/attendance-toggle/ui/AttendanceToggle.tsx
+++ b/app/src/features/attendance-toggle/ui/AttendanceToggle.tsx
@@ -30,8 +30,8 @@ const RESPONSE_OPTIONS: ResponseOption[] = [
     value: 'ABSENT',
     label: "Can't go",
     icon: X,
-    activeClass: 'bg-red-500 text-white border-red-500 hover:bg-red-500/90',
-    inactiveClass: 'border-red-300 text-red-500 hover:bg-red-500/10',
+    activeClass: 'bg-red text-white border-red hover:bg-red/90',
+    inactiveClass: 'border-red/30 text-red hover:bg-red/10',
   },
 ]
 

--- a/app/src/features/create-recurring-events/ui/MonthCalendarPreview.tsx
+++ b/app/src/features/create-recurring-events/ui/MonthCalendarPreview.tsx
@@ -52,7 +52,7 @@ export function MonthCalendarPreview({ preview, accentColor }: MonthCalendarPrev
         </div>
       )}
       {!overCap && outOfSeasonCount > 0 && (
-        <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-xs leading-snug text-red-500">
+        <div className="mb-3 flex items-start gap-2 rounded-lg border border-red/40 bg-red/10 px-3 py-2 text-xs leading-snug text-red">
           <AlertTriangle size={14} className="mt-0.5 shrink-0" />
           <span>
             {outOfSeasonCount} {outOfSeasonCount === 1 ? 'date falls' : 'dates fall'} outside the season (shown in red).

--- a/app/src/features/create-recurring-events/ui/RecurringEventsWizard.tsx
+++ b/app/src/features/create-recurring-events/ui/RecurringEventsWizard.tsx
@@ -305,7 +305,7 @@ export function RecurringEventsWizard({
           <MonthCalendarPreview preview={preview} accentColor={accentColor} />
 
           {errorMessage && (
-            <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">{errorMessage}</p>
+            <p className="rounded-lg border border-red/40 bg-red/10 px-3 py-2 text-sm text-red">{errorMessage}</p>
           )}
         </div>
       )}

--- a/app/src/features/edit-event/ui/DeleteEventDialog.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialog.tsx
@@ -37,7 +37,7 @@ export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEvent
     <Dialog open={open} onOpenChange={setOpen}>
       <Button
         variant="outline"
-        className="flex-1 border-red-200 text-red-500 hover:bg-red-500/5 hover:text-red-500"
+        className="flex-1 border-red/30 text-red hover:bg-red/5 hover:text-red"
         onClick={() => setOpen(true)}
       >
         <Trash2 size={15} />

--- a/app/src/features/edit-event/ui/DeleteEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialogView.tsx
@@ -55,7 +55,7 @@ export function DeleteEventDialogView({
         />
       )}
       {isError && (
-        <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+        <p className="rounded-lg border border-red/40 bg-red/10 px-3 py-2 text-sm text-red">
           Could not delete the event. Please try again.
         </p>
       )}

--- a/app/src/features/edit-event/ui/EditEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.tsx
@@ -178,7 +178,7 @@ export function EditEventDialogView({
       </div>
       <ReferenceRowsEditor rows={references} onChange={setReferences} />
       {isError && (
-        <p className="rounded-lg border border-red-300 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+        <p className="rounded-lg border border-red/40 bg-red/10 px-3 py-2 text-sm text-red">
           Could not save changes. Please try again.
         </p>
       )}

--- a/app/src/features/edit-event/ui/SeriesScopeField.tsx
+++ b/app/src/features/edit-event/ui/SeriesScopeField.tsx
@@ -56,8 +56,8 @@ export function SeriesScopeField({
   const verb = danger ? 'Removes' : 'Affects'
   const caption = danger ? DELETE_CAPTION[scope] : EDIT_CAPTION[scope]
   // Full literal classes — Tailwind can't see interpolated names.
-  const panelClass = danger ? 'border-red-500/20 bg-red-500/5' : 'border-blue/20 bg-blue/5'
-  const countClass = danger ? 'text-red-500' : 'text-blue'
+  const panelClass = danger ? 'border-red/20 bg-red/5' : 'border-blue/20 bg-blue/5'
+  const countClass = danger ? 'text-red' : 'text-blue'
 
   return (
     <div className="flex flex-col gap-3">
@@ -79,7 +79,7 @@ export function SeriesScopeField({
                   'flex-1 rounded-lg border px-2 py-2 text-xs font-semibold transition-colors',
                   active
                     ? danger
-                      ? 'border-red-500 bg-red-500 text-white'
+                      ? 'border-red bg-red text-white'
                       : 'border-blue bg-blue text-white'
                     : 'border-border text-muted-foreground hover:bg-muted/60',
                 ].join(' ')}
@@ -123,7 +123,7 @@ function AffectedTimeline({
   preview: NonNullable<ReturnType<typeof buildAffectedPreview>>
   danger: boolean
 }) {
-  const hit = danger ? 'bg-red-500' : 'bg-blue'
+  const hit = danger ? 'bg-red' : 'bg-blue'
   return (
     <div className="mt-2 flex items-center gap-1" aria-hidden="true">
       {preview.nodes.map((node, i) => {
@@ -138,7 +138,7 @@ function AffectedTimeline({
               className={[
                 'h-2.5 w-2.5 rounded-full transition-colors',
                 node.affected ? hit : 'bg-border',
-                node.isCurrent ? (danger ? 'ring-2 ring-red-500/40' : 'ring-2 ring-blue/40') : '',
+                node.isCurrent ? (danger ? 'ring-2 ring-red/40' : 'ring-2 ring-blue/40') : '',
               ].join(' ')}
             />
           </div>

--- a/app/src/features/edit-profile/ui/EditProfileForm.tsx
+++ b/app/src/features/edit-profile/ui/EditProfileForm.tsx
@@ -64,9 +64,9 @@ export function EditProfileForm({
           aria-invalid={touched && nameError ? true : undefined}
           placeholder="Your name"
         />
-        {touched && nameError && <p className="mt-1 text-sm text-red-500">{nameError}</p>}
+        {touched && nameError && <p className="mt-1 text-sm text-red">{nameError}</p>}
         {errorCode === 'NAME_TAKEN' && (
-          <p className="mt-1 text-sm text-red-500">That display name is already taken.</p>
+          <p className="mt-1 text-sm text-red">That display name is already taken.</p>
         )}
       </div>
 
@@ -82,7 +82,7 @@ export function EditProfileForm({
               setTouched(true)
             }}
           />
-          {touched && positionError && <p className="mt-1 text-sm text-red-500">{positionError}</p>}
+          {touched && positionError && <p className="mt-1 text-sm text-red">{positionError}</p>}
         </div>
       )}
 

--- a/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.tsx
+++ b/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.tsx
@@ -62,7 +62,7 @@ export function ManageCreationCodesView({
         <p className="mt-4 text-sm text-muted-foreground">You don't have access to creation codes.</p>
       )}
       {isError && !isForbidden && (
-        <p className="mt-4 text-sm text-red-500">Couldn't load creation codes. Please try again.</p>
+        <p className="mt-4 text-sm text-red">Couldn't load creation codes. Please try again.</p>
       )}
 
       {!isLoading && !isError && !isForbidden && (
@@ -74,7 +74,7 @@ export function ManageCreationCodesView({
           </div>
 
           {errorCode === 'CONSUMED' && (
-            <p className="text-sm text-red-500">That code was already used and cannot be revoked.</p>
+            <p className="text-sm text-red">That code was already used and cannot be revoked.</p>
           )}
 
           {codes.length === 0 ? (

--- a/app/src/features/manage-members/ui/MemberRosterView.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.tsx
@@ -69,13 +69,13 @@ export function MemberRosterView({
 
       {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
       {isError && (
-        <p className="mt-4 text-sm text-red-500">Couldn't load members. Please try again.</p>
+        <p className="mt-4 text-sm text-red">Couldn't load members. Please try again.</p>
       )}
 
       {!isLoading && !isError && (
         <div className="mt-4 flex flex-col gap-3">
           {errorMessage && (
-            <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            <p role="alert" className="rounded-md bg-red/10 px-3 py-2 text-sm text-red">
               {errorMessage}
             </p>
           )}

--- a/app/src/features/manage-positions/ui/ManagePositionsView.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositionsView.tsx
@@ -62,7 +62,7 @@ export function ManagePositionsView({
 
       {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
       {isError && (
-        <p className="mt-4 text-sm text-red-500">Couldn't load positions. Please try again.</p>
+        <p className="mt-4 text-sm text-red">Couldn't load positions. Please try again.</p>
       )}
 
       {!isLoading && !isError && (
@@ -85,7 +85,7 @@ export function ManagePositionsView({
             </Button>
           </div>
           {errorCode === 'POSITION_LABEL_TAKEN' && (
-            <p className="mt-1 text-sm text-red-500">That position already exists.</p>
+            <p className="mt-1 text-sm text-red">That position already exists.</p>
           )}
 
           {positions.length === 0 ? (

--- a/app/src/features/team-settings/ui/TeamSettingsView.tsx
+++ b/app/src/features/team-settings/ui/TeamSettingsView.tsx
@@ -53,7 +53,7 @@ export function TeamSettingsView({ season = {}, isLoading, isError, isSaving, er
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {isError && (
-        <p className="text-sm text-red-500">Couldn't load team settings. Please try again.</p>
+        <p className="text-sm text-red">Couldn't load team settings. Please try again.</p>
       )}
 
       {!isLoading && !isError && (
@@ -87,7 +87,7 @@ export function TeamSettingsView({ season = {}, isLoading, isError, isSaving, er
             </div>
           </div>
 
-          {rangeError && <p className="text-sm text-red-500">{rangeError}</p>}
+          {rangeError && <p className="text-sm text-red">{rangeError}</p>}
 
           {showWarning && !rangeError && (
             <p className="rounded-lg border border-gold/40 bg-gold/10 px-3 py-2 text-sm text-foreground" role="alert">
@@ -95,7 +95,7 @@ export function TeamSettingsView({ season = {}, isLoading, isError, isSaving, er
             </p>
           )}
 
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm text-red">{error}</p>}
 
           <div>
             <Button disabled={isSaving || !dirty || !!rangeError} onClick={handleSave}>

--- a/app/src/routes/events/$eventId.tsx
+++ b/app/src/routes/events/$eventId.tsx
@@ -32,7 +32,7 @@ const ATTENDEE_TABS: {
 }[] = [
   { state: 'ATTENDING', label: 'Going', barColor: 'bg-green', badgeBg: 'bg-green/10 text-green' },
   { state: 'MAYBE', label: 'Maybe', barColor: 'bg-gold', badgeBg: 'bg-gold/10 text-gold' },
-  { state: 'ABSENT', label: 'Absent', barColor: 'bg-red-500', badgeBg: 'bg-red-500/10 text-red-500' },
+  { state: 'ABSENT', label: 'Absent', barColor: 'bg-red', badgeBg: 'bg-red/10 text-red' },
   { state: 'NOT_RESPONDED', label: '?', barColor: 'bg-muted-foreground', badgeBg: 'bg-muted text-muted-foreground' },
 ]
 

--- a/app/src/routes/get-started/index.tsx
+++ b/app/src/routes/get-started/index.tsx
@@ -41,7 +41,7 @@ function GetStartedPage() {
       </p>
 
       {isLoading && <p className="mt-6 text-sm text-muted-foreground">Loading…</p>}
-      {error && <p className="mt-6 text-sm text-red-500">Couldn't load your profile. Please try again.</p>}
+      {error && <p className="mt-6 text-sm text-red">Couldn't load your profile. Please try again.</p>}
 
       {member && (
         <div className="mt-6">

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -100,7 +100,7 @@ function InvitePage() {
           {requestMagicLink.isPending ? 'Sending...' : 'Send magic link'}
         </Button>
         {requestMagicLink.isError && (
-          <p className="text-center text-sm text-red-500">Something went wrong. Please try again.</p>
+          <p className="text-center text-sm text-red">Something went wrong. Please try again.</p>
         )}
       </form>
     </div>

--- a/app/src/routes/login.tsx
+++ b/app/src/routes/login.tsx
@@ -60,7 +60,7 @@ function LoginPage() {
           {requestMagicLink.isPending ? 'Sending...' : 'Send magic link'}
         </Button>
         {requestMagicLink.isError && (
-          <p className="text-center text-sm text-red-500">Something went wrong. Please try again.</p>
+          <p className="text-center text-sm text-red">Something went wrong. Please try again.</p>
         )}
       </form>
     </div>

--- a/app/src/routes/profile/index.tsx
+++ b/app/src/routes/profile/index.tsx
@@ -61,7 +61,7 @@ function ProfilePage() {
       <h2 className="font-display text-2xl font-bold">Profile</h2>
 
       {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
-      {error && <p className="mt-4 text-sm text-red-500">Couldn't load your profile. Please try again.</p>}
+      {error && <p className="mt-4 text-sm text-red">Couldn't load your profile. Please try again.</p>}
 
       {member && (
         <div className="mt-4">

--- a/app/src/shared/ui/QueryErrorState.tsx
+++ b/app/src/shared/ui/QueryErrorState.tsx
@@ -25,7 +25,7 @@ export function QueryErrorState({
 }: QueryErrorStateProps) {
   return (
     <div role="alert" className="mt-10 flex flex-col items-center gap-4 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10 text-red-500">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red/10 text-red">
         <AlertTriangle size={22} />
       </div>
       <div>


### PR DESCRIPTION
Closes F9 of #159 — semantic colour drift.

## The gap

`design-tokens/tokens.css` has defined `--color-red: #D93025` all along, and `global.css` binds `--color-absent` to it. But the app's `@theme` block only ever exposed `blue`/`green`/`gold` — there was no `red` utility to reach for, so 19 files quietly fell back to Tailwind's **own** default scale (`red-500` = `#EF4444`). The token existed; nothing consumed it.

## What changed

**1. Exposed the token.** `--color-red: #D93025` added to `@theme` next to its three siblings, so `bg-red` / `text-red` / `border-red` / `ring-red` and every opacity form resolve to the brand red.

**2. Swept 19 files.** Every `red-50/200/300/500/600` utility now points at the token. Shade-based softening becomes the opacity idiom the green/gold siblings already use:

| before | after | where |
|---|---|---|
| `red-500`, `red-600` | `red` | text, fills, borders |
| `border-red-300` | `border-red/40` | error panels |
| `border-red-300` / `border-red-200` | `border-red/30` | outline buttons |
| `bg-red-50` | `bg-red/10` | inline alert |
| `bg-red-500/10`, `ring-red-500/40`, … | `bg-red/10`, `ring-red/40`, … | opacity modifiers kept as-is |

The attendance toggle's `ABSENT` option is now structurally identical to its `ATTENDING`/`MAYBE` neighbours (`bg-red` / `border-red/30` / `hover:bg-red/10`), which is what "keep it aligned with `--color-absent`" amounts to — `--color-absent` *is* `--color-red`. I deliberately did **not** introduce `bg-absent`/`bg-attending` utilities: green and gold don't use them either, and adding them for red alone would break the symmetry this slice is trying to restore.

## One thing beyond the brief — please look

I also bound shadcn's `--color-destructive` to the same token (was stock `hsl(0 84.2% 60.2%)` = `#EF4444`). This wasn't in the slice as scoped, but the sweep alone **introduced a visible clash**: the delete dialog paints a token-red error panel stacked directly on a stock-red confirm button — two different reds, touching, which is precisely the drift F9 exists to remove.

| sweep only | with `destructive` bound |
|---|---|
| error panel `#D93025` over a `#EF4444` button | one red throughout |

It also lifts that button's white-on-red contrast from **3.76:1 → 4.78:1**, clearing the AA floor it previously missed. It's a one-line change and independently revertible if you'd rather keep `destructive` on the shadcn default.

Honest note while I was measuring: `text-red` on `--color-background` is **4.43:1** — better than the `3.49:1` it replaces, but still a hair under AA for normal text. Fixing that means choosing a darker token red, which is a palette decision, not this slice's call.

## Intentional visual shift + baselines

Rendered red moves `#EF4444 → #D93025` everywhere. **Chromatic will show diffs across every story with red in it — these are expected and the baselines want accepting in this PR.**

## Tests

Per the PR gate this is a mechanical token change already covered by existing stories, with Chromatic as the visual gate — no new tests, and **no new e2e**: it introduces no new seam (no auth path, cross-tenant write, or external integration), so the login and attendance flows still cover everything it touches.

- `npm run lint` (app) — clean.
- `make test-app` — **401 passed**, 7 files failing. Those 7 all import the Wirespec-generated TS, which this container can't produce (`make wirespec` needs JDK 25; only 21 is available). I ran the same suite on a stashed tree and got **byte-identical** results, so the failures are environmental, not from this diff. `make lint`'s Kotlin half is blocked by the same missing JDK; no Kotlin is touched here.
- Verified the utilities actually compile by running the real `global.css` through Tailwind's compiler: `bg-red`, `text-red`, `border-red`, `ring-red` and every opacity form used in the sweep emit `#D93025`.
- Verified visually in headless Chromium against a live Storybook — asserted the *computed* painted colour on five red-bearing stories (attendance toggle, series scope, delete-dialog error, `QueryErrorState`, member-roster error). All report `rgb(217, 48, 37)`, with no `rgb(239, 68, 68)` left anywhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ7pxrbb26TVegQTMWF3Vy)_