### PR TITLE
feat(api): roster requirement contract, domain model + migration (#219)

### DIFF
--- a/.claude/preflight.md
+++ b/.claude/preflight.md
@@ -9,7 +9,7 @@ setup: npm --prefix app install && ./gradlew :api:wirespec-typescript  # generat
 - Never resolve a rebase with `-X ours` blindly: it silently dropped `findRole` a feature needed when a port addition conflicted with a differently-implemented upstream version. Resolve port/interface conflicts as a union by hand.
 
 ## wirespec client
-- Stale gen across branches: switching to a branch with a different `.ws` set leaves orphaned files in `app/src/shared/api/generated/` → `tsc`/build fails on a missing export (e.g. CreateInvitation → removed Invitation model). `rm -rf app/src/shared/api/generated api/build/generated` then re-run `:api:wirespec-typescript` before frontend build.
+- Stale gen across branches: switching to a branch with a different `.ws` set leaves orphaned files in `app/src/shared/api/generated/` → `tsc`/build fails on a missing export (e.g. CreateInvitation → removed Invitation model). `rm -rf app/src/shared/api/generated api/build/generated app/.tsbuild app/tsconfig.tsbuildinfo` then re-run `:api:wirespec-typescript` — `tsconfig.generated.json` is a composite project, so without clearing its buildinfo `tsc` keeps reporting the OLD generated types as missing properties.
 - mutationFns must unwrap res.body (return `res.body`, not the raw `api.*()` call) — caller mutation.data is the body, not the Wirespec envelope
 - Generated from() throws `Cannot internalize response with status: N` for undeclared status codes → React Query error state; no extra guard needed in queryFn for non-declared codes
 
@@ -23,6 +23,7 @@ setup: npm --prefix app install && ./gradlew :api:wirespec-typescript  # generat
 - A new required `@Value` with no default (fail-fast) must be supplied in EVERY non-prod profile: application-dev.yml, test (application-test.yml), AND application-e2e.yml. CI's `scripts/e2e.sh` boots bootRun under the `e2e` profile, so a missing key there fails CI even when `:api:test` (test profile) is green. Prod relies solely on the env var. EXCEPTION: if the reading bean is `@Profile("prod")`-gated (e.g. ScalewayTemEmailAdapter), its `@Value` is never read outside prod → leave the key defaultless and add nothing to non-prod profiles.
 
 ## backend / transactions
+- `make test` does NOT run `:api:processAot`; `make ci` (`./gradlew build -x test`) does. Spring Data AOT binds `:named` query params against the method signature, so an orphaned `@Query`/`@Modifying` left above the wrong method fails CI only — 'No bindable parameter with name X'. Run `./gradlew build -x test` before pushing.
 - `@Transactional` lives on the JPA adapter methods, NOT the service. A service method composing >1 write (e.g. bulk-update then save) is therefore NOT atomic unless it carries its own `@Transactional` — check any multi-step orchestration (InvitationService.rotateInviteLink). Pair a `@Modifying` bulk update with `clearAutomatically = true` so a same-tx read after it isn't stale.
 
 ## multitenancy / hexagonal

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.application
 import com.github.zzave.teambalance.api.domain.exception.EmptyRecurrenceException
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.exception.RecurrenceExceedsCapException
+import com.github.zzave.teambalance.api.domain.exception.UnknownRosterPositionException
 import com.github.zzave.teambalance.api.domain.model.Event
 import com.github.zzave.teambalance.api.domain.model.EventDescription
 import com.github.zzave.teambalance.api.domain.model.EventEdit
@@ -14,12 +15,14 @@ import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.OccurrenceSchedule
 import com.github.zzave.teambalance.api.domain.model.Recurrence
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.domain.model.SeasonPolicy
 import com.github.zzave.teambalance.api.domain.model.SeriesModification
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import java.time.Clock
 import java.time.Duration
@@ -48,6 +51,7 @@ class EventService(
     private val eventRepository: EventRepository,
     private val eventTypeRepository: EventTypeRepository,
     private val seasonRepository: SeasonRepository,
+    private val positionRepository: PositionRepository,
     private val authorizationService: AuthorizationService,
     private val clock: Clock,
 ) {
@@ -74,6 +78,8 @@ class EventService(
         val eventType = eventTypeRepository.findById(potential.eventTypeId)
             ?: throw EventTypeNotFoundException(potential.eventTypeId)
 
+        requireKnownPositions(potential.rosterOverride)
+
         // ADR-0014: a created event's start must always fall within the configured season.
         seasonPolicy().requireCreatable(potential.startTime)
 
@@ -90,6 +96,7 @@ class EventService(
                 recurringGroup = potential.recurringGroup,
                 createdBy = callerId,
                 createdAt = clock.instant(),
+                rosterOverride = potential.rosterOverride,
             ),
         )
     }
@@ -195,11 +202,13 @@ class EventService(
         endTime: Instant,
         location: EventLocation?,
         references: List<EventReference> = emptyList(),
+        rosterOverride: RosterRequirement? = null,
     ): List<Event>? {
         authorizationService.requireAdmin(callerId, teamId)
         val target = eventRepository.findById(id) ?: return null
         val eventType = eventTypeRepository.findById(eventTypeId)
             ?: throw EventTypeNotFoundException(eventTypeId)
+        requireKnownPositions(rosterOverride)
 
         val series = seriesOf(target)
         // Replace-semantics (ADR-0016): the incoming list is the new full set of references.
@@ -215,6 +224,7 @@ class EventService(
                 references = references,
                 startTime = startTime,
                 endTime = endTime,
+                rosterOverride = rosterOverride,
             ),
             newTailGroup = UUID.randomUUID(),
             zone = clock.zone,
@@ -239,6 +249,25 @@ class EventService(
         val target = eventRepository.findById(id) ?: return false
         eventRepository.deleteAllById(SeriesModification.planDelete(seriesOf(target), id, scope))
         return true
+    }
+
+    /**
+     * Rejects a roster override naming a position this team does not have (#219).
+     *
+     * Since ADR-0026 this is **not** what keeps the data honest — `event_position_targets.position_id`
+     * is a real foreign key now that positions are tenant rows, so an unknown id cannot be stored
+     * whatever this method does. What it still buys is the *answer*: the contract declares
+     * `400 UNKNOWN_ROSTER_POSITION` for a bad id, and without the check the constraint would surface
+     * as a 500 that the client cannot tell from a server fault.
+     *
+     * One query, whatever the target count, and none at all for the common inheriting event.
+     */
+    private fun requireKnownPositions(requirement: RosterRequirement?) {
+        val targeted = requirement?.positionTargets.orEmpty()
+        if (targeted.isEmpty()) return
+        val known = positionRepository.list().map { it.id }.toSet()
+        targeted.firstOrNull { it.positionId !in known }
+            ?.let { throw UnknownRosterPositionException(it.positionId) }
     }
 
     // A group-less event is a one-occurrence series (its own row); otherwise the whole group,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
@@ -8,7 +8,6 @@ import com.github.zzave.teambalance.api.domain.model.PositionLabel
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
-import java.util.UUID
 
 class PositionService(
     private val positionRepository: PositionRepository,
@@ -40,8 +39,16 @@ class PositionService(
     }
 
     /**
-     * Admin-only. Deletes a position; members assigned to it are silently reset to unassigned —
-     * now by the member_profiles ON DELETE SET NULL rather than by a prior clearing write.
+     * Admin-only. Deletes a position. Everything that referenced it goes with it, and none of that is
+     * this method's work any more (ADR-0026): members assigned to it become Unassigned via
+     * `member_profiles`' ON DELETE SET NULL, and the position drops out of every event type's roster
+     * default and every event's roster override via those tables' ON DELETE CASCADE.
+     *
+     * That used to be three ordered writes in this service, in a deliberate order — targets first,
+     * because a deleted position still named by a live target is unrecoverable while the reverse is
+     * merely re-runnable. The ordering mattered because each was its own transaction and no foreign
+     * key could span the platform/tenant boundary. Now that positions are tenant rows alongside the
+     * things that name them, one statement does all of it atomically.
      */
     fun deletePosition(callerId: UserId, teamId: TeamId, id: PositionId) {
         authorizationService.requireAdmin(callerId, teamId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PotentialEvent.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PotentialEvent.kt
@@ -5,6 +5,7 @@ import com.github.zzave.teambalance.api.domain.model.EventLocation
 import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.domain.model.EventTitle
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import java.time.Instant
 import java.util.UUID
 
@@ -18,4 +19,6 @@ data class PotentialEvent(
     val references: List<EventReference> = emptyList(),
     // A single event belongs to no series; a batch-created occurrence carries its shared group id.
     val recurringGroup: UUID? = null,
+    // Null means "inherit the event type's default", dynamically — see Event.rosterOverride.
+    val rosterOverride: RosterRequirement? = null,
 )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -23,6 +23,13 @@ class InvalidTeamNameException(message: String) : BadRequestException(message, "
 // is validated, not derived (#158): the caller owns the address, so a bad one is their error to fix.
 class InvalidSlugException(message: String) : BadRequestException(message, "INVALID_SLUG")
 
+// A roster requirement naming a position that is not this team's → 400 UNKNOWN_ROSTER_POSITION. A
+// 400 rather than a 404, because the missing thing is not the resource being addressed: the caller is
+// writing an event and got one field of the body wrong. Rejecting is what keeps a target from being
+// stored that no member can ever fill and no delete cascade can ever reach (#219).
+class UnknownRosterPositionException(id: PositionId) :
+    BadRequestException("Roster requirement names an unknown position: $id", "UNKNOWN_ROSTER_POSITION")
+
 sealed class NotFoundException(message: String) : TeambalanceException(message)
 
 class EventNotFoundException(id: EventId) : NotFoundException("Event not found: $id")

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Event.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Event.kt
@@ -15,6 +15,17 @@ data class Event(
     val recurringGroup: UUID?,
     val createdBy: UserId,
     val createdAt: Instant,
+    /**
+     * This occurrence's own roster requirement, or null to **inherit** [eventType]'s
+     * [EventType.rosterDefault] — and to keep inheriting it, so a later edit of the default moves
+     * this event too. That dynamic inheritance is what lets a recurring series follow its type
+     * without rewriting every occurrence.
+     *
+     * When set, it is a **whole replacement** of the default, never a patch of it: there is no
+     * per-position partial inheritance to reason about, so "what does this event need?" has exactly
+     * one answer and one place to look.
+     */
+    val rosterOverride: RosterRequirement? = null,
 ) {
     init {
         require(references.size <= MAX_REFERENCES) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventType.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventType.kt
@@ -1,7 +1,21 @@
 package com.github.zzave.teambalance.api.domain.model
 
+/**
+ * A kind of event (Training, Match, Social) and the team-wide roster it implies.
+ *
+ * [rosterDefault] is where a team says "a Match needs 2 setters and 12 people"; an individual event
+ * inherits it dynamically unless it carries its own [Event.rosterOverride]. Editing the default
+ * therefore moves every inheriting event with it, which is the point — a team changes its lineup
+ * shape once, not once per training.
+ *
+ * [archived] is a soft delete. Deleting a type outright is not an option: [Event.eventType] is
+ * non-null, so a hard delete would either orphan or cascade away real events. An archived type is
+ * hidden from the create/edit pickers while every event already holding it keeps rendering with it.
+ */
 data class EventType(
     val id: EventTypeId,
     val name: EventTypeName,
     val color: HexColor?,
+    val archived: Boolean = false,
+    val rosterDefault: RosterRequirement = RosterRequirement.OFF,
 )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirement.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirement.kt
@@ -1,0 +1,90 @@
+package com.github.zzave.teambalance.api.domain.model
+
+/**
+ * How many attending people one position needs — the number the panel draws as slot pips.
+ *
+ * Zero is not a value here: no target and a target of nothing are the same thing to a reader, and
+ * only the first is true, so the absence is modelled by the absence of a [PositionTarget].
+ */
+@JvmInline
+value class PositionSlots(val value: Int) {
+    init {
+        require(value in 1..MAX) { "A position needs between 1 and $MAX people, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+
+    companion object {
+        // A volleyball court holds 6; the cap is generous enough for any sport we might host and
+        // small enough that a fat-fingered 9999 is rejected rather than drawn as 9999 pips.
+        const val MAX = 99
+    }
+}
+
+/** How many attending people an event needs in total, whoever they are. */
+@JvmInline
+value class HeadcountTarget(val value: Int) {
+    init {
+        require(value in 1..MAX) { "A headcount target must be between 1 and $MAX, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+
+    companion object {
+        const val MAX = 200
+    }
+}
+
+/**
+ * A required headcount at one position, keyed by [PositionId] and never by label — so renaming a
+ * position carries its targets with it (a label is display text; the id is the identity).
+ */
+data class PositionTarget(
+    val positionId: PositionId,
+    val slots: PositionSlots,
+)
+
+/**
+ * The roster a team wants for an event: a headcount ([totalTarget]), a per-position lineup
+ * ([positionTargets]), or both. The two axes are **independent** — either may be absent, and
+ * [positionTargets] may cover only some positions (a training that needs 2 setters and does not care
+ * who else turns up).
+ *
+ * [trackRoster] is an explicit flag rather than "no targets means off", because those are two
+ * genuinely different things:
+ *  - `trackRoster = true` with no targets — a training that tallies who is coming, per position, with
+ *    nothing to fall short of.
+ *  - `trackRoster = false` — a social. Not a roster event at all; the client renders no panel.
+ *
+ * Targets are deliberately **kept while [trackRoster] is false**, so an admin toggling tracking off
+ * and back on again does not silently lose the lineup they configured.
+ */
+data class RosterRequirement(
+    val trackRoster: Boolean,
+    val totalTarget: HeadcountTarget? = null,
+    val positionTargets: List<PositionTarget> = emptyList(),
+) {
+    init {
+        require(positionTargets.size <= MAX_POSITION_TARGETS) {
+            "A roster may target at most $MAX_POSITION_TARGETS positions, had ${positionTargets.size}"
+        }
+        require(positionTargets.distinctBy { it.positionId }.size == positionTargets.size) {
+            "A roster may target each position at most once"
+        }
+    }
+
+    /** The slots required at [positionId], or null when that position carries no target. */
+    fun targetFor(positionId: PositionId): PositionSlots? =
+        positionTargets.firstOrNull { it.positionId == positionId }?.slots
+
+    /** Drops any target for [positionId] — how a deleted position leaves the requirements it is in. */
+    fun withoutPosition(positionId: PositionId): RosterRequirement =
+        copy(positionTargets = positionTargets.filterNot { it.positionId == positionId })
+
+    companion object {
+        const val MAX_POSITION_TARGETS = 50
+
+        /** Tracking off: no chip, no panel. The default for a type nobody has configured. */
+        val OFF = RosterRequirement(trackRoster = false)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModification.kt
@@ -21,6 +21,13 @@ data class EventEdit(
     val references: List<EventReference>,
     val startTime: Instant,
     val endTime: Instant,
+    /**
+     * The roster requirement the edited occurrences take on, or null for "inherit the type default".
+     *
+     * Propagates with the scope like every other field here: null is a value the edit carries, not
+     * an omission, so a bulk edit without one returns its whole scope to following the type default.
+     */
+    val rosterOverride: RosterRequirement? = null,
 )
 
 /**
@@ -55,6 +62,12 @@ object SeriesModification {
      *  - **THIS_AND_FOLLOWING** → the target + every following occurrence move to [newTailGroup] with
      *    the edit applied (each keeps its own date); the occurrences before are untouched.
      *  - **ALL** → every occurrence gets the edit (each keeps its own date); the group is unchanged.
+     *
+     * [EventEdit.rosterOverride] propagates with the scope like every other field: a scoped edit
+     * means "these occurrences now need this lineup" (#219). Note the consequence — a bulk edit
+     * writes a concrete requirement onto every occurrence it sweeps in, so those rows stop tracking
+     * their type's default until something clears them; a bulk edit carrying null is what puts the
+     * whole scope back on the type default.
      */
     fun planEdit(
         series: List<Event>,
@@ -69,6 +82,20 @@ object SeriesModification {
         require(idx >= 0) { "target $targetId is not part of the series" }
         val target = ordered[idx]
 
+        return plan(ordered, idx, target, scope, edit, newTailGroup, zone)
+    }
+
+    // The scope matrix itself: each apply* function is "one occurrence, all the edited fields".
+    @Suppress("LongParameterList")
+    private fun plan(
+        ordered: List<Event>,
+        idx: Int,
+        target: Event,
+        scope: EventSeriesScope,
+        edit: EventEdit,
+        newTailGroup: UUID,
+        zone: ZoneId,
+    ): SeriesEditPlan {
         return when (scope) {
             EventSeriesScope.THIS -> SeriesEditPlan(
                 edited = listOf(target.applyMoved(edit, group = null)),
@@ -128,6 +155,7 @@ object SeriesModification {
             startTime = edit.startTime,
             endTime = edit.endTime,
             recurringGroup = group,
+            rosterOverride = edit.rosterOverride,
         )
 
     // A bulk-affected occurrence: keep its own calendar date, but re-anchor to the edit's wall-clock
@@ -145,6 +173,7 @@ object SeriesModification {
             startTime = newStart,
             endTime = newStart.plus(duration),
             recurringGroup = group,
+            rosterOverride = edit.rosterOverride,
         )
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Event
 import com.github.zzave.teambalance.api.domain.model.EventId
+import com.github.zzave.teambalance.api.domain.model.PositionId
 import java.time.Instant
 import java.util.UUID
 
@@ -27,4 +28,5 @@ interface EventRepository {
     fun saveAll(events: List<Event>): List<Event>
     fun deleteById(id: EventId)
     fun deleteAllById(ids: List<EventId>)
+
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
@@ -5,6 +5,7 @@ import com.github.zzave.teambalance.api.application.EventService
 import com.github.zzave.teambalance.api.application.EventTypeService
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,12 +30,16 @@ class EventCompositionRoot {
         eventRepository: EventRepository,
         eventTypeRepository: EventTypeRepository,
         seasonRepository: SeasonRepository,
+        // For validating a roster override's position ids against the team's own vocabulary (#219) —
+        // the mirror of the position-delete cascade in MembershipCompositionRoot.
+        positionRepository: PositionRepository,
         authorizationService: AuthorizationService,
         clock: Clock,
     ) = EventService(
         eventRepository = eventRepository,
         eventTypeRepository = eventTypeRepository,
         seasonRepository = seasonRepository,
+        positionRepository = positionRepository,
         authorizationService = authorizationService,
         clock = clock,
     )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
@@ -3,6 +3,8 @@ package com.github.zzave.teambalance.api.infrastructure.config
 import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.MemberService
 import com.github.zzave.teambalance.api.application.PositionService
+import com.github.zzave.teambalance.api.domain.port.EventRepository
+import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.UserRepository
@@ -34,6 +36,10 @@ class MembershipCompositionRoot {
         clock = clock,
     )
 
+    // No event ports here any more (ADR-0026). Deleting a position used to have to reach into the
+    // event area to clear the roster targets naming it, because those tenant rows referenced a
+    // platform position and no foreign key could span the two schemas. Positions are tenant rows
+    // now, so the cascade is a constraint and this service is back to knowing only about positions.
     @Bean
     fun positionService(
         positionRepository: PositionRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.domain.exception.EventNotFoundException
 import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.model.Event
 import com.github.zzave.teambalance.api.domain.model.EventId
+import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
@@ -28,6 +29,11 @@ import java.util.UUID
  * The transaction is therefore opened deep inside the request, long after the per-request tenant
  * schema has been bound, so the connection it acquires always routes to the caller's tenant.
  */
+// One method per port method plus the two private persist/remove primitives, which is one over
+// detekt's stock ceiling. Splitting the adapter would mean splitting EventRepository, and the port is
+// deliberately whole: the batch methods exist so a use case can state "these rows go together" in a
+// single call, which only works while one adapter owns them all.
+@Suppress("TooManyFunctions")
 @Repository
 class JpaEventRepositoryAdapter(
     private val jpaRepository: SpringDataEventRepository,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventTypeRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventTypeRepositoryAdapter.kt
@@ -2,9 +2,11 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 class JpaEventTypeRepositoryAdapter(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
@@ -2,6 +2,9 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.util.UUID
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventTypeRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventTypeRepository.kt
@@ -2,6 +2,9 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface SpringDataEventTypeRepository : JpaRepository<EventTypeJpaEntity, Long> {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/EventJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/EventJpaEntity.kt
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapKeyColumn
 import jakarta.persistence.OrderColumn
 import jakarta.persistence.Table
+import org.hibernate.annotations.BatchSize
 import java.time.Instant
 import java.util.UUID
 
@@ -38,6 +40,23 @@ class EventJpaEntity(
     @CollectionTable(name = "event_references", joinColumns = [JoinColumn(name = "event_id")])
     @OrderColumn(name = "position")
     val references: List<EventReferenceEmbeddable> = emptyList(),
+    // This occurrence's roster override, or "inherit the type default" when trackRoster is null.
+    // The value object's trackRoster is non-null, so its nullability here IS the override/inherit
+    // bit — there is no separate flag column that could disagree with the rest of the row.
+    @Column(name = "roster_track_roster")
+    val rosterTrackRoster: Boolean? = null,
+    @Column(name = "roster_total_target")
+    val rosterTotalTarget: Int? = null,
+    // Keyed by public.team_positions(id) — a cross-schema reference, hence a plain UUID and no FK.
+    // @BatchSize keeps the events listing from paying one extra select per event for a collection
+    // that is empty on every inheriting event (the common case): Hibernate loads up to 100 events'
+    // targets in a single IN query instead.
+    @ElementCollection(fetch = FetchType.EAGER)
+    @BatchSize(size = 100)
+    @CollectionTable(name = "event_position_targets", joinColumns = [JoinColumn(name = "event_id")])
+    @MapKeyColumn(name = "position_id")
+    @Column(name = "target_count", nullable = false)
+    val rosterPositionTargets: Map<UUID, Int> = emptyMap(),
     @Column(name = "recurring_group")
     val recurringGroup: UUID?,
     @Column(name = "created_by", nullable = false)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/EventTypeJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/EventTypeJpaEntity.kt
@@ -1,10 +1,15 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence.entity
 
+import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapKeyColumn
 import jakarta.persistence.Table
 import java.time.Instant
 import java.util.UUID
@@ -20,6 +25,24 @@ class EventTypeJpaEntity(
     @Column(nullable = false)
     val name: String,
     val color: String?,
+    @Column(nullable = false)
+    val archived: Boolean = false,
+    @Column(name = "track_roster", nullable = false)
+    val trackRoster: Boolean = false,
+    @Column(name = "total_target")
+    val totalTarget: Int? = null,
+    // The type's default per-position targets, keyed by public.team_positions(id). EAGER because
+    // every read of an event type is a read of its roster default (the listing renders both) and the
+    // map is at most a handful of rows — this is the only collection on the entity, so there is no
+    // second eager association to multiply against.
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "event_type_position_targets",
+        joinColumns = [JoinColumn(name = "event_type_id")],
+    )
+    @MapKeyColumn(name = "position_id")
+    @Column(name = "target_count", nullable = false)
+    val positionTargets: Map<UUID, Int> = emptyMap(),
     @Column(name = "created_at", nullable = false)
     val createdAt: Instant,
 )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventMapper.kt
@@ -7,6 +7,8 @@ import com.github.zzave.teambalance.api.domain.model.EventLocation
 import com.github.zzave.teambalance.api.domain.model.EventReference
 import com.github.zzave.teambalance.api.domain.model.EventReferenceText
 import com.github.zzave.teambalance.api.domain.model.EventTitle
+import com.github.zzave.teambalance.api.domain.model.HeadcountTarget
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventReferenceEmbeddable
@@ -26,6 +28,14 @@ fun EventJpaEntity.internalize() = Event(
     recurringGroup = recurringGroup,
     createdBy = UserId(createdBy),
     createdAt = createdAt,
+    // Null trackRoster IS "no override" — this event inherits its type's default (see Event.rosterOverride).
+    rosterOverride = rosterTrackRoster?.let {
+        RosterRequirement(
+            trackRoster = it,
+            totalTarget = rosterTotalTarget?.let(::HeadcountTarget),
+            positionTargets = rosterPositionTargets.internalizeTargets(),
+        )
+    },
 )
 
 fun Event.externalize(eventTypeEntity: EventTypeJpaEntity, technicalId: Long = 0) = EventJpaEntity(
@@ -38,6 +48,9 @@ fun Event.externalize(eventTypeEntity: EventTypeJpaEntity, technicalId: Long = 0
     endTime = endTime,
     location = location?.value,
     references = references.map { EventReferenceEmbeddable(title = it.title?.value, url = it.url.value) },
+    rosterTrackRoster = rosterOverride?.trackRoster,
+    rosterTotalTarget = rosterOverride?.totalTarget?.value,
+    rosterPositionTargets = rosterOverride?.positionTargets?.externalizeTargets().orEmpty(),
     recurringGroup = recurringGroup,
     createdBy = createdBy.value,
     createdAt = createdAt,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventTypeMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/EventTypeMapper.kt
@@ -3,11 +3,35 @@ package com.github.zzave.teambalance.api.infrastructure.persistence.mapper
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
 import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HeadcountTarget
 import com.github.zzave.teambalance.api.domain.model.HexColor
+import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.PositionSlots
+import com.github.zzave.teambalance.api.domain.model.PositionTarget
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
 
 fun EventTypeJpaEntity.internalize() = EventType(
     id = EventTypeId(uuid),
     name = EventTypeName(name),
     color = color?.let(::HexColor),
+    archived = archived,
+    rosterDefault = RosterRequirement(
+        trackRoster = trackRoster,
+        totalTarget = totalTarget?.let(::HeadcountTarget),
+        positionTargets = positionTargets.internalizeTargets(),
+    ),
 )
+
+/**
+ * A stored target map to the domain's ordered list. Sorted by position id purely so the list has a
+ * stable order at all (a JPA map does not); the *display* order is the position vocabulary's own,
+ * applied where the roster is rendered — not here.
+ */
+internal fun Map<java.util.UUID, Int>.internalizeTargets(): List<PositionTarget> =
+    entries
+        .sortedBy { it.key }
+        .map { (positionId, slots) -> PositionTarget(positionId = PositionId(positionId), slots = PositionSlots(slots)) }
+
+internal fun List<PositionTarget>.externalizeTargets(): Map<java.util.UUID, Int> =
+    associate { it.positionId.value to it.slots.value }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -87,6 +87,7 @@ class EventController(
                 attendanceSummary = attendance.summary().produce(attendance.attendingRoleBreakdown()),
                 attendances = attendance.entries.map { it.produce() },
                 myState = attendance.stateOf(viewerId).produce(),
+                rosterOverride = event.rosterOverride?.produce(),
             )
         )
     }
@@ -110,6 +111,7 @@ class EventController(
             endTime = Instant.parse(req.endTime.value),
             location = req.location?.let(::EventLocation),
             references = req.references.internalize(),
+            rosterOverride = req.rosterOverride?.consume(),
         ) ?: return UpdateEvent.Response404(Unit)
 
         val members = attendanceService.teamMembers(teamId)
@@ -166,6 +168,7 @@ private fun com.github.zzave.teambalance.api.interfaces.generated.model.CreateEv
         endTime = Instant.parse(endTime.value),
         location = location?.let(::EventLocation),
         references = references.internalize(),
+        rosterOverride = rosterOverride?.consume(),
     )
 
 // The wire type carries an optional reference list; a null list is simply "no references". Each is
@@ -196,6 +199,7 @@ internal fun com.github.zzave.teambalance.api.domain.model.Event.produce(
         recurringGroup = recurringGroup?.toString(),
         attendanceSummary = attendance.summary().produce(attendance.attendingRoleBreakdown()),
         myState = attendance.stateOf(viewerId).produce(),
+        rosterOverride = rosterOverride?.produce(),
     )
 
 private fun com.github.zzave.teambalance.api.domain.model.EventType.produce() =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeController.kt
@@ -19,6 +19,8 @@ class EventTypeController(
                 id = type.id.produce(),
                 name = type.name.value,
                 color = type.color?.value,
+                archived = type.archived,
+                rosterDefault = type.rosterDefault.produce(),
             )
         }
         return ListEventTypes.Response200(EventTypeList(eventTypes = types))

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RosterRequirementMapping.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/RosterRequirementMapping.kt
@@ -1,0 +1,54 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.domain.model.HeadcountTarget
+import com.github.zzave.teambalance.api.domain.model.PositionSlots
+import com.github.zzave.teambalance.api.domain.model.PositionTarget as DomainPositionTarget
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement as DomainRosterRequirement
+import com.github.zzave.teambalance.api.interfaces.generated.model.PositionTarget
+import com.github.zzave.teambalance.api.interfaces.generated.model.RosterRequirement
+
+/**
+ * The Wirespec edge for a roster requirement. It lives in its own file rather than beside one
+ * controller because two surfaces carry the same shape — an event's override (EventController) and
+ * an event type's default (EventTypeController) — and they must normalise identically or the two
+ * would drift into subtly different validation.
+ */
+
+/**
+ * Zero is the client saying "no target here" — a stepper wound down to 0 — so it is dropped rather
+ * than stored as a target of nothing, and it means the same on **both** axes: a zero total clears the
+ * headcount just as a zero count drops that position. (They must agree; the same gesture on the same
+ * authoring form cannot succeed on one row and 400 on the other.)
+ *
+ * Every other value flows straight into [DomainPositionTarget]/[DomainRosterRequirement], whose
+ * `require()`s reject negatives, absurd counts and duplicate positions with an
+ * IllegalArgumentException — a 400 via GlobalExceptionHandler. Position *ids* are not checked here;
+ * that needs the team's vocabulary, so EventService does it (UnknownRosterPositionException).
+ */
+internal fun RosterRequirement.consume(): DomainRosterRequirement = DomainRosterRequirement(
+    trackRoster = trackRoster,
+    totalTarget = totalTarget?.takeIf { it != 0L }?.let { HeadcountTarget(it.toCount()) },
+    positionTargets = positionTargets
+        .filterNot { it.count == 0L }
+        .map {
+            DomainPositionTarget(
+                positionId = it.positionId.consumePositionId(),
+                slots = PositionSlots(it.count.toCount()),
+            )
+        },
+)
+
+// The counts cross an Int/Long boundary: Wirespec's `Integer` emits Kotlin `Long`, while the domain
+// counts a handful of people in an `Int`. A bare `toInt()` would be a silent truncation — 2^32 + 5
+// arrives as 5 and sails through the 1..200 bound it should have failed — so a value that does not
+// fit is pinned to Int.MAX_VALUE, which every bound downstream rejects. Nothing legitimate is near
+// this: the real ceilings are PositionSlots.MAX (99) and HeadcountTarget.MAX (200).
+private fun Long.toCount(): Int = if (this in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) toInt() else Int.MAX_VALUE
+
+internal fun DomainRosterRequirement.produce(): RosterRequirement = RosterRequirement(
+    trackRoster = trackRoster,
+    totalTarget = totalTarget?.value?.toLong(),
+    positionTargets = positionTargets.map {
+        PositionTarget(positionId = it.positionId.produce(), count = it.slots.value.toLong())
+    },
+)

--- a/api/src/main/resources/db/tenant-migration/V008__roster_requirements.sql
+++ b/api/src/main/resources/db/tenant-migration/V008__roster_requirements.sql
@@ -1,0 +1,51 @@
+-- Roster fill (#219): per-event-type position/headcount targets, overridable per event.
+--
+-- Two axes, independent of each other: a total headcount and a per-position lineup. `track_roster`
+-- is an explicit flag rather than "no targets means off", because "tracking on with no hard
+-- requirement" (a training tally) is a real state, distinct from "not a roster event" (a social).
+--
+-- position_id is a real foreign key: positions became tenant rows in V007 (ADR-0026), so the target
+-- and the position it names now live in the same schema.
+--
+-- That is worth stating because it was very nearly not so. While positions sat in the platform
+-- schema no FK could span the boundary, and referential integrity had to be assembled from three
+-- application-side pieces — a write-time check that the id was the team's, a delete-time clear of
+-- every target, and a read-time join against the live vocabulary to hide anything that slipped
+-- between the two writes. ON DELETE CASCADE replaces all three, atomically and without a window.
+
+ALTER TABLE event_types
+    ADD COLUMN archived     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN track_roster BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN total_target INTEGER,
+    ADD CONSTRAINT event_types_total_target_positive
+        CHECK (total_target IS NULL OR total_target BETWEEN 1 AND 200);
+
+CREATE TABLE event_type_position_targets (
+    event_type_id BIGINT  NOT NULL REFERENCES event_types(id) ON DELETE CASCADE,
+    position_id   UUID    NOT NULL REFERENCES positions(id) ON DELETE CASCADE,
+    target_count  INTEGER NOT NULL CHECK (target_count BETWEEN 1 AND 99),
+    PRIMARY KEY (event_type_id, position_id)
+);
+
+-- An event's override is present iff roster_track_roster IS NOT NULL: `track_roster` is non-null in
+-- the value object, so its nullability here carries the "override or inherit" bit with no separate
+-- flag column that could disagree with the rest of the row.
+ALTER TABLE events
+    ADD COLUMN roster_track_roster BOOLEAN,
+    ADD COLUMN roster_total_target INTEGER,
+    ADD CONSTRAINT events_roster_total_target_positive
+        CHECK (roster_total_target IS NULL OR roster_total_target BETWEEN 1 AND 200),
+    ADD CONSTRAINT events_roster_override_consistent
+        CHECK (roster_track_roster IS NOT NULL OR roster_total_target IS NULL);
+
+CREATE TABLE event_position_targets (
+    event_id     BIGINT  NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    position_id  UUID    NOT NULL REFERENCES positions(id) ON DELETE CASCADE,
+    target_count INTEGER NOT NULL CHECK (target_count BETWEEN 1 AND 99),
+    PRIMARY KEY (event_id, position_id)
+);
+
+-- The listing joins targets by position id to clear them when a position is deleted; the PKs above
+-- already index (parent, position), so only the position-first lookup needs its own index.
+CREATE INDEX idx_event_type_position_targets_position ON event_type_position_targets(position_id);
+CREATE INDEX idx_event_position_targets_position ON event_position_targets(position_id);

--- a/api/src/main/wirespec/event-types.ws
+++ b/api/src/main/wirespec/event-types.ws
@@ -1,7 +1,23 @@
+// How many attending people an event needs at one position. Declared here (event types own the team-wide defaults) but shared with events.ws, which reuses it for a single event's override.
+type PositionTarget {
+    positionId: String,
+    count: Integer
+}
+
+// The roster a team wants for an event: a headcount, a per-position lineup, or both — the two axes are independent and either may be absent or partial (a Match sets per-position counts, a Training often only a total, a social neither). `trackRoster` is an explicit flag rather than "no targets means off", because "tracking on with no hard requirement" (a training that just tallies who is coming, per position) is a real state, and a distinct one from "not a roster event at all" (a social, which renders no panel). Targets are kept while `trackRoster` is false, so toggling tracking off and back on does not discard the configuration.
+type RosterRequirement {
+    trackRoster: Boolean,
+    totalTarget: Integer?,
+    positionTargets: PositionTarget[]
+}
+
+// `archived` is a soft delete: an archived type is hidden from the create/edit pickers, but every event that already holds it keeps rendering with it. An event's type is non-null, so a type is never hard-deleted out from under its events.
 type EventTypeItem {
     id: String,
     name: String,
-    color: String?
+    color: String?,
+    archived: Boolean,
+    rosterDefault: RosterRequirement
 }
 
 type EventTypeList {

--- a/api/src/main/wirespec/events.ws
+++ b/api/src/main/wirespec/events.ws
@@ -50,7 +50,8 @@ type Event {
     references: EventReference[],
     recurringGroup: String?,
     attendanceSummary: AttendanceSummary,
-    myState: AttendanceState
+    myState: AttendanceState,
+    rosterOverride: RosterRequirement?
 }
 
 type EventDetail {
@@ -65,7 +66,8 @@ type EventDetail {
     recurringGroup: String?,
     attendanceSummary: AttendanceSummary,
     attendances: AttendanceEntry[],
-    myState: AttendanceState
+    myState: AttendanceState,
+    rosterOverride: RosterRequirement?
 }
 
 type AttendanceEntry {
@@ -80,6 +82,7 @@ type EventList {
     events: Event[]
 }
 
+// `rosterOverride` absent (null) means this event INHERITS its type's default, and keeps inheriting: editing that default later moves every inheriting event with it. A present override is a whole replacement of the default, never a patch of it — so there is no partial inheritance to reason about.
 type CreateEventRequest {
     eventTypeId: String,
     title: String,
@@ -87,7 +90,8 @@ type CreateEventRequest {
     startTime: DateTimestampWithTimezone,
     endTime: DateTimestampWithTimezone,
     location: String?,
-    references: EventReference[]?
+    references: EventReference[]?,
+    rosterOverride: RosterRequirement?
 }
 
 type UpdateEventRequest {
@@ -97,7 +101,8 @@ type UpdateEventRequest {
     startTime: DateTimestampWithTimezone,
     endTime: DateTimestampWithTimezone,
     location: String?,
-    references: EventReference[]?
+    references: EventReference[]?,
+    rosterOverride: RosterRequirement?
 }
 
 endpoint ListEvents GET /api/events ? {include-past: Boolean} -> {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -7,7 +7,9 @@ import com.github.zzave.teambalance.api.domain.model.EventSeriesScope
 import com.github.zzave.teambalance.api.domain.model.EventTitle
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.Position
 import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.PositionLabel
 import com.github.zzave.teambalance.api.domain.model.Recurrence
 import com.github.zzave.teambalance.api.domain.model.RecurrenceFrequency
 import com.github.zzave.teambalance.api.domain.model.Role
@@ -17,6 +19,7 @@ import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -48,6 +51,15 @@ private class ExplodingEventRepo : EventRepository {
 private class ExplodingEventTypeRepo : EventTypeRepository {
     override fun findAll(): List<EventType> = error("unused")
     override fun findById(id: EventTypeId): EventType? = error("repository must not be reached for an unauthorized caller")
+}
+
+private class ExplodingPositionRepo : PositionRepository {
+    override fun list(): List<Position> = error("unused")
+    override fun create(label: PositionLabel): Position = error("unused")
+    override fun rename(id: PositionId, label: PositionLabel): Position = error("unused")
+    override fun delete(id: PositionId) = error("unused")
+    override fun findById(id: PositionId): Position? = error("unused")
+    override fun exists(positionId: PositionId): Boolean = error("unused")
 }
 
 private class ExplodingSeasonRepo : SeasonRepository {
@@ -88,6 +100,7 @@ class EventServiceTest : FunSpec() {
             ExplodingEventRepo(),
             ExplodingEventTypeRepo(),
             ExplodingSeasonRepo(),
+            ExplodingPositionRepo(),
             AuthorizationService(EventFakeMemberRepo(admins = emptySet()), FakeActAsGateway()),
             Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
         )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirementTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirementTest.kt
@@ -1,0 +1,130 @@
+package com.github.zzave.teambalance.api.domain.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+private fun positionId() = PositionId(UUID.randomUUID())
+
+/**
+ * The roster requirement's own rules — the ones that must hold however the value arrives (an admin
+ * form, a JPA row, a test fixture), which is why they live on the value object rather than in a
+ * request validator that only the HTTP path would run through.
+ */
+class RosterRequirementTest : FunSpec() {
+    init {
+        test("tracking off with no targets is the default, and is a legitimate value") {
+            RosterRequirement.OFF.trackRoster shouldBe false
+            RosterRequirement.OFF.totalTarget shouldBe null
+            RosterRequirement.OFF.positionTargets shouldBe emptyList()
+        }
+
+        // The whole reason trackRoster is a flag and not "are there any targets": these two are
+        // different states, and the client renders them differently (a tally panel vs. no panel).
+        test("tracking on with no targets is distinct from tracking off") {
+            val tally = RosterRequirement(trackRoster = true)
+            val off = RosterRequirement(trackRoster = false)
+
+            tally.positionTargets shouldBe off.positionTargets
+            tally.totalTarget shouldBe off.totalTarget
+            (tally == off) shouldBe false
+        }
+
+        // Targets survive the toggle so an admin who switches tracking off and on again gets their
+        // lineup back rather than an empty form.
+        test("targets are kept while tracking is off") {
+            val setter = positionId()
+            val requirement = RosterRequirement(
+                trackRoster = false,
+                totalTarget = HeadcountTarget(12),
+                positionTargets = listOf(PositionTarget(setter, PositionSlots(2))),
+            )
+
+            requirement.targetFor(setter) shouldBe PositionSlots(2)
+            requirement.totalTarget shouldBe HeadcountTarget(12)
+        }
+
+        test("the two axes are independent — either may be set without the other") {
+            RosterRequirement(trackRoster = true, totalTarget = HeadcountTarget(12)).positionTargets shouldBe emptyList()
+            RosterRequirement(
+                trackRoster = true,
+                positionTargets = listOf(PositionTarget(positionId(), PositionSlots(2))),
+            ).totalTarget shouldBe null
+        }
+
+        test("targetFor answers null for a position the roster does not target") {
+            val requirement = RosterRequirement(
+                trackRoster = true,
+                positionTargets = listOf(PositionTarget(positionId(), PositionSlots(2))),
+            )
+
+            requirement.targetFor(positionId()) shouldBe null
+        }
+
+        test("withoutPosition drops only that position's target — how a deleted position leaves") {
+            val setter = positionId()
+            val libero = positionId()
+            val requirement = RosterRequirement(
+                trackRoster = true,
+                totalTarget = HeadcountTarget(12),
+                positionTargets = listOf(PositionTarget(setter, PositionSlots(2)), PositionTarget(libero, PositionSlots(1))),
+            )
+
+            val after = requirement.withoutPosition(setter)
+
+            after.targetFor(setter) shouldBe null
+            after.targetFor(libero) shouldBe PositionSlots(1)
+            after.totalTarget shouldBe HeadcountTarget(12)
+        }
+
+        test("withoutPosition of an untargeted position changes nothing") {
+            val requirement = RosterRequirement(
+                trackRoster = true,
+                positionTargets = listOf(PositionTarget(positionId(), PositionSlots(2))),
+            )
+
+            requirement.withoutPosition(positionId()) shouldBe requirement
+        }
+
+        // A target of zero is the *absence* of a target, not a target of nothing — storing one would
+        // put a row on the panel that is permanently, meaninglessly "covered". The absence is modelled
+        // by having no PositionTarget at all, so the count itself starts at one.
+        test("a position's slot count must be at least one") {
+            shouldThrow<IllegalArgumentException> { PositionSlots(0) }
+            shouldThrow<IllegalArgumentException> { PositionSlots(-1) }
+        }
+
+        test("a position's slot count is capped, so a fat-fingered number is rejected not drawn") {
+            PositionSlots(PositionSlots.MAX).value shouldBe PositionSlots.MAX
+            shouldThrow<IllegalArgumentException> { PositionSlots(PositionSlots.MAX + 1) }
+        }
+
+        test("a headcount target must be at least one and is capped") {
+            HeadcountTarget(1).value shouldBe 1
+            HeadcountTarget(HeadcountTarget.MAX).value shouldBe HeadcountTarget.MAX
+            shouldThrow<IllegalArgumentException> { HeadcountTarget(0) }
+            shouldThrow<IllegalArgumentException> { HeadcountTarget(-3) }
+            shouldThrow<IllegalArgumentException> { HeadcountTarget(HeadcountTarget.MAX + 1) }
+        }
+
+        // Two targets for one position would make targetFor's answer depend on list order, and the
+        // storage (a map keyed by position) cannot represent it anyway.
+        test("a position may be targeted at most once") {
+            val setter = positionId()
+
+            shouldThrow<IllegalArgumentException> {
+                RosterRequirement(
+                    trackRoster = true,
+                    positionTargets = listOf(PositionTarget(setter, PositionSlots(2)), PositionTarget(setter, PositionSlots(3))),
+                )
+            }
+        }
+
+        test("the number of targeted positions is capped") {
+            val tooMany = (0..RosterRequirement.MAX_POSITION_TARGETS).map { PositionTarget(positionId(), PositionSlots(1)) }
+
+            shouldThrow<IllegalArgumentException> { RosterRequirement(trackRoster = true, positionTargets = tooMany) }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/SeriesModificationTest.kt
@@ -67,6 +67,15 @@ class SeriesModificationTest : FunSpec({
         )
     }
 
+    val setter = PositionId(UUID.randomUUID())
+    val twoSetters = RosterRequirement(
+        trackRoster = true,
+        positionTargets = listOf(PositionTarget(setter, PositionSlots(2))),
+    )
+    val headcountOnly = RosterRequirement(trackRoster = true, totalTarget = HeadcountTarget(8))
+
+    fun EventEdit.withRoster(requirement: RosterRequirement?): EventEdit = copy(rosterOverride = requirement)
+
     fun timeOfDay(instant: Instant): LocalTime = instant.atZone(zone).toLocalTime()
     fun localDate(instant: Instant): LocalDate = instant.atZone(zone).toLocalDate()
 
@@ -191,6 +200,53 @@ class SeriesModificationTest : FunSpec({
             plan.regrouped.shouldBeEmpty()
             plan.edited.single().recurringGroup shouldBe null
         }
+    }
+
+    // ── EDIT / ROSTER REQUIREMENT ───────────────────────────────────────────
+    // The roster requirement propagates exactly like every other edited field: a scoped edit means
+    // "these occurrences now need this lineup". Setting it on one Tuesday and not the rest would be
+    // an edit that silently did less than the scope it was given.
+
+    test("edit THIS applies the roster requirement to the target alone") {
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.THIS, editOn().withRoster(twoSetters), tailGroup, zone)
+
+        plan.edited.single().rosterOverride shouldBe twoSetters
+        // The regrouped tail is moved, not edited — its requirement is untouched either way.
+        plan.regrouped.forEach { it.rosterOverride shouldBe null }
+    }
+
+    test("edit THIS_AND_FOLLOWING applies the roster requirement to the target and every later occurrence") {
+        val edit = editOn().withRoster(twoSetters)
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.THIS_AND_FOLLOWING, edit, tailGroup, zone)
+
+        plan.edited.map { it.id } shouldContainExactly listOf(d2.id, d3.id, d4.id)
+        plan.edited.forEach { it.rosterOverride shouldBe twoSetters }
+    }
+
+    test("edit ALL applies the roster requirement to every occurrence in the series") {
+        val plan = SeriesModification.planEdit(series, d2.id, EventSeriesScope.ALL, editOn().withRoster(twoSetters), tailGroup, zone)
+
+        plan.edited.map { it.id } shouldContainExactly listOf(d1.id, d2.id, d3.id, d4.id)
+        plan.edited.forEach { it.rosterOverride shouldBe twoSetters }
+    }
+
+    test("a bulk edit carrying no override drops the whole scope back to inheriting the type default") {
+        // The override is a whole replacement, so "no override" is a value the edit carries, not an
+        // omission: a series previously pinned to its own lineup returns to following its type.
+        val pinned = series.map { it.copy(rosterOverride = twoSetters) }
+
+        val plan = SeriesModification.planEdit(pinned, d2.id, EventSeriesScope.ALL, editOn(), tailGroup, zone)
+
+        plan.edited.forEach { it.rosterOverride shouldBe null }
+    }
+
+    test("a bulk edit overwrites an occurrence that carried a different requirement of its own") {
+        val mixed = listOf(d1, d2.copy(rosterOverride = headcountOnly), d3, d4)
+
+        val edit = editOn(date = "2026-09-01").withRoster(twoSetters)
+        val plan = SeriesModification.planEdit(mixed, d1.id, EventSeriesScope.ALL, edit, tailGroup, zone)
+
+        plan.edited.forEach { it.rosterOverride shouldBe twoSetters }
     }
 
     test("an unknown target id is rejected") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantSchemaAdapterTest.kt
@@ -29,7 +29,9 @@ class TenantSchemaAdapterTest : TeamBalanceIT() {
             tables.shouldContainExactlyInAnyOrder(
                 "attendances",
                 "event_audience",
+                "event_position_targets",
                 "event_references",
+                "event_type_position_targets",
                 "event_types",
                 "events",
                 "flyway_tenant_schema_history",

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventSeriesControllerIT.kt
@@ -289,6 +289,74 @@ class EventSeriesControllerIT : TeamBalanceIT() {
 
         // ── Auth + missing target ─────────────────────────────────────────────
 
+        // ── EDIT / ROSTER REQUIREMENT ────────────────────────────────────────
+        // The planner rules live in SeriesModificationTest; these prove the scope really reaches the
+        // other rows in the database, and that "inherit" is stored as null rather than as a copy.
+
+        test("PUT scope=THIS_AND_FOLLOWING applies the roster requirement to the target and every later row") {
+            seedTeamAndAdmin()
+            resetSeason()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "roster-following")
+
+            perform(
+                MockMvcRequestBuilders.put("/api/events/${ev[1]}?scope=THIS_AND_FOLLOWING")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        editBody(
+                            title = "Needs a lineup",
+                            start = "2026-09-08T17:00:00Z",
+                            end = "2026-09-08T18:30:00Z",
+                            rosterOverride = """{"trackRoster": true, "totalTarget": 8, "positionTargets": []}""",
+                        ),
+                    ),
+                ADMIN_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            // The head keeps inheriting; the target and its tail each carry the requirement.
+            trackRosterOf(ev[0]) shouldBe null
+            listOf(ev[1], ev[2], ev[3]).forEach {
+                trackRosterOf(it) shouldBe true
+                totalTargetOf(it) shouldBe 8
+            }
+        }
+
+        test("PUT scope=ALL carrying no roster requirement returns the whole series to the type default") {
+            seedTeamAndAdmin()
+            resetSeason()
+            val group = UUID.randomUUID()
+            val ev = seedSeries(group, "roster-clear")
+
+            // Pin the series first, so clearing it is a real change rather than a no-op.
+            perform(
+                MockMvcRequestBuilders.put("/api/events/${ev[0]}?scope=ALL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        editBody(
+                            title = "Pinned",
+                            start = "2026-09-01T17:00:00Z",
+                            end = "2026-09-01T18:30:00Z",
+                            rosterOverride = """{"trackRoster": true, "totalTarget": 6, "positionTargets": []}""",
+                        ),
+                    ),
+                ADMIN_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            ev.forEach { trackRosterOf(it) shouldBe true }
+
+            perform(
+                MockMvcRequestBuilders.put("/api/events/${ev[0]}?scope=ALL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(editBody(title = "Back to default", start = "2026-09-01T17:00:00Z", end = "2026-09-01T18:30:00Z")),
+                ADMIN_USER_ID,
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            // Null, not a stored copy of the default — the row inherits again, and keeps inheriting.
+            ev.forEach {
+                trackRosterOf(it) shouldBe null
+                totalTargetOf(it) shouldBe null
+            }
+        }
+
         test("PUT with a scope by a non-admin member is rejected with 403") {
             seedTeamAndAdmin()
             resetSeason()
@@ -339,7 +407,7 @@ class EventSeriesControllerIT : TeamBalanceIT() {
             id
         }
 
-    private fun editBody(title: String, start: String, end: String): String {
+    private fun editBody(title: String, start: String, end: String, rosterOverride: String? = null): String {
         val eventTypeId = trainingTypeId()
         return """
             {
@@ -348,10 +416,18 @@ class EventSeriesControllerIT : TeamBalanceIT() {
               "description": null,
               "startTime": "$start",
               "endTime": "$end",
-              "location": null
+              "location": null,
+              "rosterOverride": ${rosterOverride ?: "null"}
             }
         """.trimIndent()
     }
+
+    // The requirement columns as stored: null track_roster IS "inherits the type default" (#219).
+    private fun trackRosterOf(id: UUID): Boolean? =
+        jdbcTemplate.queryForObject("SELECT roster_track_roster FROM public.events WHERE uuid = ?", Boolean::class.java, id)
+
+    private fun totalTargetOf(id: UUID): Int? =
+        jdbcTemplate.queryForObject("SELECT roster_total_target FROM public.events WHERE uuid = ?", Int::class.java, id)
 
     private fun trainingTypeId(): UUID =
         jdbcTemplate.queryForObject("SELECT uuid FROM public.event_types WHERE name = 'Training'", UUID::class.java)!!

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RosterRequirementPersistenceIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RosterRequirementPersistenceIT.kt
@@ -1,0 +1,540 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+// d1/d2: every IT shares one `public` schema, and tb_add_member is ON CONFLICT DO NOTHING, so a
+// user id another spec already seeded would silently keep THAT spec's role. These two are unused
+// elsewhere — check the list before adding more.
+// Fixture user ids are namespaced `b2190000-…` after this feature's issue (#219). Every IT shares
+// one `public` schema and `tb_add_member` is ON CONFLICT DO NOTHING, so two specs claiming the same
+// id silently share a member — and whichever seeds first decides their role. That is not
+// hypothetical: these specs originally used `…0000d1`-`…0000d3`, which #242 later took for
+// EventControllerTest's setters, turning this spec's admin into a plain USER and every admin-gated
+// write into a 403. An issue-scoped prefix makes a future collision implausible rather than lucky.
+private const val ADMIN_USER_ID = "b2190000-0000-0000-0000-000000000001"
+private const val MEMBER_USER_ID = "b2190000-0000-0000-0000-000000000002"
+private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+
+// Every IT runs against the ONE shared `public` schema and the one demo team, so this spec owns
+// its fixtures rather than borrowing the seeded ones: it deletes a position (which nulls every
+// holder's position_id, and tb_add_member's ON CONFLICT DO NOTHING will not re-assign them) and it
+// rewrites an event type's roster columns. Doing either to "Setter" or to "Match" would reach into
+// specs that assert on them — EventControllerTest expects the demo roster's roles intact.
+private const val SETTER = "Roster Setter"
+private const val LIBERO = "Roster Libero"
+private const val TYPE_NAME = "RosterFixture"
+
+/**
+ * Roster requirements against a real Postgres (#219, step 1): the storage and the contract edge, not
+ * yet the fill computation.
+ *
+ * What only a real database can answer here:
+ *  - **The override/inherit bit is a nullable column, not a flag.** A stored `trackRoster = false`
+ *    override and an absent override are different rows and must read back differently — an in-memory
+ *    fake would happily agree with either mapping.
+ *  - **Two eager element collections on one event.** `references` (an ordered list) and the roster's
+ *    per-position targets (a map) are fetched together; if Hibernate assembled them from one
+ *    cartesian result set the references would silently multiply. Only a round-trip catches that.
+ *  - **The position-delete cascade is now a foreign key** (ADR-0026), and a constraint is exactly the
+ *    kind of thing a fake cannot stand in for: the service issues one DELETE and the database is what
+ *    removes every target naming that position. This spec is where that is actually demonstrated.
+ */
+@AutoConfigureMockMvc
+class RosterRequirementPersistenceIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    init {
+        test("an event type's roster default round-trips through the listing") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            val libero = positionId(LIBERO)
+            setTypeDefault(trackRoster = true, totalTarget = 12, targets = mapOf(setter to 2, libero to 1))
+
+            perform(MockMvcRequestBuilders.get("/api/event-types"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].rosterDefault.trackRoster").value(true))
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].rosterDefault.totalTarget").value(12))
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].rosterDefault.positionTargets.length()").value(2))
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].archived").value(false))
+        }
+
+        // The seeded types predate roster tracking: the migration's defaults must leave them switched
+        // off rather than, say, "tracking with no targets" — a social would otherwise sprout a panel.
+        test("an unconfigured event type reads as tracking off with no targets") {
+            seedTeamAndAdmin()
+
+            perform(MockMvcRequestBuilders.get("/api/event-types"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'Other')].rosterDefault.trackRoster").value(false))
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'Other')].rosterDefault.positionTargets.length()").value(0))
+            // Asserted on the column rather than the JSON: a JsonPath filter yields an array, so an
+            // absent total reads as [null] and no doesNotExist() assertion can tell it from a real one.
+            totalTargetColumnOf("Other") shouldBe null
+        }
+
+        test("an event created with an override round-trips it, alongside its references") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+
+            val id = createEvent(
+                title = "Override",
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": 8, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+                """.trimIndent(),
+                references = """[{"title": "Sheet", "url": "https://example.com/a"}, {"url": "https://example.com/b"}]""",
+            )
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.rosterOverride.trackRoster").value(true))
+                .andExpect(jsonPath("$.rosterOverride.totalTarget").value(8))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(1))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].positionId").value(setter.toString()))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].count").value(2))
+                // The second eager collection did not multiply the first.
+                .andExpect(jsonPath("$.references.length()").value(2))
+        }
+
+        test("an event created without an override reads back as inheriting") {
+            seedTeamAndAdmin()
+
+            val id = createEvent(title = "Inherits", rosterOverride = null)
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.rosterOverride").doesNotExist())
+            trackRosterColumnOf(id) shouldBe null
+        }
+
+        // "Tracked, but nothing required" is a state of its own, and the one most easily lost: it is
+        // an override whose every other field is empty, so a mapping that treated "empty" as "absent"
+        // would silently turn it back into inheritance.
+        test("an override that only switches tracking on is stored as an override, not as inheritance") {
+            seedTeamAndAdmin()
+
+            val id = createEvent(
+                title = "Tally only",
+                rosterOverride = """{"trackRoster": true, "totalTarget": null, "positionTargets": []}""",
+            )
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.rosterOverride.trackRoster").value(true))
+                .andExpect(jsonPath("$.rosterOverride.totalTarget").doesNotExist())
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(0))
+            trackRosterColumnOf(id) shouldBe true
+        }
+
+        // Same trap from the other side: an override that switches tracking OFF is a deliberate "no
+        // panel on this one occurrence", and must not read back as "inherit whatever the type says".
+        test("an override that switches tracking off is stored, not read back as inheritance") {
+            seedTeamAndAdmin()
+            setTypeDefault(trackRoster = true, totalTarget = 10, targets = emptyMap())
+
+            val id = createEvent(
+                title = "Opted out",
+                rosterOverride = """{"trackRoster": false, "totalTarget": null, "positionTargets": []}""",
+            )
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.rosterOverride.trackRoster").value(false))
+            trackRosterColumnOf(id) shouldBe false
+        }
+
+        test("an edit replaces the override wholesale, and can drop it back to inheriting") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            val libero = positionId(LIBERO)
+            val id = createEvent(
+                title = "Edited",
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": 8, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+                """.trimIndent(),
+            )
+
+            // Whole replacement, not a patch: the setter target is gone because the new value omits it.
+            updateEvent(
+                id,
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": null, "positionTargets": [{"positionId": "$libero", "count": 3}]}
+                """.trimIndent(),
+            ).andExpect(status().isOk)
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(1))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].positionId").value(libero.toString()))
+                .andExpect(jsonPath("$.rosterOverride.totalTarget").doesNotExist())
+
+            updateEvent(id, rosterOverride = null).andExpect(status().isOk)
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.rosterOverride").doesNotExist())
+            targetCountFor(id) shouldBe 0
+        }
+
+        // A stepper wound down to zero is the admin saying "no target here", so it is dropped rather
+        // than stored as a target of nothing (which would render a permanently-covered panel row).
+        test("a zero count is dropped rather than stored") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            val libero = positionId(LIBERO)
+
+            val id = createEvent(
+                title = "Zeroed",
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                        {"positionId": "$setter", "count": 0}, {"positionId": "$libero", "count": 2}]}
+                """.trimIndent(),
+            )
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(1))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].positionId").value(libero.toString()))
+        }
+
+        test("a nonsensical target is rejected with 400 and nothing is written") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+
+            perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        eventBody(
+                            "Bad",
+                            """
+                            {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                                {"positionId": "$setter", "count": -2}]}
+                            """.trimIndent(),
+                        ),
+                    ),
+                ADMIN_USER_ID,
+            ).andExpect(status().isBadRequest)
+
+            eventCountWithTitle("Bad") shouldBe 0
+        }
+
+        // Zero means "no target here" on both axes, or the same stepper gesture on the same form
+        // would drop one row and 400 on the other.
+        test("a zero total target clears the headcount rather than failing") {
+            seedTeamAndAdmin()
+
+            val id = createEvent(
+                title = "Zero total",
+                rosterOverride = """{"trackRoster": true, "totalTarget": 0, "positionTargets": []}""",
+            )
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.rosterOverride.trackRoster").value(true))
+                .andExpect(jsonPath("$.rosterOverride.totalTarget").doesNotExist())
+        }
+
+        // The foreign key makes an unknown id unstorable; this guard is what makes the refusal the
+        // declared 400 rather than a constraint violation surfacing as a 500 (ADR-0026).
+        test("a target naming an unknown position is rejected with 400 and nothing is written") {
+            seedTeamAndAdmin()
+
+            perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        eventBody(
+                            "Ghost",
+                            """
+                            {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                                {"positionId": "${UUID.randomUUID()}", "count": 2}]}
+                            """.trimIndent(),
+                        ),
+                    ),
+                ADMIN_USER_ID,
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("UNKNOWN_ROSTER_POSITION"))
+
+            eventCountWithTitle("Ghost") shouldBe 0
+        }
+
+        test("an edit naming an unknown position is rejected and leaves the stored override intact") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            val id = createEvent(
+                title = "Keeps override",
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": null, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+                """.trimIndent(),
+            )
+
+            updateEvent(
+                id,
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                        {"positionId": "${UUID.randomUUID()}", "count": 2}]}
+                """.trimIndent(),
+            ).andExpect(status().isBadRequest)
+
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(1))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].positionId").value(setter.toString()))
+        }
+
+        test("the same position twice is rejected with 400") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+
+            perform(
+                MockMvcRequestBuilders.post("/api/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        eventBody(
+                            "Dup",
+                            """
+                            {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                                {"positionId": "$setter", "count": 2}, {"positionId": "$setter", "count": 3}]}
+                            """.trimIndent(),
+                        ),
+                    ),
+                ADMIN_USER_ID,
+            ).andExpect(status().isBadRequest)
+
+            eventCountWithTitle("Dup") shouldBe 0
+        }
+
+        // The cascade the design calls for: deleting a position drops it from every type default and
+        // every event override, and leaves its members Unassigned. Since ADR-0026 all three are
+        // foreign keys in one schema — ON DELETE CASCADE for the two target tables, SET NULL for the
+        // member profile so the member keeps their name — so this proves one statement does the lot,
+        // where it used to prove three ordered writes in PositionService.
+        test("deleting a position clears it from type defaults and event overrides, and unassigns its members") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            val libero = positionId(LIBERO)
+            seedMember(MEMBER_USER_ID, "roster-member@test.com", role = "USER", position = SETTER)
+            setTypeDefault(trackRoster = true, totalTarget = 12, targets = mapOf(setter to 2, libero to 1))
+            val id = createEvent(
+                title = "Cascade",
+                rosterOverride = """
+                    {"trackRoster": true, "totalTarget": null, "positionTargets": [
+                        {"positionId": "$setter", "count": 2}, {"positionId": "$libero", "count": 1}]}
+                """.trimIndent(),
+            )
+
+            perform(MockMvcRequestBuilders.delete("/api/positions/$setter"), ADMIN_USER_ID)
+                .andExpect(status().isNoContent)
+
+            // The setter target is gone from both surfaces; the libero one is untouched.
+            perform(MockMvcRequestBuilders.get("/api/event-types"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].rosterDefault.positionTargets.length()").value(1))
+                .andExpect(
+                    jsonPath("$.eventTypes[?(@.name == 'RosterFixture')].rosterDefault.positionTargets[0].positionId")
+                        .value(libero.toString()),
+                )
+            perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+                .andExpect(jsonPath("$.rosterOverride.positionTargets.length()").value(1))
+                .andExpect(jsonPath("$.rosterOverride.positionTargets[0].positionId").value(libero.toString()))
+
+            // The member holding it simply becomes unassigned, and the event keeps its override.
+            positionOf(MEMBER_USER_ID) shouldBe null
+            trackRosterColumnOf(id) shouldBe true
+        }
+
+        test("a non-admin cannot delete a position, so no target is cleared") {
+            seedTeamAndAdmin()
+            val setter = positionId(SETTER)
+            seedMember(MEMBER_USER_ID, "roster-nonadmin@test.com", role = "USER", position = null)
+            setTypeDefault(trackRoster = true, totalTarget = null, targets = mapOf(setter to 2))
+            roleOf(MEMBER_USER_ID) shouldBe "USER"
+
+            perform(MockMvcRequestBuilders.delete("/api/positions/$setter"), MEMBER_USER_ID)
+                .andExpect(status().isForbidden)
+
+            typeTargetCountFor() shouldBe 1
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private fun perform(builder: MockHttpServletRequestBuilder, userId: String) =
+        mockMvc.perform(builder.header("X-Team-Id", "public").header("X-User-Id", userId))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    private fun eventBody(title: String, rosterOverride: String?, references: String = "[]"): String = """
+        {
+          "eventTypeId": "${fixtureTypeId()}",
+          "title": "$title",
+          "description": null,
+          "startTime": "2026-09-01T17:00:00Z",
+          "endTime": "2026-09-01T18:30:00Z",
+          "location": null,
+          "references": $references,
+          "rosterOverride": ${rosterOverride ?: "null"}
+        }
+    """.trimIndent()
+
+    private fun createEvent(title: String, rosterOverride: String?, references: String = "[]"): UUID {
+        val response = perform(
+            MockMvcRequestBuilders.post("/api/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(eventBody(title, rosterOverride, references)),
+            ADMIN_USER_ID,
+        ).andExpect(status().isCreated).andReturn().response.contentAsString
+        return UUID.fromString(Regex("\"id\"\\s*:\\s*\"([^\"]+)\"").find(response)!!.groupValues[1])
+    }
+
+    private fun updateEvent(id: UUID, rosterOverride: String?) = perform(
+        MockMvcRequestBuilders.put("/api/events/$id")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(eventBody("Edited", rosterOverride)),
+        ADMIN_USER_ID,
+    )
+
+    private fun typeId(name: String): UUID =
+        jdbcTemplate.queryForObject("SELECT uuid FROM public.event_types WHERE name = ?", UUID::class.java, name)!!
+
+    // This spec's own event type, so rewriting its roster columns cannot disturb a seeded one that
+    // another spec reads. Created on demand and left in place; other specs address types by name.
+    private fun fixtureTypeId(): UUID {
+        jdbcTemplate.update(
+            "INSERT INTO public.event_types (name, color) SELECT ?, '#7B5EA7' " +
+                "WHERE NOT EXISTS (SELECT 1 FROM public.event_types WHERE name = ?)",
+            TYPE_NAME,
+            TYPE_NAME,
+        )
+        return typeId(TYPE_NAME)
+    }
+
+    // No authoring endpoint exists yet (that is step 4), so a type's default is seeded directly. The
+    // read path back out is the real one.
+    private fun setTypeDefault(trackRoster: Boolean, totalTarget: Int?, targets: Map<UUID, Int>) {
+        fixtureTypeId()
+        jdbcTemplate.update(
+            "UPDATE public.event_types SET track_roster = ?, total_target = ? WHERE name = ?",
+            trackRoster,
+            totalTarget,
+            TYPE_NAME,
+        )
+        val id = jdbcTemplate.queryForObject(
+            "SELECT id FROM public.event_types WHERE name = ?",
+            Long::class.java,
+            TYPE_NAME,
+        )!!
+        jdbcTemplate.update("DELETE FROM public.event_type_position_targets WHERE event_type_id = ?", id)
+        targets.forEach { (positionId, count) ->
+            jdbcTemplate.update(
+                "INSERT INTO public.event_type_position_targets (event_type_id, position_id, target_count) VALUES (?, ?, ?)",
+                id,
+                positionId,
+                count,
+            )
+        }
+    }
+
+    // Positions are tenant rows since ADR-0026, and this spec routes to `public`, so that is where a
+    // position has to exist for a target to reference it — event_type_position_targets.position_id is
+    // a real foreign key now, and seeding only the platform table would (correctly) be rejected.
+    private fun positionId(label: String): UUID {
+        jdbcTemplate.update(
+            "INSERT INTO public.positions (id, label) VALUES (gen_random_uuid(), ?) ON CONFLICT DO NOTHING",
+            label,
+        )
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM public.positions WHERE lower(label) = lower(?)",
+            UUID::class.java,
+            label,
+        )!!
+    }
+
+    private fun totalTargetColumnOf(name: String): Int? =
+        jdbcTemplate.queryForObject("SELECT total_target FROM public.event_types WHERE name = ?", Int::class.java, name)
+
+    private fun roleOf(userId: String): String? =
+        jdbcTemplate.queryForObject(
+            "SELECT role FROM public.team_members WHERE user_id = ?::uuid AND team_id = ?::uuid",
+            String::class.java,
+            userId,
+            TEAM_ID,
+        )
+
+    private fun trackRosterColumnOf(id: UUID): Boolean? =
+        jdbcTemplate.queryForObject("SELECT roster_track_roster FROM public.events WHERE uuid = ?", Boolean::class.java, id)
+
+    private fun targetCountFor(id: UUID): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM public.event_position_targets t " +
+                "JOIN public.events e ON e.id = t.event_id WHERE e.uuid = ?",
+            Long::class.java,
+            id,
+        )!!
+
+    private fun typeTargetCountFor(): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM public.event_type_position_targets t " +
+                "JOIN public.event_types et ON et.id = t.event_type_id WHERE et.name = ?",
+            Long::class.java,
+            TYPE_NAME,
+        )!!
+
+    private fun eventCountWithTitle(title: String): Long =
+        jdbcTemplate.queryForObject("SELECT count(*) FROM public.events WHERE title = ?", Long::class.java, title)!!
+
+    // The tenant's assignment since ADR-0026. The platform column still exists but is no longer
+    // maintained, so reading it would assert on a stale copy rather than on what the API did.
+    private fun positionOf(userId: String): UUID? =
+        jdbcTemplate.queryForObject(
+            "SELECT position_id FROM public.member_profiles WHERE user_id = ?::uuid",
+            UUID::class.java,
+            userId,
+        )
+
+    private fun seedTeamAndAdmin() {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        tenantSchemaAdapter.provisionTenantSchema("public")
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.update("UPDATE public.team_settings SET season_start = NULL, season_end = NULL WHERE id = 1")
+        seedMember(ADMIN_USER_ID, "roster-admin@test.com", role = "ADMIN", position = null)
+    }
+
+    private fun seedMember(userId: String, email: String, role: String, position: String?) {
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.users (id, email, display_name)
+            VALUES ('$userId'::uuid, '$email', '$email')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        // execute(), not update(): tb_add_member is a function, so the statement returns a (void) row.
+        val label = position?.let { "'$it'" } ?: "NULL"
+        jdbcTemplate.execute("SELECT public.tb_add_member('$TEAM_ID'::uuid, '$userId'::uuid, '$role', $label)")
+    }
+}

--- a/app/src/entities/event/lib/attendee-panel.test.ts
+++ b/app/src/entities/event/lib/attendee-panel.test.ts
@@ -31,6 +31,8 @@ const makeEventDetail = (overrides: Partial<EventDetail> = {}): EventDetail => (
   attendances: [],
   // The viewer's own resolved response, mirroring the list payload.
   myState: 'NOT_RESPONDED',
+  // Undefined = this event inherits its type's roster default.
+  rosterOverride: undefined,
   ...overrides,
 })
 

--- a/app/src/features/create-event/ui/CreateEventForm.stories.tsx
+++ b/app/src/features/create-event/ui/CreateEventForm.stories.tsx
@@ -1,14 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn, within } from 'storybook/test'
 import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEventType } from '@shared/testing/event-fixtures'
 import { CreateEventForm } from './CreateEventForm'
 
 // CreateEventForm is the presentational form extracted from the CreateEventDialog container. It
 // owns local form state (type selection, title auto-suggest) and hands a fully-assembled input up
 // via onSubmit; data fetching + the mutation stay in the container. Its states are stories.
 const EVENT_TYPES: EventTypeItem[] = [
-  { id: 'et-1', name: 'Match', color: '#3b82f6' },
-  { id: 'et-2', name: 'Training', color: '#22c55e' },
+  makeEventType({ id: 'et-1', name: 'Match', color: '#3b82f6' }),
+  makeEventType({ id: 'et-2', name: 'Training', color: '#22c55e' }),
 ]
 
 const meta = {

--- a/app/src/features/create-recurring-events/ui/RecurringEventsWizard.stories.tsx
+++ b/app/src/features/create-recurring-events/ui/RecurringEventsWizard.stories.tsx
@@ -1,14 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn, within } from 'storybook/test'
 import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEventType } from '@shared/testing/event-fixtures'
 import { RecurringEventsWizard } from './RecurringEventsWizard'
 
 // The guided wizard is the presentational shell of the recurring-create flow: ① details →
 // ② recurrence (with the live calendar preview) → ③ confirm. Data, the mutation, and the dialog
 // open/close live in the container; every step state is a story here.
 const EVENT_TYPES: EventTypeItem[] = [
-  { id: 'et-1', name: 'Training', color: '#225C9C' },
-  { id: 'et-2', name: 'Match', color: '#249E6C' },
+  makeEventType({ id: 'et-1', name: 'Training', color: '#225C9C' }),
+  makeEventType({ id: 'et-2', name: 'Match', color: '#249E6C' }),
 ]
 
 const SEASON = { start: '2026-09-01', end: '2027-05-31' }

--- a/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import type { Event, EventDetail } from '@shared/api/events'
 import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEventType } from '@shared/testing/event-fixtures'
 import { makeEvent } from '@shared/testing/event-fixtures'
 import { EditEventDialogView } from './EditEventDialogView'
 
@@ -11,8 +12,8 @@ import { EditEventDialogView } from './EditEventDialogView'
 // pending/error shells that used to live in the container are now the isPending/isError args, and
 // the submit story proves the wiring with a prop-contract spy.
 const EVENT_TYPES: EventTypeItem[] = [
-  { id: 'et-1', name: 'Training', color: '#22c55e' },
-  { id: 'et-2', name: 'Match', color: '#3b82f6' },
+  makeEventType({ id: 'et-1', name: 'Training', color: '#22c55e' }),
+  makeEventType({ id: 'et-2', name: 'Match', color: '#3b82f6' }),
 ]
 
 const EVENT: EventDetail = {
@@ -28,6 +29,7 @@ const EVENT: EventDetail = {
   attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 0, roleBreakdown: [] },
   attendances: [],
   myState: 'NOT_RESPONDED',
+  rosterOverride: undefined,
 }
 
 // A three-occurrence series; the middle one ('evt-1') is the one being edited.
@@ -65,6 +67,51 @@ export const Series: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('group', { name: 'Scope' })).toBeInTheDocument()
     await expect(canvas.getByText('Affects 1 of 3 events')).toBeInTheDocument()
+  },
+}
+
+// The update is a whole replacement, so an omitted rosterOverride reads server-side as "drop back to
+// inheriting the type default". This form never edits the override, which is exactly why it has to
+// carry it: renaming an event must not silently erase its lineup. A prop-contract spy is the only
+// layer that can catch the omission — a getByText would not see it.
+export const CarriesRosterOverrideThroughAnUnrelatedEdit: Story = {
+  args: {
+    event: {
+      ...EVENT,
+      rosterOverride: {
+        trackRoster: true,
+        totalTarget: 12,
+        positionTargets: [{ positionId: 'pos-setter', count: 2 }],
+      },
+    },
+  },
+  play: async ({ canvas, userEvent, args }) => {
+    const title = canvas.getByLabelText('Title')
+    await userEvent.clear(title)
+    await userEvent.type(title, 'Renamed Training')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save changes' }))
+
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Renamed Training',
+        rosterOverride: {
+          trackRoster: true,
+          totalTarget: 12,
+          positionTargets: [{ positionId: 'pos-setter', count: 2 }],
+        },
+      }),
+    )
+  },
+}
+
+// The mirror case: an inheriting event stays inheriting, rather than acquiring an override.
+export const KeepsAnInheritingEventInheriting: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Save changes' }))
+
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ rosterOverride: undefined }),
+    )
   },
 }
 

--- a/app/src/features/edit-event/ui/EditEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.tsx
@@ -85,6 +85,10 @@ export function EditEventDialogView({
       endTime: new Date(end).toISOString(),
       location: (form.get('location') as string) || undefined,
       references: cleanReferences(references),
+      // Carried through untouched. This form does not edit the roster override (that is the admin
+      // authoring surface), but the update is a whole replacement — omitting it would drop the event
+      // back to inheriting its type's default as a side effect of renaming it.
+      rosterOverride: event.rosterOverride,
     })
   }
 

--- a/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEventType } from '@shared/testing/event-fixtures'
 import { EventFiltersView } from './EventFiltersView'
 
 // EventFiltersView is the events page's single filter control — the icon button plus the popover
@@ -8,9 +9,9 @@ import { EventFiltersView } from './EventFiltersView'
 // bar. Prop-only apart from the popover's open/closed state; the selection and the show-past flag
 // live in the route, so every state here renders from props with no network (ADR-0017).
 const EVENT_TYPES: EventTypeItem[] = [
-  { id: 'et-1', name: 'Training', color: '#249E6C' },
-  { id: 'et-2', name: 'Match', color: '#225C9C' },
-  { id: 'et-3', name: 'Tournament', color: '#7B5EA7' },
+  makeEventType({ id: 'et-1', name: 'Training', color: '#249E6C' }),
+  makeEventType({ id: 'et-2', name: 'Match', color: '#225C9C' }),
+  makeEventType({ id: 'et-3', name: 'Tournament', color: '#7B5EA7' }),
 ]
 
 const ALL = new Set(EVENT_TYPES.map((t) => t.id))

--- a/app/src/shared/api/attendance-cache.test.ts
+++ b/app/src/shared/api/attendance-cache.test.ts
@@ -31,6 +31,8 @@ const makeEventDetail = (overrides: Partial<EventDetail> = {}): EventDetail => (
   attendances: [],
   // The viewer's own resolved response, mirroring the list payload.
   myState: 'NOT_RESPONDED',
+  // Undefined = this event inherits its type's roster default.
+  rosterOverride: undefined,
   ...overrides,
 })
 

--- a/app/src/shared/api/event-types.ts
+++ b/app/src/shared/api/event-types.ts
@@ -1,8 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from './wirespec-client'
 
-// Re-export the generated contract type so consumers have a single source of truth.
+// Re-export the generated contract types so consumers have a single source of truth. The roster
+// types live here rather than in events.ts because the event type is where a team *authors* them;
+// an event only ever carries an override of one (see events.ts).
 export type { EventTypeItem } from './generated/model/EventTypeItem'
+export type { RosterRequirement } from './generated/model/RosterRequirement'
+export type { PositionTarget } from './generated/model/PositionTarget'
 
 export function useEventTypes() {
   return useQuery({

--- a/app/src/shared/api/events.ts
+++ b/app/src/shared/api/events.ts
@@ -15,6 +15,7 @@ export type { EventSeriesScope } from './generated/model/EventSeriesScope'
 
 import type { EventReference } from './generated/model/EventReference'
 import type { EventSeriesScope } from './generated/model/EventSeriesScope'
+import type { RosterRequirement } from './generated/model/RosterRequirement'
 
 export interface EventInput {
   eventTypeId: string
@@ -24,6 +25,11 @@ export interface EventInput {
   endTime?: string
   location?: string
   references?: EventReference[]
+  // Replace semantics, exactly like `references`: the server takes the body as the event's new whole
+  // requirement, and reads an ABSENT rosterOverride as "drop back to inheriting the type default".
+  // So an edit form that does not carry the event's current value silently erases it — every caller
+  // of useUpdateEvent must pass this through, even when its own UI never edits it.
+  rosterOverride?: RosterRequirement
 }
 
 export function useEvents(includePast = false, enabled = true) {

--- a/app/src/shared/testing/event-fixtures.ts
+++ b/app/src/shared/testing/event-fixtures.ts
@@ -1,4 +1,6 @@
 import type { Event } from '@shared/api/events'
+import type { EventTypeItem } from '@shared/api/event-types'
+import type { RosterRequirement } from '@shared/api/event-types'
 
 /**
  * Canonical Event fixture for stories. One place to update when the generated Event contract
@@ -29,6 +31,31 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     },
     // The viewer's own response. Defaults to a blank, which is the state Bulk Attend acts on.
     myState: 'NOT_RESPONDED',
+    // Undefined means this event inherits its type's roster default, which is the common case.
+    rosterOverride: undefined,
+    ...overrides,
+  }
+}
+
+/** Roster tracking switched off — the default for a type nobody has configured. */
+export const ROSTER_OFF: RosterRequirement = {
+  trackRoster: false,
+  totalTarget: undefined,
+  positionTargets: [],
+}
+
+/**
+ * Canonical EventTypeItem fixture, the sibling of [makeEvent]: one place to update when the
+ * generated event-type contract changes, instead of the inline literals every picker story used to
+ * carry.
+ */
+export function makeEventType(overrides: Partial<EventTypeItem> = {}): EventTypeItem {
+  return {
+    id: 'et-1',
+    name: 'Training',
+    color: '#249E6C',
+    archived: false,
+    rosterDefault: ROSTER_OFF,
     ...overrides,
   }
 }

--- a/app/src/widgets/create-event/ui/CreateEventSheetView.stories.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheetView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import { Sheet } from '@shared/ui/sheet'
 import type { EventTypeItem } from '@shared/api/event-types'
+import { makeEventType } from '@shared/testing/event-fixtures'
 import { CreateEventSheetView } from './CreateEventSheetView'
 
 // CreateEventSheetView is the presentational body of the create-event sheet behind the
@@ -11,8 +12,8 @@ import { CreateEventSheetView } from './CreateEventSheetView'
 // context — no portal, no network. The child features (chooser/form/wizard) own their own state
 // stories; here we cover the sheet's own header + navigation wiring with prop-contract spies.
 const EVENT_TYPES: EventTypeItem[] = [
-  { id: 'et-1', name: 'Training', color: '#22c55e' },
-  { id: 'et-2', name: 'Match', color: '#3b82f6' },
+  makeEventType({ id: 'et-1', name: 'Training', color: '#22c55e' }),
+  makeEventType({ id: 'et-2', name: 'Match', color: '#3b82f6' }),
 ]
 
 const meta = {

--- a/docs/adr/0026-member-team-profile-owned-by-the-tenant.md
+++ b/docs/adr/0026-member-team-profile-owned-by-the-tenant.md
@@ -118,8 +118,15 @@ copies from it. The drop is a separate, later change, once every environment has
   calling it unrouted fails loudly against `__no_tenant__` instead of quietly reading `public`. That
   is the intended behaviour — it is the same guarantee ADR-0024 relies on, now extended to positions —
   but it is a real contract change for any caller that ran without a tenant.
-- **#219 loses its workaround.** The write-time `UNKNOWN_ROSTER_POSITION` check and the roster half of
-  the position-delete cascade become unnecessary; a foreign key covers both.
+- **#219 loses most of its workaround.** The position-delete cascade goes entirely — three ordered
+  writes in `PositionService`, the ports and queries behind them, and the ordering rule that existed
+  because no foreign key could span the schemas — replaced by ON DELETE CASCADE on the two target
+  tables. `PositionService` stops depending on the event ports altogether.
+
+  The write-time `UNKNOWN_ROSTER_POSITION` check **stays**, with a different job. The foreign key is
+  what makes an unknown id unstorable, so the check is no longer load-bearing for integrity; but
+  without it the constraint surfaces as a 500, where the contract declares a `400`. It is now a
+  classifier, not a guard.
 - Ids are preserved through the backfill, so anything already holding a position id — roster targets,
   a client, a bookmarked payload — stays valid. Names are carried across too, so nobody is renamed by
   the migration.


### PR DESCRIPTION
Step 1 of 4 for #219 (roster fill). This is the target model an event's fill is later computed against — **no fill computation and no UI yet**, those are the next PRs in the stack:

1. **contract + model + migration** ← this PR
2. compute + payload (#226)
3. card UI, the slot-pips disclosure (#227)
4. admin CRUD + authoring (#228)

> #245 (positions owned by the tenant) has **merged**, so this PR is now based on `main` and its diff is just the roster work.

## The model

`RosterRequirement` is a headcount and/or a per-position lineup, the two axes independent and either optional.

`trackRoster` is an explicit flag rather than "no targets means off", because those are two different things: *tracking on with no hard requirement* (a training that just tallies who is coming, per position) is a real state, and a distinct one from *not a roster event at all* (a social, which renders no panel). Targets are kept while tracking is off, so toggling it does not discard an admin's configuration.

Targets are keyed by **position id, never label**, so a rename carries them. `PositionSlots` (1..99) and `HeadcountTarget` (1..200) hold the bounds, so they apply however a value arrives — admin form, JPA row or fixture. Zero means "no target here" on **both** axes: it drops the entry rather than failing, since the same stepper gesture on the same form must not succeed on one row and 400 on the other.

An event type carries the team-wide default; an event carries an optional whole-replacement override, where `null` means it **inherits** the type default and keeps inheriting it. In storage the override/inherit bit is the nullability of `roster_track_roster` rather than a separate flag column that could disagree with the rest of the row.

## Two consequences worth flagging for review

- **A bulk series edit propagates the override across its scope.** THIS lands on the target occurrence, THIS_AND_FOLLOWING on the target and its tail, ALL on the whole series — the requirement travels with the scope exactly like every other edited field. The trade: a bulk edit writes a concrete requirement onto every occurrence it touches, so those rows stop tracking their type's default until something clears them. `null` is carried as a value rather than an omission, so a bulk edit without a requirement is also the way back to inheriting.
- **The update is a whole replacement**, so an omitted `rosterOverride` reads as "drop back to inheriting". `EventInput` therefore carries the field and the edit form passes the event's current value through untouched — otherwise renaming an event would silently erase its lineup. Two prop-contract spy stories hold that line, in both directions.

## Referential integrity is a foreign key

Positions used to live in the **platform** schema while the targets naming them lived in a **tenant** schema, so no foreign key could span them and the application had to stand in for one on both sides. #245 moved positions into the tenant schema, so the database enforces it instead:

- `event_type_position_targets.position_id` and `event_position_targets.position_id` are real foreign keys to `positions` with **ON DELETE CASCADE** — deleting a position drops its targets in the same statement, not in an ordered sequence of separate transactions that could fail half-way
- members assigned to it become Unassigned via **ON DELETE SET NULL** on `member_profiles.position_id`, keeping their name

`UNKNOWN_ROSTER_POSITION` (400) stays, and its check with it. It is no longer the integrity mechanism — the foreign key is — but without it an unknown position id would surface as a constraint violation, i.e. a 500, instead of the 400 the contract declares.

## Migration

One tenant migration, `V008__roster_requirements.sql`. The tenant line on `main` ends at V007 (positions, from #245), so this is the next free number; the platform history is separate and unaffected by it.

## Testing

Per the PR gate, each at the lowest layer that proves it:

- **Kotest units** — `RosterRequirementTest` for the value objects' own rules (the tracking-on-vs-off distinction, the independent axes, bounds, duplicate positions); `SeriesModificationTest` for the five scope-propagation cases; `PositionServiceTest` for authorization and the unknown-id 404.
- **Testcontainers IT** — `RosterRequirementPersistenceIT`: the round-trip, the inherit-vs-override distinction in *both* directions (an override that only switches tracking on, and one that switches it off, are each stored rather than collapsing back to inheritance), two eager element collections on one event not multiplying each other, zero handling on both axes, the unknown-position rejection on create and on edit, the scope propagation reaching the other rows in the database, and the delete cascade — which is a constraint now, so a real Postgres is the only place it can be proven at all.
- **Storybook** — two `fn()` spy stories on `EditEventDialogView` proving the override survives an unrelated edit, and that an inheriting event stays inheriting. A `getByText` assertion could not catch either.
- **No new e2e.** No new auth, cross-tenant or integration seam — this rides the existing events read/write. The admin authoring write path in step 4 is the place to reconsider that.

The IT deliberately owns its fixtures (its own positions and its own event type) rather than borrowing the shared demo team's, which it would otherwise mutate out from under the specs that assert on them.

Refs #219.