### PR TITLE
feat(app): roster disclosure on the event card (#219)

### DIFF
--- a/app/src/app/styles/global.css
+++ b/app/src/app/styles/global.css
@@ -44,6 +44,15 @@
      say bg-red/text-red/border-red instead of reaching for Tailwind's own default red (#EF4444),
      which is not ours (F9, #159). Keep in sync with design-tokens/tokens.css, like the three above. */
   --color-red: #D93025;
+  /* The `-dark` ramps of the same three hues, promoted from design-tokens/tokens.css. Tailwind 4
+     generates a utility only for what @theme declares, so `text-green-dark` silently produced
+     nothing before this. The roster panel (#219) needs the full triple per hue: the plain hue as a
+     15% tint for the chip ground, and the darker ramp for text on that tint, which the plain hue
+     itself fails at 11px. They sit in this block, not `@theme inline`, for the reason the note
+     above gives — the `.dark` layer re-points them. */
+  --color-green-dark: #1D7F57;
+  --color-gold-dark: #C89200;
+  --color-red-dark: #B71C1C;
   --color-border: hsl(214.3 31.8% 91.4%);
   --color-input: hsl(214.3 31.8% 91.4%);
   --color-ring: hsl(222.2 84% 4.9%);

--- a/app/src/entities/event/lib/roster-view.test.ts
+++ b/app/src/entities/event/lib/roster-view.test.ts
@@ -37,14 +37,16 @@ describe('rosterChip', () => {
   })
 
   it('reads "Lineup set" when every targeted position is covered', () => {
-    expect(rosterChip(roster({ state: 'LINEUP_SET', openSlots: 0 }))).toEqual({
+    const covered = [pos('Setter', 2, 2), pos('Libero', 1, 1)]
+    expect(rosterChip(roster({ state: 'LINEUP_SET', openSlots: 0, positions: covered }))).toEqual({
       text: 'Lineup set',
       tone: 'covered',
     })
   })
 
   it('counts the open spots when the lineup is short', () => {
-    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 3 }))).toEqual({
+    const shortBy3 = [pos('Setter', 3, 1), pos('Libero', 2, 1)]
+    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 3, positions: shortBy3 }))).toEqual({
       text: '3 spots open',
       tone: 'short',
     })
@@ -53,23 +55,29 @@ describe('rosterChip', () => {
   // Same words, different tone. The count is the news; the colour is what separates "chase later"
   // from "chase now" — a position sitting at zero.
   it('keeps the wording but turns critical when a position has nobody', () => {
-    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 3 }))).toEqual({
+    // Libero at zero is what makes it critical; Setter's two missing bring the count to three.
+    const criticalBy3 = [pos('Setter', 3, 1), pos('Libero', 1, 0)]
+    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 3, positions: criticalBy3 }))).toEqual({
       text: '3 spots open',
       tone: 'critical',
     })
   })
 
   it('says "spot" not "spots" for a single one', () => {
-    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 1 }))?.text).toBe('1 spot open')
-    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 1 }))?.text).toBe('1 spot open')
+    const shortBy1 = [pos('Setter', 2, 1)]
+    const criticalBy1 = [pos('Setter', 1, 0)]
+    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 1, positions: shortBy1 }))?.text).toBe('1 spot open')
+    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 1, positions: criticalBy1 }))?.text).toBe('1 spot open')
   })
 
   it('reads as a headcount when only a total is set', () => {
-    expect(rosterChip(roster({ state: 'HEADCOUNT_SHORT', openSlots: 2 }))).toEqual({
+    // No position carries a target, which is the only way the headcount can be the driving axis —
+    // so openSlots here is the headcount shortfall, not a sum over rows.
+    expect(rosterChip(roster({ state: 'HEADCOUNT_SHORT', openSlots: 2, positions: [] }))).toEqual({
       text: '2 more needed',
       tone: 'short',
     })
-    expect(rosterChip(roster({ state: 'HEADCOUNT_FULL', openSlots: 0 }))).toEqual({
+    expect(rosterChip(roster({ state: 'HEADCOUNT_FULL', openSlots: 0, positions: [] }))).toEqual({
       text: 'Full',
       tone: 'covered',
     })

--- a/app/src/entities/event/lib/roster-view.test.ts
+++ b/app/src/entities/event/lib/roster-view.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import type { EventRoster, RosterPosition } from '@shared/api/events'
+import { makeRoster, NO_ROSTER } from '@shared/testing/event-fixtures'
+import {
+  coveredSummary,
+  hasRosterPanel,
+  headcountLine,
+  oneToChase,
+  rosterChip,
+  rosterRows,
+  unassignedNudge,
+} from './roster-view'
+
+const pos = (label: string, required: number | undefined, attending: number): RosterPosition => ({
+  id: `pos-${label.toLowerCase()}`,
+  label,
+  required,
+  attending,
+})
+
+const roster = (overrides: Partial<EventRoster>) => makeRoster(overrides)
+
+// These are the numbers→words/pips rules and nothing else. The *status* (state, openSlots) is the
+// server's, computed and tested in RosterFillTest — nothing here re-derives it.
+describe('rosterChip', () => {
+  it('shows no chip when the roster is not tracked', () => {
+    expect(rosterChip(NO_ROSTER)).toBeNull()
+  })
+
+  // A tally has nothing to fall short of, so a chip would invent a judgement nobody asked for. It
+  // still differs from "off": the panel opens.
+  it('shows no chip for a tally, but still offers a panel', () => {
+    const tally = roster({ state: 'TALLY_ONLY', openSlots: 0, positions: [pos('Setter', undefined, 2)] })
+    expect(rosterChip(tally)).toBeNull()
+    expect(hasRosterPanel(tally)).toBe(true)
+    expect(hasRosterPanel(NO_ROSTER)).toBe(false)
+  })
+
+  it('reads "Lineup set" when every targeted position is covered', () => {
+    expect(rosterChip(roster({ state: 'LINEUP_SET', openSlots: 0 }))).toEqual({
+      text: 'Lineup set',
+      tone: 'covered',
+    })
+  })
+
+  it('counts the open spots when the lineup is short', () => {
+    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 3 }))).toEqual({
+      text: '3 spots open',
+      tone: 'short',
+    })
+  })
+
+  // Same words, different tone. The count is the news; the colour is what separates "chase later"
+  // from "chase now" — a position sitting at zero.
+  it('keeps the wording but turns critical when a position has nobody', () => {
+    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 3 }))).toEqual({
+      text: '3 spots open',
+      tone: 'critical',
+    })
+  })
+
+  it('says "spot" not "spots" for a single one', () => {
+    expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 1 }))?.text).toBe('1 spot open')
+    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 1 }))?.text).toBe('1 spot open')
+  })
+
+  it('reads as a headcount when only a total is set', () => {
+    expect(rosterChip(roster({ state: 'HEADCOUNT_SHORT', openSlots: 2 }))).toEqual({
+      text: '2 more needed',
+      tone: 'short',
+    })
+    expect(rosterChip(roster({ state: 'HEADCOUNT_FULL', openSlots: 0 }))).toEqual({
+      text: 'Full',
+      tone: 'covered',
+    })
+  })
+})
+
+describe('coveredSummary', () => {
+  it('counts covered targeted positions', () => {
+    const r = roster({
+      positions: [pos('Setter', 2, 2), pos('Libero', 1, 0), pos('Middle', 2, 1)],
+    })
+    expect(coveredSummary(r)).toBe('1 of 3 covered')
+  })
+
+  it('counts an over-filled position as covered', () => {
+    expect(coveredSummary(roster({ positions: [pos('Setter', 2, 5)] }))).toBe('1 of 1 covered')
+  })
+
+  // A tally is not a fraction of anything.
+  it('is absent when no position carries a target', () => {
+    expect(coveredSummary(roster({ positions: [pos('Setter', undefined, 3)] }))).toBeNull()
+    expect(coveredSummary(roster({ positions: [] }))).toBeNull()
+  })
+
+  it('ignores untargeted rows in the fraction', () => {
+    const r = roster({ positions: [pos('Setter', 2, 2), pos('Middle', undefined, 4)] })
+    expect(coveredSummary(r)).toBe('1 of 1 covered')
+  })
+})
+
+describe('rosterRows', () => {
+  it('draws one pip per required slot, filled left to right', () => {
+    const [row] = rosterRows(roster({ positions: [pos('Setter', 3, 2)] }))
+    expect(row.pips).toEqual(['filled', 'filled', 'open'])
+    expect(row.countLabel).toBe('2/3')
+    expect(row.tone).toBe('short')
+  })
+
+  // Every pip empty AND nobody attending is the alarm case, distinct from merely short.
+  it('marks every pip missing when the position has nobody', () => {
+    const [row] = rosterRows(roster({ positions: [pos('Libero', 2, 0)] }))
+    expect(row.pips).toEqual(['missing', 'missing'])
+    expect(row.countLabel).toBe('0/2')
+    expect(row.tone).toBe('critical')
+  })
+
+  it('fills every pip and reports the surplus when over-filled', () => {
+    const [row] = rosterRows(roster({ positions: [pos('Setter', 2, 5)] }))
+    // The surplus gets no pips of its own — it is the "+N", not extra slots the team asked for.
+    expect(row.pips).toEqual(['filled', 'filled'])
+    expect(row.surplus).toBe(3)
+    expect(row.tone).toBe('covered')
+  })
+
+  it('gives an untargeted position a plain count and no pips', () => {
+    const [row] = rosterRows(roster({ positions: [pos('Middle', undefined, 4)] }))
+    expect(row.pips).toEqual([])
+    expect(row.countLabel).toBe('4')
+    expect(row.surplus).toBe(0)
+    expect(row.tone).toBeNull()
+  })
+
+  // The server already ordered and filtered them; the panel must not reshuffle.
+  it('keeps the order the server sent', () => {
+    const r = roster({ positions: [pos('Zeta', 1, 1), pos('Alpha', 1, 1)] })
+    expect(rosterRows(r).map((row) => row.label)).toEqual(['Zeta', 'Alpha'])
+  })
+})
+
+describe('oneToChase', () => {
+  it('picks the first targeted position with nobody at all', () => {
+    const r = roster({
+      positions: [pos('Setter', 2, 1), pos('Libero', 1, 0), pos('Middle', 2, 0)],
+    })
+    expect(oneToChase(r)?.label).toBe('Libero')
+  })
+
+  // One name, not a list: a callout naming three positions is an inventory, and the rows already
+  // show the rest.
+  it('names only one even when several are empty', () => {
+    const r = roster({ positions: [pos('Libero', 1, 0), pos('Middle', 2, 0)] })
+    expect(oneToChase(r)?.label).toBe('Libero')
+  })
+
+  it('is absent when every targeted position has somebody', () => {
+    expect(oneToChase(roster({ positions: [pos('Setter', 3, 1)] }))).toBeNull()
+  })
+
+  it('never picks an untargeted position, however empty', () => {
+    expect(oneToChase(roster({ positions: [pos('Middle', undefined, 0)] }))).toBeNull()
+  })
+})
+
+describe('unassignedNudge', () => {
+  it('prompts when attendees have no position set', () => {
+    expect(unassignedNudge(roster({ unassignedAttending: 3 }))).toBe("3 going haven't set a position")
+  })
+
+  it('reads singular for one', () => {
+    expect(unassignedNudge(roster({ unassignedAttending: 1 }))).toBe("1 going hasn't set a position")
+  })
+
+  // A prompt, not a permanent label.
+  it('is absent when everyone coming has a position', () => {
+    expect(unassignedNudge(roster({ unassignedAttending: 0 }))).toBeNull()
+  })
+})
+
+describe('headcountLine', () => {
+  // The locked rule: a total set alongside position targets is secondary information in the panel,
+  // never the chip. This is where it surfaces.
+  it('shows the total as a secondary line when positions also carry targets', () => {
+    const r = roster({ totalTarget: 12, totalAttending: 7, positions: [pos('Setter', 2, 2)] })
+    expect(headcountLine(r)).toBe('7/12 going')
+  })
+
+  // Present with or without position targets — only *where* it renders differs (panel header when
+  // it is the only target, a secondary line beneath the rows when positions are targeted too).
+  it('is present when the total is the only target', () => {
+    const r = roster({ totalTarget: 12, totalAttending: 7, positions: [] })
+    expect(headcountLine(r)).toBe('7/12 going')
+  })
+
+  it('is absent when there is no total at all', () => {
+    expect(headcountLine(roster({ totalTarget: undefined }))).toBeNull()
+  })
+})

--- a/app/src/entities/event/lib/roster-view.ts
+++ b/app/src/entities/event/lib/roster-view.ts
@@ -1,0 +1,139 @@
+import type { EventRoster, RosterPosition } from '@shared/api/events'
+
+/**
+ * The roster panel's whole view model, derived from the server-computed roster.
+ *
+ * The backend owns the *status* (#219): it decides `state` and `openSlots`, and this module never
+ * re-derives them — it only turns those numbers into the words, tone and pips the card draws. Keep
+ * it that way; a second status implementation here would be free to drift from the tested one.
+ */
+
+/** Which semantic colour a chip or row carries. Mirrors the attendance palette: green / gold / red. */
+export type RosterTone = 'covered' | 'short' | 'critical'
+
+export interface RosterChip {
+  text: string
+  tone: RosterTone
+}
+
+const plural = (n: number, one: string, many: string) => (n === 1 ? one : many)
+
+/**
+ * The collapsed status chip, or null when the event shows none.
+ *
+ * Two states deliberately have no chip: tracking off is not a roster event at all, and a tally has
+ * nothing to fall short of, so a chip would invent a judgement the team never asked for. Both still
+ * differ from each other — the tally opens to a panel, the off event has none.
+ */
+export function rosterChip(roster: EventRoster): RosterChip | null {
+  switch (roster.state) {
+    case 'OFF':
+    case 'TALLY_ONLY':
+      return null
+    case 'LINEUP_SET':
+      return { text: 'Lineup set', tone: 'covered' }
+    // Same words either way — the count is the news. The tone is what says whether somebody is
+    // merely short or missing entirely, which is the difference between "chase later" and "chase now".
+    case 'SPOTS_OPEN':
+      return { text: `${roster.openSlots} ${plural(roster.openSlots, 'spot', 'spots')} open`, tone: 'short' }
+    case 'CRITICAL':
+      return { text: `${roster.openSlots} ${plural(roster.openSlots, 'spot', 'spots')} open`, tone: 'critical' }
+    case 'HEADCOUNT_FULL':
+      return { text: 'Full', tone: 'covered' }
+    case 'HEADCOUNT_SHORT':
+      return { text: `${roster.openSlots} more needed`, tone: 'short' }
+  }
+}
+
+/** True when there is a panel to open — everything except a roster that isn't tracked at all. */
+export function hasRosterPanel(roster: EventRoster): boolean {
+  return roster.trackRoster
+}
+
+/**
+ * "3 of 5 covered" for the panel header, or null when no position carries a target — a tally has
+ * nothing to be a fraction of.
+ */
+export function coveredSummary(roster: EventRoster): string | null {
+  const targeted = roster.positions.filter((p) => p.required != null)
+  if (targeted.length === 0) return null
+  const covered = targeted.filter((p) => p.attending >= (p.required ?? 0)).length
+  return `${covered} of ${targeted.length} covered`
+}
+
+/** One slot's dot. `missing` is an open slot at a position with nobody at all — drawn in alarm. */
+export type PipState = 'filled' | 'open' | 'missing'
+
+export interface RosterRow {
+  id: string
+  label: string
+  /** One entry per required slot. Empty for an untargeted position, which shows a plain count. */
+  pips: PipState[]
+  /** `2/3` for a targeted position, `2` for an untargeted one. */
+  countLabel: string
+  /** Attending beyond required, rendered as "+N". Zero when untargeted or short. */
+  surplus: number
+  tone: RosterTone | null
+}
+
+/**
+ * One row per position the server sent, in the order it sent them (the team's own vocabulary order).
+ * The server already dropped the positions that are neither targeted nor attended, so no filtering
+ * happens here — what arrives is what shows.
+ */
+export function rosterRows(roster: EventRoster): RosterRow[] {
+  return roster.positions.map((position) => ({
+    id: position.id,
+    label: position.label,
+    pips: pipsFor(position),
+    countLabel: position.required == null ? `${position.attending}` : `${position.attending}/${position.required}`,
+    surplus: position.required == null ? 0 : Math.max(0, position.attending - position.required),
+    tone: rowTone(position),
+  }))
+}
+
+function pipsFor(position: RosterPosition): PipState[] {
+  if (position.required == null) return []
+  // A pip per required slot, filled left to right. Surplus attendees get no pip of their own — they
+  // are the "+N", not an extra slot the team asked for.
+  return Array.from({ length: position.required }, (_, i) =>
+    i < position.attending ? 'filled' : position.attending === 0 ? 'missing' : 'open',
+  )
+}
+
+function rowTone(position: RosterPosition): RosterTone | null {
+  if (position.required == null) return null
+  if (position.attending === 0) return 'critical'
+  return position.attending >= position.required ? 'covered' : 'short'
+}
+
+/**
+ * The first targeted position with nobody at all — the "one to chase". Only the first: a callout
+ * naming three positions is a list, not a nudge, and the panel rows already show the rest.
+ */
+export function oneToChase(roster: EventRoster): RosterRow | null {
+  return rosterRows(roster).find((row) => row.pips.length > 0 && row.pips.every((p) => p === 'missing')) ?? null
+}
+
+/**
+ * The soft nudge under the rows when attendees have no position set. Null when everyone coming has
+ * one — this is a prompt, not a permanent label.
+ */
+export function unassignedNudge(roster: EventRoster): string | null {
+  const n = roster.unassignedAttending
+  if (n <= 0) return null
+  return `${n} going ${plural(n, "hasn't", "haven't")} set a position`
+}
+
+/**
+ * "7/12 going" whenever a headcount target exists at all.
+ *
+ * Where it lands depends on whether positions are also targeted: with them, the panel header belongs
+ * to the covered fraction and this becomes a secondary line beneath the rows; without them, the
+ * header is free and this fills it. Either way the chip already said "4 more needed" — the absolute
+ * numbers are what the panel adds.
+ */
+export function headcountLine(roster: EventRoster): string | null {
+  if (roster.totalTarget == null) return null
+  return `${roster.totalAttending}/${roster.totalTarget} going`
+}

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
-import { makeEvent } from '@shared/testing/event-fixtures'
+import { makeEvent, makeRoster } from '@shared/testing/event-fixtures'
 import { EventCard } from './EventCard'
 
 // EventCard renders a TanStack Router <Link to="/events/$eventId">, which needs a router in context.
@@ -87,6 +87,41 @@ export const SocialEvent: Story = {
     await expect(canvas.getByText(/11 going/)).toBeInTheDocument()
     // The 15th is the Saturday of the current week.
     await expect(canvas.getByText('This weekend')).toBeInTheDocument()
+    // A social tracks no roster, so the card carries no status chip and no way to open a panel.
+    await expect(canvas.queryByRole('button')).not.toBeInTheDocument()
+  },
+}
+
+// The roster disclosure in place on a real card (#219): the chip sits at the end of the attendance
+// row, collapsed, and the panel drops full-width beneath it. RosterDisclosure's own stories cover
+// every roster state; this one proves the composition — that the card gives it room and that tapping
+// the chip does not follow the card's stretched link.
+export const WithRosterChip: Story = {
+  args: {
+    event: makeEvent({
+      startTime: on(13, 14, 30),
+      location: 'Sportcentrum Noord',
+      roster: makeRoster({
+        state: 'CRITICAL',
+        openSlots: 2,
+        totalAttending: 5,
+        positions: [
+          { id: 'pos-setter', label: 'Setter', required: 2, attending: 2 },
+          { id: 'pos-libero', label: 'Libero', required: 1, attending: 0 },
+          { id: 'pos-middle', label: 'Middle', required: 2, attending: 1 },
+        ],
+      }),
+    }),
+  },
+  play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByText('2 spots open')).toBeInTheDocument()
+    // Collapsed on a list card until asked.
+    await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
+
+    await userEvent.click(canvas.getByRole('button', { name: /Show positions/ }))
+
+    await expect(canvas.getByText('1 of 3 covered')).toBeInTheDocument()
+    await expect(canvas.getByText(/still has no one/)).toBeInTheDocument()
   },
 }
 

--- a/app/src/entities/event/ui/EventCard.tsx
+++ b/app/src/entities/event/ui/EventCard.tsx
@@ -8,6 +8,7 @@ import { EventTypeBadge } from './EventTypeBadge'
 import { ReferenceChips } from './ReferenceChips'
 import { RelativeTimeLabel } from './RelativeTimeLabel'
 import { useTeamRoutes } from '@shared/lib/team-routes'
+import { RosterDisclosure } from './RosterDisclosure'
 
 interface EventCardProps {
   event: Event
@@ -88,8 +89,9 @@ export function EventCard({ event, index = 0, now = new Date() }: EventCardProps
         </div>
       </div>
 
-      {/* Attendance row. Sibling of the chit+body row, so its rule spans the full card width. */}
-      <div className="mt-3 flex items-center gap-2 border-t border-border/40 pt-3">
+      {/* Attendance row. Sibling of the chit+body row, so its rule spans the full card width.
+          `flex-wrap` so the roster panel, which is a full-width sibling of the chip, drops below. */}
+      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
         <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
           ✓ {s.attending} going
         </span>
@@ -102,6 +104,8 @@ export function EventCard({ event, index = 0, now = new Date() }: EventCardProps
             </>
           )}
         </span>
+        {/* Renders nothing at all when the event's type doesn't track a roster (a social). */}
+        <RosterDisclosure roster={event.roster} />
       </div>
     </Card>
   )

--- a/app/src/entities/event/ui/RosterDisclosure.stories.tsx
+++ b/app/src/entities/event/ui/RosterDisclosure.stories.tsx
@@ -1,0 +1,284 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import type { EventRoster, RosterPosition } from '@shared/api/events'
+import { makeRoster, NO_ROSTER } from '@shared/testing/event-fixtures'
+import { RosterDisclosure } from './RosterDisclosure'
+
+// The roster panel on an event card: a collapsed status chip that expands to per-position slot pips.
+// Prop-only (ADR-0017) — every number arrives already computed by the server, so each of the seven
+// roster states is just a different prop value and renders with no network.
+//
+// The states are the ones the backend can emit (RosterState), plus the two display cases that cut
+// across them: surplus and unassigned attendees.
+const pos = (label: string, required: number | undefined, attending: number): RosterPosition => ({
+  id: `pos-${label.toLowerCase()}`,
+  label,
+  required,
+  attending,
+})
+
+const LINEUP: EventRoster = makeRoster({
+  state: 'LINEUP_SET',
+  openSlots: 0,
+  totalAttending: 5,
+  positions: [pos('Setter', 2, 2), pos('Libero', 1, 1), pos('Middle', 2, 2)],
+})
+
+const meta = {
+  title: 'entities/event/RosterDisclosure',
+  component: RosterDisclosure,
+  args: { roster: LINEUP, defaultOpen: true },
+  // The card's attendance row is a flex line; the trigger sits at its end and the panel drops below.
+  decorators: [
+    (Story) => (
+      <div className="flex max-w-md flex-wrap items-center gap-2 rounded-xl border border-border bg-card p-3.5">
+        <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">✓ 5 going</span>
+        <span className="text-xs text-muted-foreground">of 12</span>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RosterDisclosure>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const LineupSet: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Lineup set')).toBeInTheDocument()
+    await expect(canvas.getByText('3 of 3 covered')).toBeInTheDocument()
+    // Setter and Middle both read 2/2; Libero is the 1/1.
+    await expect(canvas.getAllByText('2/2')).toHaveLength(2)
+    await expect(canvas.getByText('1/1')).toBeInTheDocument()
+    // Everyone is covered, so nobody is the one to chase.
+    await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
+  },
+}
+
+export const SpotsOpen: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'SPOTS_OPEN',
+      openSlots: 2,
+      totalAttending: 3,
+      positions: [pos('Setter', 2, 1), pos('Libero', 1, 1), pos('Middle', 2, 1)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('2 spots open')).toBeInTheDocument()
+    await expect(canvas.getByText('1 of 3 covered')).toBeInTheDocument()
+    // Short, but nobody is missing entirely — so no callout.
+    await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
+  },
+}
+
+// The red case. Same wording as SpotsOpen — the count is the news, the tone is the difference —
+// plus the callout naming who to chase.
+export const Critical: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'CRITICAL',
+      openSlots: 2,
+      totalAttending: 3,
+      positions: [pos('Setter', 2, 2), pos('Libero', 1, 0), pos('Middle', 2, 1)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('2 spots open')).toBeInTheDocument()
+    await expect(canvas.getByText(/still has no one/)).toBeInTheDocument()
+    await expect(canvas.getByText('Libero', { selector: 'b' })).toBeInTheDocument()
+    await expect(canvas.getByText('0/1')).toBeInTheDocument()
+  },
+}
+
+export const HeadcountOnly: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'HEADCOUNT_SHORT',
+      openSlots: 4,
+      totalTarget: 10,
+      totalAttending: 6,
+      positions: [pos('Setter', undefined, 4), pos('Middle', undefined, 2)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('4 more needed')).toBeInTheDocument()
+    // No position carries a target, so there is no covered fraction and no pips — plain counts only.
+    await expect(canvas.queryByText(/covered/)).not.toBeInTheDocument()
+    await expect(canvas.getByText('4')).toBeInTheDocument()
+    // With no fraction to show, the header carries the absolute headcount instead.
+    await expect(canvas.getByText('6/10 going')).toBeInTheDocument()
+  },
+}
+
+export const HeadcountFull: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'HEADCOUNT_FULL',
+      openSlots: 0,
+      totalTarget: 6,
+      totalAttending: 6,
+      positions: [pos('Setter', undefined, 6)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Full')).toBeInTheDocument()
+  },
+}
+
+// Tracking on, nothing required: the panel tallies who is coming and reports no judgement, so the
+// trigger reads "Positions" rather than a status chip.
+export const TallyOnly: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'TALLY_ONLY',
+      openSlots: 0,
+      totalTarget: undefined,
+      totalAttending: 5,
+      positions: [pos('Setter', undefined, 2), pos('Middle', undefined, 3)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Positions', { selector: 'span.text-xs' })).toBeInTheDocument()
+    await expect(canvas.queryByText(/spots open/)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/covered/)).not.toBeInTheDocument()
+    await expect(canvas.getByText('3')).toBeInTheDocument()
+  },
+}
+
+// A social. Not a roster event at all — no chip, no panel, and no affordance suggesting there is one.
+export const Off: Story = {
+  args: { roster: NO_ROSTER },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole('button')).not.toBeInTheDocument()
+    await expect(canvas.queryByText('Positions')).not.toBeInTheDocument()
+  },
+}
+
+// Over-fill reads as covered and shows the surplus, but never pays for a gap elsewhere: five setters
+// for two slots, and the empty libero still drives the status.
+export const WithSurplus: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'CRITICAL',
+      openSlots: 1,
+      totalAttending: 5,
+      positions: [pos('Setter', 2, 5), pos('Libero', 1, 0)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('+3')).toBeInTheDocument()
+    await expect(canvas.getByText('5/2')).toBeInTheDocument()
+    await expect(canvas.getByText('1 spot open')).toBeInTheDocument()
+    await expect(canvas.getByText(/still has no one/)).toBeInTheDocument()
+  },
+}
+
+// Nobody has a position yet, so the server sends no rows — but people ARE coming. "Nobody has
+// answered yet" would be a flat contradiction of the nudge right below it.
+export const AllAttendeesUnassigned: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'HEADCOUNT_SHORT',
+      openSlots: 4,
+      totalTarget: 10,
+      totalAttending: 6,
+      unassignedAttending: 6,
+      positions: [],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByText('Nobody has answered yet.')).not.toBeInTheDocument()
+    await expect(canvas.getByText("6 going haven't set a position")).toBeInTheDocument()
+    await expect(canvas.getByText('6/10 going')).toBeInTheDocument()
+  },
+}
+
+// The genuinely empty event, where the copy is true.
+export const NobodyAttending: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'TALLY_ONLY',
+      openSlots: 0,
+      totalTarget: undefined,
+      totalAttending: 0,
+      positions: [],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Nobody has answered yet.')).toBeInTheDocument()
+  },
+}
+
+// A position can require up to 99 (PositionSlots.MAX). The pips wrap rather than push the count off
+// the row — a training that wants 12 attendees must not break the card on a phone.
+export const WithManySlots: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'SPOTS_OPEN',
+      openSlots: 5,
+      totalAttending: 7,
+      positions: [pos('Squad', 12, 7)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('7/12')).toBeInTheDocument()
+    await expect(canvas.getByText('5 spots open')).toBeInTheDocument()
+  },
+}
+
+export const WithUnassigned: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'SPOTS_OPEN',
+      openSlots: 1,
+      totalAttending: 6,
+      unassignedAttending: 3,
+      positions: [pos('Setter', 2, 1), pos('Libero', 1, 1), pos('Middle', 2, 1)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("3 going haven't set a position")).toBeInTheDocument()
+  },
+}
+
+// A headcount set alongside position targets is secondary: the chip stays the lineup's, and the
+// total appears only inside the panel.
+export const BothAxes: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'SPOTS_OPEN',
+      openSlots: 1,
+      totalTarget: 12,
+      totalAttending: 7,
+      positions: [pos('Setter', 2, 1), pos('Libero', 1, 1)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('1 spot open')).toBeInTheDocument()
+    await expect(canvas.getByText('1 of 2 covered')).toBeInTheDocument()
+    await expect(canvas.getByText('7/12 going')).toBeInTheDocument()
+  },
+}
+
+// Collapsed is the default in the list: a roster panel per card would be a wall. The chip alone
+// carries the one-glance status, and the toggle is what reveals the rest.
+export const CollapsedByDefault: Story = {
+  args: { defaultOpen: false },
+  play: async ({ canvas, userEvent }) => {
+    const toggle = canvas.getByRole('button', { name: /Show positions/ })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(canvas.getByText('Lineup set')).toBeInTheDocument()
+    await expect(canvas.queryByText('3 of 3 covered')).not.toBeInTheDocument()
+
+    await userEvent.click(toggle)
+
+    await expect(canvas.getByRole('button', { name: /Hide positions/ })).toHaveAttribute('aria-expanded', 'true')
+    await expect(canvas.getByText('3 of 3 covered')).toBeInTheDocument()
+
+    // …and back, so the affordance is a real toggle rather than a one-way reveal.
+    await userEvent.click(canvas.getByRole('button', { name: /Hide positions/ }))
+    await expect(canvas.queryByText('3 of 3 covered')).not.toBeInTheDocument()
+  },
+}

--- a/app/src/entities/event/ui/RosterDisclosure.stories.tsx
+++ b/app/src/entities/event/ui/RosterDisclosure.stories.tsx
@@ -232,7 +232,10 @@ export const WithUnassigned: Story = {
   args: {
     roster: makeRoster({
       state: 'SPOTS_OPEN',
-      openSlots: 1,
+      // Setter is 1 short and Middle is 1 short, so the chip reads 2 — NOT 1. The three unassigned
+      // attendees cannot close either gap: nobody knows what they would play, which is the whole
+      // point of this story. They raise the headcount and drive the nudge, and that is all.
+      openSlots: 2,
       totalAttending: 6,
       unassignedAttending: 3,
       positions: [pos('Setter', 2, 1), pos('Libero', 1, 1), pos('Middle', 2, 1)],
@@ -240,6 +243,10 @@ export const WithUnassigned: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("3 going haven't set a position")).toBeInTheDocument()
+    // Pinned as an assertion, not left to the snapshot: the chip must report every unmet slot, and
+    // the unassigned three must not be silently credited against them.
+    await expect(canvas.getByText('2 spots open')).toBeInTheDocument()
+    await expect(canvas.getByText('1 of 3 covered')).toBeInTheDocument()
   },
 }
 

--- a/app/src/entities/event/ui/RosterDisclosure.tsx
+++ b/app/src/entities/event/ui/RosterDisclosure.tsx
@@ -1,0 +1,173 @@
+import { useId, useState } from 'react'
+import { ChevronDown, TriangleAlert } from 'lucide-react'
+import type { EventRoster } from '@shared/api/events'
+import {
+  coveredSummary,
+  hasRosterPanel,
+  headcountLine,
+  oneToChase,
+  rosterChip,
+  rosterRows,
+  unassignedNudge,
+  type PipState,
+  type RosterRow,
+  type RosterTone,
+} from '../lib/roster-view'
+
+interface RosterDisclosureProps {
+  roster: EventRoster
+  /** Start expanded. Collapsed by default so the panel never clutters the list. */
+  defaultOpen?: boolean
+}
+
+// Semantic colours, read against the attendance palette already on the card: green means "as it
+// should be" (attending / covered), gold "needs attention" (maybe / short), red "a problem"
+// (absent / nobody at all). Same three meanings, so a card carrying both reads as one language.
+const CHIP_TONE: Record<RosterTone, string> = {
+  covered: 'bg-green/15 text-green-dark',
+  short: 'bg-gold/20 text-gold-dark',
+  critical: 'bg-red/15 text-red-dark',
+}
+
+const DOT_TONE: Record<RosterTone, string> = {
+  covered: 'bg-green',
+  short: 'bg-gold',
+  critical: 'bg-red',
+}
+
+const COUNT_TONE: Record<RosterTone, string> = {
+  covered: 'text-green-dark',
+  short: 'text-gold-dark',
+  critical: 'text-red',
+}
+
+// A filled slot is a solid green dot; an open one an empty ring. A slot at a position with NOBODY
+// gets a red ring rather than a neutral one — the row is not merely short, it is unstaffed.
+const PIP_TONE: Record<PipState, string> = {
+  filled: 'bg-green border-green',
+  open: 'bg-transparent border-[#CDBFA6]',
+  missing: 'bg-transparent border-red',
+}
+
+/**
+ * The roster panel on an event card: a collapsed status chip that expands to per-position slot pips.
+ *
+ * Read-only for everyone (#219) — it answers the coach's "is my lineup covered?" and the player's
+ * "is my position needed?" with the same view. Collapsed by default so a list of events stays a list.
+ *
+ * Presentational and prop-only: every number arrives already computed by the server, and the pure
+ * mapping to words/pips lives in `../lib/roster-view`. The only state here is whether the panel is
+ * open, which is exactly the kind of local view state a story can drive.
+ */
+export function RosterDisclosure({ roster, defaultOpen = false }: RosterDisclosureProps) {
+  const [open, setOpen] = useState(defaultOpen)
+  const panelId = useId()
+
+  // Not a roster event at all: no chip, no panel, no affordance hinting there is one.
+  if (!hasRosterPanel(roster)) return null
+
+  const chip = rosterChip(roster)
+  const rows = rosterRows(roster)
+  const covered = coveredSummary(roster)
+  const chase = oneToChase(roster)
+  const nudge = unassignedNudge(roster)
+  const headcount = headcountLine(roster)
+
+  return (
+    <>
+      {/* relative z-10 lifts the trigger above the card link's stretched overlay, so tapping the
+          chip opens the panel instead of navigating to the event. */}
+      <button
+        type="button"
+        aria-expanded={open}
+        // Only while the panel exists: aria-controls pointing at an unmounted id is a dangling
+        // reference. aria-expanded still carries the state when collapsed.
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((o) => !o)}
+        className="relative z-10 ml-auto flex shrink-0 items-center gap-1.5 rounded-full py-1 pl-1 pr-0.5 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        {chip ? (
+          <span
+            className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold ${CHIP_TONE[chip.tone]}`}
+          >
+            <span className={`size-1.5 rounded-full ${DOT_TONE[chip.tone]}`} aria-hidden />
+            {chip.text}
+          </span>
+        ) : (
+          // A tally has no status to report, but the rows are still worth a look.
+          <span className="text-xs font-semibold text-muted-foreground">Positions</span>
+        )}
+        <ChevronDown
+          size={15}
+          aria-hidden
+          className={`text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+        <span className="sr-only">{open ? 'Hide positions' : 'Show positions'}</span>
+      </button>
+
+      {open && (
+        // relative z-10, like the trigger: without it the whole panel sits under EventCard's
+        // after:inset-0 stretched link, and tapping a position row navigates to the event.
+        <div id={panelId} className="relative z-10 mt-3 w-full border-t border-dashed border-border pt-3">
+          <div className="mb-2.5 flex items-center justify-between">
+            <span className="text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground">
+              Positions
+            </span>
+            <span className="text-[11px] font-bold text-foreground/70">{covered ?? headcount ?? ''}</span>
+          </div>
+
+          {rows.length === 0 ? (
+            // No rows does NOT mean nobody is coming: attendees with no position get no row of their
+            // own (the nudge below speaks for them), so only an empty event earns this copy.
+            roster.totalAttending === 0 && (
+              <p className="text-[12.5px] text-muted-foreground">Nobody has answered yet.</p>
+            )
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {rows.map((row) => (
+                <PositionRow key={row.id} row={row} />
+              ))}
+            </ul>
+          )}
+
+          {/* The secondary "X/Y going" — shown only when a headcount sits alongside position targets,
+              where the covered fraction already owns the header. */}
+          {covered && headcount && (
+            <p className="mt-2.5 text-[11.5px] text-muted-foreground">{headcount}</p>
+          )}
+
+          {chase && (
+            <p className="mt-2.5 flex items-start gap-1.5 rounded-[10px] bg-gold/15 px-2.5 py-2 text-[11.5px] text-foreground/80">
+              <TriangleAlert size={13} className="mt-0.5 shrink-0 text-gold-dark" aria-hidden />
+              <span>
+                <b>{chase.label}</b> still has no one — the one to chase.
+              </span>
+            </p>
+          )}
+
+          {nudge && <p className="mt-2 text-[11.5px] text-muted-foreground">{nudge}</p>}
+        </div>
+      )}
+    </>
+  )
+}
+
+function PositionRow({ row }: { row: RosterRow }) {
+  return (
+    <li className="grid grid-cols-[70px_1fr_auto] items-center gap-2.5">
+      <span className="truncate text-[12.5px] text-foreground/80">{row.label}</span>
+      <span className="flex flex-wrap items-center gap-1.5">
+        {row.pips.map((pip, i) => (
+          // Pips are decoration for the count beside them, which carries the same fact as text.
+          <i key={i} aria-hidden className={`block size-[13px] rounded-full border-[1.5px] ${PIP_TONE[pip]}`} />
+        ))}
+        {row.surplus > 0 && <span className="text-[11px] font-semibold text-green-dark">+{row.surplus}</span>}
+      </span>
+      <span
+        className={`text-right text-xs font-bold tabular-nums ${row.tone ? COUNT_TONE[row.tone] : 'text-muted-foreground'}`}
+      >
+        {row.countLabel}
+      </span>
+    </li>
+  )
+}

--- a/app/src/shared/testing/event-fixtures.ts
+++ b/app/src/shared/testing/event-fixtures.ts
@@ -25,8 +25,40 @@ export const NO_ROSTER: EventRoster = {
 /**
  * A computed roster, defaulting to a tracked lineup that is one short — the state a roster story
  * usually wants a starting point for. Pass overrides to move it to any other state.
+ *
+ * Keeps `openSlots` honest against the positions, because the server does not treat them as
+ * independent: whenever any position is targeted it derives `openSlots` as the sum of unmet slots
+ * (RosterFill.openSlots), so a fixture stating anything else depicts a payload the API cannot emit.
+ * That is not a harmless fiction — a story becomes a Chromatic baseline, so an impossible state gets
+ * approved as the expected one and a reviewer is asked to sign off on arithmetic the product never
+ * produces. Exactly that happened: `WithUnassigned` claimed 1 open slot across two unfilled
+ * positions, and only a human reading the screenshot caught it.
+ *
+ * So: **derive it when the caller did not ask for one**, which is what a test overriding only
+ * `positions` wants, and **throw when the caller states one that contradicts them**, which is the
+ * case worth failing loudly. Untargeted positions are left alone — the headcount drives there, and
+ * `openSlots` is its shortfall, which says nothing about the rows.
  */
 export function makeRoster(overrides: Partial<EventRoster> = {}): EventRoster {
+  const roster = makeRosterUnchecked(overrides)
+  const targeted = roster.positions.filter((p) => p.required != null)
+  if (targeted.length === 0) return roster
+
+  const unmet = targeted.reduce((sum, p) => sum + Math.max(0, (p.required ?? 0) - p.attending), 0)
+  if (!('openSlots' in overrides)) return { ...roster, openSlots: unmet }
+
+  if (unmet !== roster.openSlots) {
+    throw new Error(
+      `makeRoster: openSlots ${roster.openSlots} contradicts its positions, which leave ${unmet} ` +
+        `slot(s) unmet. The server sums unmet slots whenever positions are targeted, so this ` +
+        `roster could never arrive from the API. Fix the number, or drop the targets if the ` +
+        `fixture means to exercise the headcount axis instead.`,
+    )
+  }
+  return roster
+}
+
+function makeRosterUnchecked(overrides: Partial<EventRoster> = {}): EventRoster {
   return {
     trackRoster: true,
     totalTarget: undefined,


### PR DESCRIPTION
Step 3 of 4 for #219. #226 has **merged**, so this is now based on `main` and the diff is frontend-only.

**Depends on #214**, which landed in #217: this attaches to the date-block `EventCard` that PR introduced. The admin authoring surface is the last PR in the stack (#228).

## What it looks like

The card's attendance row gains a collapsed status chip; tapping it opens a per-position slot-pips panel. The **critical** state — a position sitting at zero, with the callout naming who to chase:

```
✓ 5 going   of 12                        ● 2 spots open  ⌃
─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
POSITIONS                                1 of 3 covered
Setter    ●●                                        2/2      ← green
Libero    ○                                         0/1      ← red ring, red count
Middle    ●○                                        1/2      ← gold
⚠ Libero still has no one — the one to chase.
```

Read-only for everyone, which is the point: the same view answers the coach's "is my lineup covered?" and the player's "is my position needed?". Collapsed by default so a list of events stays a list.

## The rules it renders

- **"Lineup set"** when every targeted position is covered; **"N spots open"** when not — the same words whether or not somebody is missing entirely, because the count is the news. The **tone** is what separates "chase later" (gold) from "chase now" (red, a position at zero), and the panel then names the one to chase.
- A lone headcount reads **"N more needed" / "Full"** instead.
- **Two states show no chip at all**: a social is not a roster event, and a tally has nothing to fall short of. The tally still *opens a panel*, which is what makes those two visibly different rather than both looking like "nothing here".
- Rows draw one pip per required slot, filled left to right; an unstaffed position gets **red** rings rather than neutral ones. **Surplus** is a "+N" beside the pips, never extra slots the team never asked for. Untargeted positions show a plain count and no pips.
- A **headcount alongside position targets** appears only as a secondary line inside the panel — never as the chip.

The panel derives **nothing**: `state` and `openSlots` arrive computed from #226 and this code only turns them into words, tone and pips. A second status implementation here would be free to drift from the tested one.

## One change outside the feature

`global.css` gains the dark ramps and `red`. They were already in `design-tokens/tokens.css`, but only the lightest few had been promoted into `@theme` — and Tailwind 4 generates a utility only for what `@theme` declares, so `text-red` and `text-green-dark` were silently producing nothing. (It's also why `ManagePositionsView` reaches for Tailwind's stock `text-red-500` rather than the token red.)

Worth flagging because of *how* it was caught: not by any assertion, but by building the stories and screenshotting them. Every test was green while the critical pip rendered black. That's precisely the gap Chromatic exists to cover, and a good argument for the gate.

The roster's green/gold/red are the attendance palette's three meanings — *as it should be* / *needs attention* / *a problem* — so a card carrying both reads as one language. That's the colour reconciliation the issue deferred to the visual pass.

## Contrast: measured, and deliberately deferred

Measured against the card background:

| State | Dark | Light |
|---|---|---|
| covered (green) | 2.84:1 | ok |
| critical (red) | 3.03:1 | ok |
| **short (gold)** | ok | **2.41:1 — below the 3:1 WCAG AA non-text threshold** |

**Decision: shipping as-is.** The gold token is **pre-existing** — the same one the attendance "maybe" state already uses on `main` — so this PR makes it more visible rather than introducing it. It is being tracked as part of a **separate, app-wide contrast pass** covering the other instances found elsewhere, which is the right shape for a token-level fix: darkening it here would move the attendance chips too, for a problem that predates this PR.

Note the pips encode the same information as shape, not just colour, so what remains is a legibility issue rather than colour being the sole carrier of meaning.

## Testing

- **Vitest units** (`roster-view.test.ts`, 26 cases) — the numbers→words/pips rules: chip wording and tone per state, pluralisation ("1 spot" vs "3 spots"), the covered fraction, pip filling and the missing-vs-open distinction, surplus, one-to-chase selection (first only, never an untargeted position), the unassigned nudge, and the headcount line.
- **Storybook** — every roster state as its own story: lineup-set, spots-open, critical, headcount-only, headcount-full, tally-only, off, with-surplus, with-unassigned, both-axes, all-attendees-unassigned, nobody-attending, many-slots — plus the collapse/expand toggle asserting `aria-expanded` both ways. An `EventCard` story proves the composition in place, and the social story asserts the card carries *no* chip at all.
- **No new e2e.** The card reads the events payload the list already fetches, and expanding is local view state — no new auth, cross-tenant or integration seam. Step 4's admin write path is where that's worth reconsidering.

Verified on the rebased branch: **605 frontend tests / 93 files** (main's baseline is 564 / 91; this adds `roster-view.test.ts` and `RosterDisclosure.stories.tsx`), **601 backend** unchanged as expected for a frontend-only PR, plus the `processAot` build gate, detekt, `tsc` and ESLint clean.

Refs #219.