### PR TITLE
feat: event-type CRUD, roster authoring and per-event override (#219)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventTypeService.kt
@@ -1,12 +1,148 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.exception.CannotArchiveLastEventTypeException
+import com.github.zzave.teambalance.api.domain.exception.EventTypeNameTakenException
+import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
+import com.github.zzave.teambalance.api.domain.exception.MigrationTargetInvalidException
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
+import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.port.PositionRepository
 
+/**
+ * Event types and the roster defaults they carry (#219).
+ *
+ * Framework-free like its siblings (ADR-0018): one call to a port method is one transaction, so a
+ * use case that must write several rows as a unit hands them over in a single call.
+ */
 class EventTypeService(
     private val eventTypeRepository: EventTypeRepository,
+    private val positionRepository: PositionRepository,
+    private val authorizationService: AuthorizationService,
 ) {
-    fun findAll(): List<EventType> = eventTypeRepository.findAll()
+    /**
+     * The team's event types. Archived ones are excluded unless [includeArchived] — that exclusion is
+     * the whole mechanism of archiving: the type vanishes from every picker while the events holding
+     * it keep rendering with it.
+     */
+    fun findAll(includeArchived: Boolean = false): List<EventType> =
+        eventTypeRepository.findAll().filter { includeArchived || !it.archived }
+
     fun findById(id: EventTypeId): EventType? = eventTypeRepository.findById(id)
+
+    /** Admin-only. Names are unique per team, case-insensitively — the same rule positions follow. */
+    fun createEventType(
+        callerId: UserId,
+        teamId: TeamId,
+        name: EventTypeName,
+        color: HexColor?,
+        rosterDefault: RosterRequirement,
+    ): EventType {
+        authorizationService.requireAdmin(callerId, teamId)
+        requireNotBlank(name)
+        requireNameFree(name, excludingId = null)
+        requireKnownPositions(rosterDefault)
+        return eventTypeRepository.create(name = name, color = color, rosterDefault = rosterDefault)
+    }
+
+    /**
+     * Admin-only. A whole replacement of the type's editable fields. Editing the roster default here
+     * is what moves every *inheriting* event with it — the events resolve their requirement on read,
+     * so nothing is rewritten and nothing needs to be.
+     */
+    fun updateEventType(
+        callerId: UserId,
+        teamId: TeamId,
+        id: EventTypeId,
+        name: EventTypeName,
+        color: HexColor?,
+        rosterDefault: RosterRequirement,
+    ): EventType {
+        authorizationService.requireAdmin(callerId, teamId)
+        val existing = eventTypeRepository.findById(id) ?: throw EventTypeNotFoundException(id)
+        requireNotBlank(name)
+        requireNameFree(name, excludingId = existing.id)
+        requireKnownPositions(rosterDefault)
+        return eventTypeRepository.update(id = id, name = name, color = color, rosterDefault = rosterDefault)
+    }
+
+    /**
+     * Admin-only. Archives a type, optionally moving its events onto another **active** type first.
+     *
+     * Archiving is destructive in the sense that matters to a team — the type disappears from the
+     * pickers — but never to data: an [com.github.zzave.teambalance.api.domain.model.Event]'s type is
+     * non-null, so this can neither orphan nor cascade-delete an event. Without a migration target
+     * the existing events simply keep the archived type and keep rendering with it.
+     *
+     * The last active type cannot be archived: with none left, creating an event becomes impossible
+     * and the team is stuck with no way out through the UI.
+     */
+    fun archiveEventType(
+        callerId: UserId,
+        teamId: TeamId,
+        id: EventTypeId,
+        migrateEventsTo: EventTypeId?,
+    ): EventType {
+        authorizationService.requireAdmin(callerId, teamId)
+        val target = eventTypeRepository.findById(id) ?: throw EventTypeNotFoundException(id)
+        if (target.archived) return target
+
+        val remainingActive = findAll().filterNot { it.id == id }
+        if (remainingActive.isEmpty()) throw CannotArchiveLastEventTypeException()
+        migrateEventsTo?.let { requireValidMigrationTarget(it, from = id, activeTypes = remainingActive) }
+
+        // One call, one transaction: the reassignment and the archive commit together, so a failure
+        // can never leave events pointing at a type that is already hidden from every picker.
+        return eventTypeRepository.archive(id = id, migrateEventsTo = migrateEventsTo)
+    }
+
+    /** Admin-only. Puts an archived type back in the pickers — the counterpart that makes it a soft delete. */
+    fun unarchiveEventType(callerId: UserId, teamId: TeamId, id: EventTypeId): EventType {
+        authorizationService.requireAdmin(callerId, teamId)
+        val existing = eventTypeRepository.findById(id) ?: throw EventTypeNotFoundException(id)
+        if (!existing.archived) return existing
+        // A name freed up while the type was archived may since have been taken by a new one.
+        requireNameFree(existing.name, excludingId = existing.id)
+        return eventTypeRepository.unarchive(id)
+    }
+
+    // The length cap lives on EventTypeName itself (so it holds however a name arrives); "not blank"
+    // is a write-path rule, exactly as it is for a position label.
+    private fun requireNotBlank(name: EventTypeName) {
+        require(name.value.isNotBlank()) { "Event type name must not be blank" }
+    }
+
+    // Archived types are included: two types may not share a name even when one of them is hidden,
+    // or unarchiving would silently produce a duplicate the pickers cannot tell apart.
+    private fun requireNameFree(name: EventTypeName, excludingId: EventTypeId?) {
+        val taken = eventTypeRepository.findAll()
+            .any { it.id != excludingId && it.name.value.equals(name.value, ignoreCase = true) }
+        if (taken) throw EventTypeNameTakenException(name.value)
+    }
+
+    private fun requireValidMigrationTarget(target: EventTypeId, from: EventTypeId, activeTypes: List<EventType>) {
+        if (target == from) throw MigrationTargetInvalidException("an event type cannot be migrated to itself")
+        if (activeTypes.none { it.id == target }) {
+            // Unknown or archived, which are the same thing to an admin picking from a list of active
+            // types: either way the events would land somewhere they cannot be found again.
+            throw MigrationTargetInvalidException("the migration target must be an active event type")
+        }
+    }
+
+    // Mirrors EventService.requireKnownPositions, and for the same reason: the foreign key on
+    // event_type_position_targets.position_id is what actually keeps an unknown position out, but it
+    // would surface as a 500. This turns it into the declared 400 (UNKNOWN_ROSTER_POSITION) before
+    // the write is attempted. Takes no team id since ADR-0025 — the tenant schema is the team.
+    private fun requireKnownPositions(requirement: RosterRequirement) {
+        if (requirement.positionTargets.isEmpty()) return
+        val known: Set<PositionId> = positionRepository.list().map { it.id }.toSet()
+        requirement.positionTargets.firstOrNull { it.positionId !in known }
+            ?.let { throw com.github.zzave.teambalance.api.domain.exception.UnknownRosterPositionException(it.positionId) }
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/PositionService.kt
@@ -7,10 +7,18 @@ import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.model.PositionLabel
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.EventRepository
+import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.domain.model.PositionUsage
+import com.github.zzave.teambalance.api.domain.model.UsageCount
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 
 class PositionService(
     private val positionRepository: PositionRepository,
+    private val eventTypeRepository: EventTypeRepository,
+    private val eventRepository: EventRepository,
+    private val teamMemberRepository: TeamMemberRepository,
     private val authorizationService: AuthorizationService,
 ) {
     /**
@@ -39,10 +47,29 @@ class PositionService(
     }
 
     /**
+     * What deleting [id] would touch (#219): the type defaults and event overrides that name it, and
+     * the members who hold it. The admin confirmation states these before proceeding — the delete is
+     * still allowed, so this is a warning, not a veto, and it exists so the warning names real
+     * numbers instead of gesturing at "some types and members".
+     *
+     * Admin-only, because it is the delete's own dialog that reads it.
+     */
+    fun positionUsage(callerId: UserId, teamId: TeamId, id: PositionId): PositionUsage {
+        authorizationService.requireAdmin(callerId, teamId)
+        if (!positionRepository.exists(id)) throw PositionNotFoundException(id)
+        return PositionUsage(
+            eventTypeCount = UsageCount(eventTypeRepository.countTargetsForPosition(id)),
+            eventCount = UsageCount(eventRepository.countTargetsForPosition(id)),
+            memberCount = UsageCount(teamMemberRepository.countByPosition(teamId, id)),
+        )
+    }
+
+    /**
      * Admin-only. Deletes a position. Everything that referenced it goes with it, and none of that is
      * this method's work any more (ADR-0026): members assigned to it become Unassigned via
      * `member_profiles`' ON DELETE SET NULL, and the position drops out of every event type's roster
-     * default and every event's roster override via those tables' ON DELETE CASCADE.
+     * default and every event's roster override via those tables' ON DELETE CASCADE. Deleting is
+     * destructive by design — the admin UI warns what it is about to touch, using [positionUsage].
      *
      * That used to be three ordered writes in this service, in a deliberate order — targets first,
      * because a deleted position still named by a live target is unrecoverable while the reverse is

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -30,6 +30,11 @@ class InvalidSlugException(message: String) : BadRequestException(message, "INVA
 class UnknownRosterPositionException(id: PositionId) :
     BadRequestException("Roster requirement names an unknown position: $id", "UNKNOWN_ROSTER_POSITION")
 
+// The migration target offered when archiving an event type must be a different, still-active type
+// (#219) — anything else would move the events somewhere nobody can find them again.
+class MigrationTargetInvalidException(reason: String) :
+    BadRequestException("Invalid migration target: $reason", "INVALID_MIGRATION_TARGET")
+
 sealed class NotFoundException(message: String) : TeambalanceException(message)
 
 class EventNotFoundException(id: EventId) : NotFoundException("Event not found: $id")
@@ -117,6 +122,16 @@ class LastAdminException(teamId: TeamId) :
 
 class PositionLabelTakenException(label: String) :
     ConflictException("Position '$label' already exists in this team", "POSITION_LABEL_TAKEN")
+
+// Event-type names are unique per team case-insensitively, the same rule positions follow. Archived
+// types count: two types sharing a name would become indistinguishable the moment one is restored.
+class EventTypeNameTakenException(name: String) :
+    ConflictException("Event type '$name' already exists in this team", "EVENT_TYPE_NAME_TAKEN")
+
+// Archiving the last active type would leave no type to create an event with, and no way back
+// through the UI (#219). The team must keep at least one, exactly as it must keep one admin.
+class CannotArchiveLastEventTypeException :
+    ConflictException("A team must keep at least one active event type", "LAST_EVENT_TYPE")
 
 // A team with this slug (and therefore this derived schema) already exists. No auto-suffixing — the
 // caller picks a different name.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventTypeName.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventTypeName.kt
@@ -1,7 +1,21 @@
 package com.github.zzave.teambalance.api.domain.model
 
-/** The name of an [EventType]. */
+/**
+ * The name of an [EventType] ("Match", "Training").
+ *
+ * The length cap lives here rather than only on the write path, so it also holds for names the JPA
+ * mapper builds — and, more to the point, so a 101-character name is a 400 from the value object
+ * instead of a 500 from `VARCHAR(100)`. Mirrors [PositionLabel], whose column it matches.
+ */
 @JvmInline
 value class EventTypeName(val value: String) {
+    init {
+        require(value.length <= MAX_LENGTH) { "Event type name must be at most $MAX_LENGTH characters" }
+    }
+
     override fun toString(): String = value
+
+    companion object {
+        const val MAX_LENGTH = 100
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/PositionUsage.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/PositionUsage.kt
@@ -1,0 +1,32 @@
+package com.github.zzave.teambalance.api.domain.model
+
+/**
+ * How many things of one kind name a position — the unit the delete warning counts in.
+ *
+ * A count, not a target: [PositionSlots] is how many people a position *wants*, this is how many
+ * rows *refer* to it. Separate types so the two can never be handed to each other.
+ */
+@JvmInline
+value class UsageCount(val value: Int) {
+    init {
+        require(value >= 0) { "A usage count cannot be negative, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+/**
+ * What a position is currently used by, so a delete confirmation can name real numbers instead of
+ * gesturing at "some types and members" (#219).
+ *
+ * A warning, not a veto: the delete proceeds regardless, cascading the targets away and leaving the
+ * members Unassigned. This exists so the admin knows what that will cost before they agree to it.
+ */
+data class PositionUsage(
+    /** Event-type roster defaults naming this position. */
+    val eventTypeCount: UsageCount,
+    /** Event roster overrides naming this position. */
+    val eventCount: UsageCount,
+    /** Active members holding it, who would become Unassigned. */
+    val memberCount: UsageCount,
+)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
@@ -29,4 +29,7 @@ interface EventRepository {
     fun deleteById(id: EventId)
     fun deleteAllById(ids: List<EventId>)
 
+
+    /** How many event roster overrides name [positionId] — half of the position-delete warning. */
+    fun countTargetsForPosition(positionId: PositionId): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventTypeRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventTypeRepository.kt
@@ -2,8 +2,35 @@ package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
+import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 
 interface EventTypeRepository {
+    /** Every type, archived included — callers decide what to hide. */
     fun findAll(): List<EventType>
     fun findById(id: EventTypeId): EventType?
+
+    fun create(name: EventTypeName, color: HexColor?, rosterDefault: RosterRequirement): EventType
+
+    /** Replaces the type's editable fields. Archived state is not among them — see [archive]. */
+    fun update(id: EventTypeId, name: EventTypeName, color: HexColor?, rosterDefault: RosterRequirement): EventType
+
+    /**
+     * Archives [id], first reassigning every event of that type to [migrateEventsTo] when given.
+     *
+     * ONE call, so the reassignment and the archive commit together — a partial failure must never
+     * leave events pointing at a type that is already hidden from every picker.
+     */
+    fun archive(id: EventTypeId, migrateEventsTo: EventTypeId?): EventType
+
+    fun unarchive(id: EventTypeId): EventType
+
+    /** How many events currently hold this type — what the archive dialog reports before migrating. */
+    fun countEventsOfType(id: EventTypeId): Int
+
+    /** How many type roster defaults name [positionId] — half of the position-delete warning. */
+    fun countTargetsForPosition(positionId: PositionId): Int
+
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -66,4 +66,7 @@ interface TeamMemberRepository {
 
     /** Number of active ADMIN members on the team. */
     fun countAdmins(teamId: TeamId): Int
+
+    /** Active members currently assigned [positionId] — what a position delete would leave Unassigned. */
+    fun countByPosition(teamId: TeamId, positionId: PositionId): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/EventCompositionRoot.kt
@@ -45,6 +45,16 @@ class EventCompositionRoot {
     )
 
     // Event types are the events area's reference data — EventService resolves one on every write.
+    // PositionRepository is here for the same reason it is on EventService: a roster default must
+    // name positions this team actually has (#219).
     @Bean
-    fun eventTypeService(eventTypeRepository: EventTypeRepository) = EventTypeService(eventTypeRepository)
+    fun eventTypeService(
+        eventTypeRepository: EventTypeRepository,
+        positionRepository: PositionRepository,
+        authorizationService: AuthorizationService,
+    ) = EventTypeService(
+        eventTypeRepository = eventTypeRepository,
+        positionRepository = positionRepository,
+        authorizationService = authorizationService,
+    )
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/MembershipCompositionRoot.kt
@@ -43,9 +43,15 @@ class MembershipCompositionRoot {
     @Bean
     fun positionService(
         positionRepository: PositionRepository,
+        eventTypeRepository: EventTypeRepository,
+        eventRepository: EventRepository,
+        teamMemberRepository: TeamMemberRepository,
         authorizationService: AuthorizationService,
     ) = PositionService(
         positionRepository = positionRepository,
+        eventTypeRepository = eventTypeRepository,
+        eventRepository = eventRepository,
+        teamMemberRepository = teamMemberRepository,
         authorizationService = authorizationService,
     )
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -73,6 +73,10 @@ class JpaEventRepositoryAdapter(
     @Transactional
     override fun deleteAllById(ids: List<EventId>) = ids.forEach { remove(it) }
 
+    @Transactional(readOnly = true)
+    override fun countTargetsForPosition(positionId: PositionId): Int =
+        jpaRepository.countPositionTargets(positionId.value)
+
     private fun persist(event: Event): Event {
         val eventTypeEntity = eventTypeJpaRepository.findByUuid(event.eventType.id.value)
             ?: throw EventTypeNotFoundException(event.eventType.id)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventTypeRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventTypeRepositoryAdapter.kt
@@ -1,21 +1,125 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
+import com.github.zzave.teambalance.api.domain.exception.EventTypeNotFoundException
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
 import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
+import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalizeTargets
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.util.UUID
 
+/**
+ * As with [JpaEventRepositoryAdapter], the transactional boundary sits here: one call to a port
+ * method is one transaction. Reads are transactional too — `open-in-view` is off, and the eager
+ * `positionTargets` collection is mapped after the query, which needs the session still open.
+ */
+@Suppress("TooManyFunctions") // One per port method; splitting the port to satisfy a count would be artificial.
 @Repository
 class JpaEventTypeRepositoryAdapter(
     private val jpaRepository: SpringDataEventTypeRepository,
+    private val eventJpaRepository: SpringDataEventRepository,
+    private val clock: Clock,
 ) : EventTypeRepository {
 
+    @Transactional(readOnly = true)
     override fun findAll(): List<EventType> =
-        jpaRepository.findAll().map { it.internalize() }
+        jpaRepository.findAll().sortedBy { it.id }.map { it.internalize() }
 
+    @Transactional(readOnly = true)
     override fun findById(id: EventTypeId): EventType? =
         jpaRepository.findByUuid(id.value)?.internalize()
+
+    @Transactional
+    override fun create(name: EventTypeName, color: HexColor?, rosterDefault: RosterRequirement): EventType =
+        jpaRepository.save(
+            EventTypeJpaEntity(
+                uuid = UUID.randomUUID(),
+                name = name.value,
+                color = color?.value,
+                archived = false,
+                trackRoster = rosterDefault.trackRoster,
+                totalTarget = rosterDefault.totalTarget?.value,
+                positionTargets = rosterDefault.positionTargets.externalizeTargets(),
+                createdAt = clock.instant(),
+            ),
+        ).internalize()
+
+    // The entity is immutable (all `val`), so an update is a save of a fresh instance carrying the
+    // same technical id, uuid and createdAt — the same shape JpaEventRepositoryAdapter.persist uses.
+    @Transactional
+    override fun update(
+        id: EventTypeId,
+        name: EventTypeName,
+        color: HexColor?,
+        rosterDefault: RosterRequirement,
+    ): EventType {
+        val existing = jpaRepository.findByUuid(id.value) ?: throw EventTypeNotFoundException(id)
+        return jpaRepository.save(
+            existing.copyWith(
+                name = name.value,
+                color = color?.value,
+                archived = existing.archived,
+                rosterDefault = rosterDefault,
+            ),
+        ).internalize()
+    }
+
+    /**
+     * Reassign-then-archive in ONE transaction. The reassignment is a bulk update that bypasses the
+     * persistence context, so `clearAutomatically` keeps the archive's read of the same rows honest.
+     */
+    @Transactional
+    override fun archive(id: EventTypeId, migrateEventsTo: EventTypeId?): EventType {
+        val existing = jpaRepository.findByUuid(id.value) ?: throw EventTypeNotFoundException(id)
+        migrateEventsTo?.let { targetUuid ->
+            val target = jpaRepository.findByUuid(targetUuid.value) ?: throw EventTypeNotFoundException(targetUuid)
+            eventJpaRepository.reassignEventType(fromTypeId = existing.id, toTypeId = target.id)
+        }
+        return jpaRepository.save(existing.copyWith(archived = true)).internalize()
+    }
+
+    @Transactional
+    override fun unarchive(id: EventTypeId): EventType {
+        val existing = jpaRepository.findByUuid(id.value) ?: throw EventTypeNotFoundException(id)
+        return jpaRepository.save(existing.copyWith(archived = false)).internalize()
+    }
+
+    @Transactional(readOnly = true)
+    override fun countEventsOfType(id: EventTypeId): Int {
+        val existing = jpaRepository.findByUuid(id.value) ?: return 0
+        return eventJpaRepository.countByEventTypeId(existing.id)
+    }
+
+    @Transactional(readOnly = true)
+    override fun countTargetsForPosition(positionId: PositionId): Int =
+        jpaRepository.countPositionTargets(positionId.value)
+
+    @Transactional
+
+    // Identity (technical id, uuid, createdAt) is carried over verbatim; only the editable fields and
+    // the archived flag move. Named rather than a data-class copy because the entity is a JPA class.
+    private fun EventTypeJpaEntity.copyWith(
+        name: String = this.name,
+        color: String? = this.color,
+        archived: Boolean = this.archived,
+        rosterDefault: RosterRequirement? = null,
+    ) = EventTypeJpaEntity(
+        id = id,
+        uuid = uuid,
+        name = name,
+        color = color,
+        archived = archived,
+        trackRoster = rosterDefault?.trackRoster ?: trackRoster,
+        totalTarget = if (rosterDefault != null) rosterDefault.totalTarget?.value else totalTarget,
+        positionTargets = rosterDefault?.positionTargets?.externalizeTargets() ?: positionTargets,
+        createdAt = createdAt,
+    )
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -137,6 +137,9 @@ class JpaTeamMemberRepositoryAdapter(
 
     override fun countAdmins(teamId: TeamId): Int = jpaRepository.countActiveAdmins(teamId.value)
 
+    override fun countByPosition(teamId: TeamId, positionId: PositionId): Int =
+        jpaRepository.countActiveByPosition(teamId.value, positionId.value)
+
     @Transactional
     override fun addMember(teamId: TeamId, userId: UserId) {
         if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId.value, userId.value) != null) return

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
@@ -14,4 +14,20 @@ interface SpringDataEventRepository : JpaRepository<EventJpaEntity, Long> {
     fun findByStartTimeGreaterThanOrderByStartTimeAsc(since: Instant): List<EventJpaEntity>
     fun findAllByOrderByStartTimeDesc(): List<EventJpaEntity>
     fun findByRecurringGroupOrderByStartTimeAsc(recurringGroup: UUID): List<EventJpaEntity>
+
+    fun countByEventTypeId(eventTypeId: Long): Int
+
+    /** How many event roster overrides name this position — half of the position-delete warning. */
+    @Query("SELECT count(*) FROM event_position_targets WHERE position_id = :positionId", nativeQuery = true)
+    fun countPositionTargets(@Param("positionId") positionId: UUID): Int
+
+    /**
+     * Moves every event of one type onto another, the migration an archive offers before hiding a
+     * type (#219). Bulk, because it must be one statement inside the archive's transaction rather
+     * than a row-at-a-time loop that could half-succeed. `clearAutomatically` so the archive's own
+     * read of these rows, in the same transaction, is not served a stale persistence context.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE events SET event_type_id = :toTypeId WHERE event_type_id = :fromTypeId", nativeQuery = true)
+    fun reassignEventType(@Param("fromTypeId") fromTypeId: Long, @Param("toTypeId") toTypeId: Long): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventTypeRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventTypeRepository.kt
@@ -2,11 +2,14 @@ package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventTypeJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface SpringDataEventTypeRepository : JpaRepository<EventTypeJpaEntity, Long> {
     fun findByUuid(uuid: UUID): EventTypeJpaEntity?
+
+    /** How many type roster defaults name this position — half of the position-delete warning. */
+    @Query("SELECT count(*) FROM event_type_position_targets WHERE position_id = :positionId", nativeQuery = true)
+    fun countPositionTargets(@Param("positionId") positionId: UUID): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataMemberProfileRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataMemberProfileRepository.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.entity.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface SpringDataMemberProfileRepository : JpaRepository<MemberProfileJpaEntity, UUID> {
-    fun countByPositionId(positionId: UUID): Int
-}
+// The per-team half of a member: what they are called here and what they play here (ADR-0025).
+// Reads that also need the platform half — role, active — go through SpringDataTeamMemberRepository,
+// which joins this table in from the routed schema rather than the other way round.
+interface SpringDataMemberProfileRepository : JpaRepository<MemberProfileJpaEntity, UUID>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -58,6 +58,23 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun countActiveAdmins(@Param("teamId") teamId: UUID): Int
 
+    /**
+     * Active members holding this position — what a delete would leave Unassigned (#219).
+     *
+     * Same shape as the member listing: the platform table drives (it owns membership and the active
+     * flag) and the unqualified `member_profiles` joins in from the routed tenant schema, which is
+     * where the assignment has lived since ADR-0026. The team id is still needed even though the
+     * schema already scopes the profiles — without it, somebody removed from THIS team but active in
+     * another would keep their profile row and be counted.
+     */
+    @Query(
+        "SELECT COUNT(*) FROM public.team_members tm " +
+            "JOIN member_profiles mp ON mp.user_id = tm.user_id " +
+            "WHERE mp.position_id = :positionId AND tm.team_id = :teamId AND tm.active = true",
+        nativeQuery = true,
+    )
+    fun countActiveByPosition(@Param("teamId") teamId: UUID, @Param("positionId") positionId: UUID): Int
+
     // The tenant's name for this member, falling back to the platform one (ADR-0026). The fallback is
     // not decoration: a member seeded outside the backfill has no profile row yet, and answering NULL
     // would blank a name that exists.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeController.kt
@@ -1,8 +1,17 @@
 package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.EventTypeService
+import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
+import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ArchiveEventType
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateEventType
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ListEventTypes
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.UnarchiveEventType
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.UpdateEventType
 import com.github.zzave.teambalance.api.interfaces.generated.model.EventTypeItem
 import com.github.zzave.teambalance.api.interfaces.generated.model.EventTypeList
 import org.springframework.web.bind.annotation.RestController
@@ -11,21 +20,83 @@ import java.util.UUID
 @RestController
 class EventTypeController(
     private val eventTypeService: EventTypeService,
-) : ListEventTypes.Handler {
+    private val currentUserGateway: CurrentUserGateway,
+    private val currentTeamGateway: CurrentTeamGateway,
+) : ListEventTypes.Handler,
+    CreateEventType.Handler,
+    UpdateEventType.Handler,
+    ArchiveEventType.Handler,
+    UnarchiveEventType.Handler {
 
+    /**
+     * Readable by any authenticated member — the pickers and the roster panel both need it. Archived
+     * types are excluded unless asked for; only the admin screen asks, so every other surface gets
+     * exactly the types a team can still choose.
+     */
     override suspend fun listEventTypes(request: ListEventTypes.Request): ListEventTypes.Response<*> {
-        val types = eventTypeService.findAll().map { type ->
-            EventTypeItem(
-                id = type.id.produce(),
-                name = type.name.value,
-                color = type.color?.value,
-                archived = type.archived,
-                rosterDefault = type.rosterDefault.produce(),
-            )
-        }
-        return ListEventTypes.Response200(EventTypeList(eventTypes = types))
+        currentUserGateway.requireCurrentUserId()
+        val includeArchived = request.queries.includearchived == true
+        return ListEventTypes.Response200(
+            EventTypeList(eventTypes = eventTypeService.findAll(includeArchived).map { it.produce() }),
+        )
     }
+
+    override suspend fun createEventType(request: CreateEventType.Request): CreateEventType.Response<*> {
+        val body = request.body
+        return CreateEventType.Response201(
+            eventTypeService.createEventType(
+                callerId = currentUserGateway.requireCurrentUserId(),
+                teamId = currentTeamGateway.requireCurrentTeamId(),
+                name = EventTypeName(body.name.trim()),
+                color = body.color?.let(::HexColor),
+                rosterDefault = body.rosterDefault.consume(),
+            ).produce(),
+        )
+    }
+
+    override suspend fun updateEventType(request: UpdateEventType.Request): UpdateEventType.Response<*> {
+        val body = request.body
+        return UpdateEventType.Response200(
+            eventTypeService.updateEventType(
+                callerId = currentUserGateway.requireCurrentUserId(),
+                teamId = currentTeamGateway.requireCurrentTeamId(),
+                id = request.path.id.consumeEventTypeId(),
+                name = EventTypeName(body.name.trim()),
+                color = body.color?.let(::HexColor),
+                rosterDefault = body.rosterDefault.consume(),
+            ).produce(),
+        )
+    }
+
+    // Soft delete: the type stops appearing in pickers, its events keep it and keep rendering. The
+    // optional migration moves those events onto another active type first, in the same transaction.
+    override suspend fun archiveEventType(request: ArchiveEventType.Request): ArchiveEventType.Response<*> =
+        ArchiveEventType.Response200(
+            eventTypeService.archiveEventType(
+                callerId = currentUserGateway.requireCurrentUserId(),
+                teamId = currentTeamGateway.requireCurrentTeamId(),
+                id = request.path.id.consumeEventTypeId(),
+                migrateEventsTo = request.body.migrateEventsTo?.consumeEventTypeId(),
+            ).produce(),
+        )
+
+    override suspend fun unarchiveEventType(request: UnarchiveEventType.Request): UnarchiveEventType.Response<*> =
+        UnarchiveEventType.Response200(
+            eventTypeService.unarchiveEventType(
+                callerId = currentUserGateway.requireCurrentUserId(),
+                teamId = currentTeamGateway.requireCurrentTeamId(),
+                id = request.path.id.consumeEventTypeId(),
+            ).produce(),
+        )
 }
+
+private fun EventType.produce() = EventTypeItem(
+    id = id.produce(),
+    name = name.value,
+    color = color?.value,
+    archived = archived,
+    rosterDefault = rosterDefault.produce(),
+)
 
 // The Wirespec edge for an event type's identity — the contract still carries a bare UUID
 // string, unchanged by EventTypeId (ADR-0018). internal so EventController and

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/PositionController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/PositionController.kt
@@ -7,9 +7,11 @@ import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreatePosition
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.DeletePosition
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetPositionUsage
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ListPositions
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RenamePosition
 import com.github.zzave.teambalance.api.interfaces.generated.model.PositionList
+import com.github.zzave.teambalance.api.interfaces.generated.model.PositionUsage
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 import com.github.zzave.teambalance.api.interfaces.generated.model.Position as PositionDto
@@ -22,7 +24,8 @@ class PositionController(
 ) : ListPositions.Handler,
     CreatePosition.Handler,
     RenamePosition.Handler,
-    DeletePosition.Handler {
+    DeletePosition.Handler,
+    GetPositionUsage.Handler {
 
     override suspend fun listPositions(request: ListPositions.Request): ListPositions.Response<*> {
         // Any authenticated member may read the vocabulary; requireCurrentUserId fails closed with 401.
@@ -51,6 +54,23 @@ class PositionController(
             rawLabel = request.body.label,
         )
         return RenamePosition.Response200(renamed.toDto())
+    }
+
+    // What the delete confirmation reports before it lets the admin proceed (#219). Admin-only,
+    // because it is the delete's own dialog that reads it.
+    override suspend fun getPositionUsage(request: GetPositionUsage.Request): GetPositionUsage.Response<*> {
+        val usage = positionService.positionUsage(
+            callerId = currentUserGateway.requireCurrentUserId(),
+            teamId = currentTeamGateway.requireCurrentTeamId(),
+            id = request.path.id.consumePositionId(),
+        )
+        return GetPositionUsage.Response200(
+            PositionUsage(
+                eventTypeCount = usage.eventTypeCount.value.toLong(),
+                eventCount = usage.eventCount.value.toLong(),
+                memberCount = usage.memberCount.value.toLong(),
+            ),
+        )
     }
 
     override suspend fun deletePosition(request: DeletePosition.Request): DeletePosition.Response<*> {

--- a/api/src/main/wirespec/event-types.ws
+++ b/api/src/main/wirespec/event-types.ws
@@ -24,6 +24,68 @@ type EventTypeList {
     eventTypes: EventTypeItem[]
 }
 
-endpoint ListEventTypes GET /api/event-types -> {
+type CreateEventTypeRequest {
+    name: String,
+    color: String?,
+    rosterDefault: RosterRequirement
+}
+
+// A whole replacement of the type's editable fields — name, colour and roster default together. Archiving is NOT here: it is a separate, destructive operation with its own confirmation and its own migration step.
+type UpdateEventTypeRequest {
+    name: String,
+    color: String?,
+    rosterDefault: RosterRequirement
+}
+
+// `migrateEventsTo` moves every event of this type onto another ACTIVE type before archiving, which is what the admin UI offers first. Null archives the type and leaves its events holding it: they keep rendering, and the type simply stops appearing in the pickers. An event's type is non-null, so neither path ever orphans or deletes an event.
+type ArchiveEventTypeRequest {
+    migrateEventsTo: String?
+}
+
+// What a position is currently used by, so the delete confirmation can say what it is about to touch rather than warning in the abstract. Deleting proceeds regardless — this is a warning, not a veto.
+type PositionUsage {
+    eventTypeCount: Integer,
+    eventCount: Integer,
+    memberCount: Integer
+}
+
+// Archived types are excluded unless `include-archived` is true — that exclusion is what makes archiving hide a type from every create/edit picker without touching the events that hold it. The admin screen asks for them so it can list and restore them.
+endpoint ListEventTypes GET /api/event-types ? {include-archived: Boolean?} -> {
     200 -> EventTypeList
+}
+
+endpoint CreateEventType POST CreateEventTypeRequest /api/event-types -> {
+    201 -> EventTypeItem
+    400 -> Unit
+    403 -> Unit
+    409 -> Unit
+}
+
+endpoint UpdateEventType PUT UpdateEventTypeRequest /api/event-types/{id: String} -> {
+    200 -> EventTypeItem
+    400 -> Unit
+    403 -> Unit
+    404 -> Unit
+    409 -> Unit
+}
+
+endpoint ArchiveEventType POST ArchiveEventTypeRequest /api/event-types/{id: String}/archive -> {
+    200 -> EventTypeItem
+    400 -> Unit
+    403 -> Unit
+    404 -> Unit
+    409 -> Unit
+}
+
+endpoint UnarchiveEventType POST /api/event-types/{id: String}/unarchive -> {
+    200 -> EventTypeItem
+    403 -> Unit
+    404 -> Unit
+    409 -> Unit
+}
+
+endpoint GetPositionUsage GET /api/positions/{id: String}/usage -> {
+    200 -> PositionUsage
+    403 -> Unit
+    404 -> Unit
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -49,6 +49,7 @@ private class FakeTeamMemberRepository(private val roles: Map<Pair<TeamId, UserI
     ) = Unit
     override fun markOnboarded(teamId: TeamId, userId: UserId, at: java.time.Instant) = Unit
     override fun countAdmins(teamId: TeamId): Int = 0
+    override fun countByPosition(teamId: TeamId, positionId: PositionId): Int = 0
 }
 
 class AuthorizationServiceTest : FunSpec() {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -8,7 +8,10 @@ import com.github.zzave.teambalance.api.domain.model.EventTitle
 import com.github.zzave.teambalance.api.domain.model.EventType
 import com.github.zzave.teambalance.api.domain.model.EventTypeId
 import com.github.zzave.teambalance.api.domain.model.Position
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
 import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.domain.model.PositionLabel
 import com.github.zzave.teambalance.api.domain.model.Recurrence
 import com.github.zzave.teambalance.api.domain.model.RecurrenceFrequency
@@ -46,11 +49,24 @@ private class ExplodingEventRepo : EventRepository {
     override fun saveAll(events: List<Event>): List<Event> = error("unused")
     override fun deleteById(id: EventId) = error("unused")
     override fun deleteAllById(ids: List<EventId>) = error("unused")
+    override fun countTargetsForPosition(positionId: PositionId): Int = error("unused")
 }
 
 private class ExplodingEventTypeRepo : EventTypeRepository {
     override fun findAll(): List<EventType> = error("unused")
     override fun findById(id: EventTypeId): EventType? = error("repository must not be reached for an unauthorized caller")
+    override fun countTargetsForPosition(positionId: PositionId): Int = error("unused")
+    override fun countEventsOfType(id: EventTypeId): Int = error("unused")
+    override fun create(name: EventTypeName, color: HexColor?, rosterDefault: RosterRequirement): EventType =
+        error("unused")
+    override fun update(
+        id: EventTypeId,
+        name: EventTypeName,
+        color: HexColor?,
+        rosterDefault: RosterRequirement,
+    ): EventType = error("unused")
+    override fun archive(id: EventTypeId, migrateEventsTo: EventTypeId?): EventType = error("unused")
+    override fun unarchive(id: EventTypeId): EventType = error("unused")
 }
 
 private class ExplodingPositionRepo : PositionRepository {
@@ -89,6 +105,7 @@ private class EventFakeMemberRepo(private val admins: Set<UserId>) : TeamMemberR
     ) = Unit
     override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
     override fun countAdmins(teamId: TeamId): Int = admins.size
+    override fun countByPosition(teamId: TeamId, positionId: PositionId): Int = 0
 }
 
 class EventServiceTest : FunSpec() {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
@@ -108,6 +108,9 @@ private class FakeMembershipRepo(
     }
     override fun countAdmins(teamId: TeamId): Int =
         store.count { it.key.first == teamId && it.value.active && it.value.role == Role.ADMIN }
+
+    override fun countByPosition(teamId: TeamId, positionId: PositionId): Int =
+        store.count { it.value.active && it.value.positionId == positionId }
 }
 
 // Positions of ONE tenant, keyed by id. Since ADR-0026 the schema scopes them, so "a position of

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
@@ -4,19 +4,29 @@ import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
 import com.github.zzave.teambalance.api.domain.exception.PositionLabelTakenException
 import com.github.zzave.teambalance.api.domain.exception.PositionNotFoundException
 import com.github.zzave.teambalance.api.domain.model.DisplayName
+import com.github.zzave.teambalance.api.domain.model.Event
+import com.github.zzave.teambalance.api.domain.model.EventId
+import com.github.zzave.teambalance.api.domain.model.EventType
+import com.github.zzave.teambalance.api.domain.model.EventTypeId
+import com.github.zzave.teambalance.api.domain.model.EventTypeName
+import com.github.zzave.teambalance.api.domain.model.HexColor
 import com.github.zzave.teambalance.api.domain.model.Position
 import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.model.PositionLabel
 import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.RosterRequirement
 import com.github.zzave.teambalance.api.domain.model.TeamId
-import com.github.zzave.teambalance.api.domain.model.TenantRouting
 import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.model.TenantRouting
 import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.EventRepository
+import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.time.Instant
 import java.util.UUID
 
 // In-memory positions keyed by id. No owning-team tag since ADR-0026: the fake stands in for one
@@ -25,23 +35,67 @@ import java.util.UUID
 private class PosFakePositionRepo : PositionRepository {
     private val store: MutableMap<PositionId, PositionLabel> = mutableMapOf()
 
-    override fun list(): List<Position> =
-        store.map { Position(it.key, it.value) }.sortedBy { it.label.value }
+    override fun list(): List<Position> = store.map { Position(it.key, it.value) }.sortedBy { it.label.value }
+
     override fun create(label: PositionLabel): Position {
         val id = PositionId(UUID.randomUUID())
         store[id] = label
         return Position(id, label)
     }
+
     override fun rename(id: PositionId, label: PositionLabel): Position {
         store[id] = label
         return Position(id, label)
     }
-    override fun delete(id: PositionId) { store.remove(id) }
+
+    override fun delete(id: PositionId) {
+        store.remove(id)
+    }
+
     override fun findById(id: PositionId): Position? = store[id]?.let { Position(id, it) }
     override fun exists(positionId: PositionId): Boolean = store.containsKey(positionId)
 }
 
-// Reports whichever role was seeded for a (team, user); everyone else is a non-member (null).
+// Fixed usage counts, so the delete-warning assertions read as the numbers the dialog would show.
+// There is deliberately no fake for the delete *cascade* any more: since ADR-0025 the positions and
+// the rows naming them share one schema, so clearing them is a foreign key (ON DELETE CASCADE for
+// the two target tables, SET NULL for member_profiles), not an ordered sequence of service calls.
+// A constraint can only be proven against a real database — RosterRequirementPersistenceIT does it.
+private const val TYPE_TARGETS = 2
+private const val EVENT_TARGETS = 5
+private const val MEMBERS_ON_POSITION = 3
+
+private class CountingEventTypeRepo : EventTypeRepository {
+    override fun countTargetsForPosition(positionId: PositionId): Int = TYPE_TARGETS
+    override fun findAll(): List<EventType> = error("unused")
+    override fun findById(id: EventTypeId): EventType? = error("unused")
+    override fun countEventsOfType(id: EventTypeId): Int = error("unused")
+    override fun create(name: EventTypeName, color: HexColor?, rosterDefault: RosterRequirement): EventType =
+        error("unused")
+    override fun update(
+        id: EventTypeId,
+        name: EventTypeName,
+        color: HexColor?,
+        rosterDefault: RosterRequirement,
+    ): EventType = error("unused")
+    override fun archive(id: EventTypeId, migrateEventsTo: EventTypeId?): EventType = error("unused")
+    override fun unarchive(id: EventTypeId): EventType = error("unused")
+}
+
+private class CountingEventRepo : EventRepository {
+    override fun countTargetsForPosition(positionId: PositionId): Int = EVENT_TARGETS
+    override fun findById(id: EventId): Event? = error("unused")
+    override fun findByIds(ids: List<EventId>): List<Event> = error("unused")
+    override fun findUpcoming(since: Instant): List<Event> = error("unused")
+    override fun findAll(): List<Event> = error("unused")
+    override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
+    override fun save(event: Event): Event = error("unused")
+    override fun saveAll(events: List<Event>): List<Event> = error("unused")
+    override fun deleteById(id: EventId) = error("unused")
+    override fun deleteAllById(ids: List<EventId>) = error("unused")
+}
+
+// Reports whichever role was seeded for a (team, user); everyone else is a plain member.
 private class FakeAdminRepo(private val admins: Set<UserId>) : TeamMemberRepository {
     override fun findRole(teamId: TeamId, userId: UserId): Role? = if (userId in admins) Role.ADMIN else Role.USER
     override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
@@ -59,10 +113,11 @@ private class FakeAdminRepo(private val admins: Set<UserId>) : TeamMemberReposit
         displayName: DisplayName,
         role: Role,
         positionId: PositionId?,
-        markOnboardedAt: java.time.Instant?,
+        markOnboardedAt: Instant?,
     ) = Unit
-    override fun markOnboarded(teamId: TeamId, userId: UserId, at: java.time.Instant) = Unit
+    override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
     override fun countAdmins(teamId: TeamId): Int = admins.size
+    override fun countByPosition(teamId: TeamId, positionId: PositionId): Int = MEMBERS_ON_POSITION
 }
 
 class PositionServiceTest : FunSpec() {
@@ -73,7 +128,13 @@ class PositionServiceTest : FunSpec() {
 
         fun newService(): Pair<PositionService, PosFakePositionRepo> {
             val positions = PosFakePositionRepo()
-            val service = PositionService(positions, AuthorizationService(FakeAdminRepo(setOf(adminId)), FakeActAsGateway()))
+            val service = PositionService(
+                positionRepository = positions,
+                eventTypeRepository = CountingEventTypeRepo(),
+                eventRepository = CountingEventRepo(),
+                teamMemberRepository = FakeAdminRepo(setOf(adminId)),
+                authorizationService = AuthorizationService(FakeAdminRepo(setOf(adminId)), FakeActAsGateway()),
+            )
             return service to positions
         }
 
@@ -115,7 +176,9 @@ class PositionServiceTest : FunSpec() {
 
         test("renamePosition of an unknown id returns 404") {
             val (service, _) = newService()
-            shouldThrow<PositionNotFoundException> { service.renamePosition(adminId, teamId, PositionId(UUID.randomUUID()), "X") }
+            shouldThrow<PositionNotFoundException> {
+                service.renamePosition(adminId, teamId, PositionId(UUID.randomUUID()), "X")
+            }
         }
 
         test("deletePosition removes the position") {
@@ -127,7 +190,29 @@ class PositionServiceTest : FunSpec() {
 
         test("deletePosition of an unknown id returns 404") {
             val (service, _) = newService()
-            shouldThrow<PositionNotFoundException> { service.deletePosition(adminId, teamId, PositionId(UUID.randomUUID())) }
+            shouldThrow<PositionNotFoundException> {
+                service.deletePosition(adminId, teamId, PositionId(UUID.randomUUID()))
+            }
+        }
+
+        // The three numbers the delete confirmation reads out (#219). It is a warning, not a veto,
+        // so what matters is that each count comes from its own surface and none is silently zero.
+        test("positionUsage reports the type defaults, event overrides and members that name it") {
+            val (service, _) = newService()
+            val created = service.createPosition(adminId, teamId, "Setter")
+
+            val usage = service.positionUsage(adminId, teamId, created.id)
+
+            usage.eventTypeCount.value shouldBe TYPE_TARGETS
+            usage.eventCount.value shouldBe EVENT_TARGETS
+            usage.memberCount.value shouldBe MEMBERS_ON_POSITION
+        }
+
+        test("positionUsage of an unknown id returns 404") {
+            val (service, _) = newService()
+            shouldThrow<PositionNotFoundException> {
+                service.positionUsage(adminId, teamId, PositionId(UUID.randomUUID()))
+            }
         }
 
         test("mutations by a non-admin are forbidden") {
@@ -135,6 +220,7 @@ class PositionServiceTest : FunSpec() {
             val created = service.createPosition(adminId, teamId, "Setter")
             shouldThrow<NotTeamAdminException> { service.renamePosition(userId, teamId, created.id, "X") }
             shouldThrow<NotTeamAdminException> { service.deletePosition(userId, teamId, created.id) }
+            shouldThrow<NotTeamAdminException> { service.positionUsage(userId, teamId, created.id) }
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -132,6 +132,11 @@ internal class TeamDirectory {
         ) = Unit
         override fun countAdmins(teamId: TeamId): Int =
             memberships.count { it.key.second == teamId && it.value == Role.ADMIN }
+
+        // This directory models membership and roles, not positions — assignPosition is a no-op here
+        // — so nobody holds one. The position-usage counts (#219) are proven against a real Postgres
+        // in EventTypeAdminIT and as pure logic in PositionServiceTest, both of which track positions.
+        override fun countByPosition(teamId: TeamId, positionId: PositionId): Int = 0
     }
 }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeAdminIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTypeAdminIT.kt
@@ -1,0 +1,444 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+// This spec runs against its OWN tenant schema, not the shared `public` one every other IT uses.
+// It archives event types — including, deliberately, all but one of the seeded ones — and event
+// types are tenant-schema rows, so doing that in `public` would hide Training/Match/Other from every
+// other spec that reads them. The team, members and positions still come from the platform schema.
+// Fixture user ids are namespaced `b2190000-…` after this feature's issue (#219). Every IT shares
+// one `public` schema and `tb_add_member` is ON CONFLICT DO NOTHING, so two specs claiming the same
+// id silently share a member — and whichever seeds first decides their role. That is not
+// hypothetical: these specs originally used `…0000d1`-`…0000d3`, which #242 later took for
+// EventControllerTest's setters, turning this spec's admin into a plain USER and every admin-gated
+// write into a 403. An issue-scoped prefix makes a future collision implausible rather than lucky.
+private const val ADMIN_USER_ID = "b2190000-0000-0000-0000-000000000021"
+private const val MEMBER_USER_ID = "b2190000-0000-0000-0000-000000000022"
+private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"
+private const val SETTER = "Admin Setter"
+private const val SCHEMA = "team_roster_admin"
+private const val OFF_DEFAULT = """{"trackRoster": false, "totalTarget": null, "positionTargets": []}"""
+
+/**
+ * Event-type authoring against a real Postgres (#219, step 4): create / rename / recolor / archive,
+ * and the roster default each type carries.
+ *
+ * The rules worth proving here are the ones that protect a team from locking itself out or losing
+ * events: archiving is a soft delete that never touches an event, the migration and the archive
+ * commit together, and the last active type cannot be archived at all.
+ */
+@AutoConfigureMockMvc
+class EventTypeAdminIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    init {
+        test("an admin creates a type with a roster default and reads it back") {
+            seedTeam()
+            val setter = positionId(SETTER)
+
+            val id = createType(
+                name = "Cup Match",
+                color = "#225C9C",
+                rosterDefault = """
+                    {"trackRoster": true, "totalTarget": 10, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+                """.trimIndent(),
+            )
+
+            listTypes()
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$id')].name").value("Cup Match"))
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$id')].color").value("#225C9C"))
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$id')].archived").value(false))
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$id')].rosterDefault.trackRoster").value(true))
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$id')].rosterDefault.totalTarget").value(10))
+        }
+
+        test("an admin renames, recolors and re-targets a type in one update") {
+            seedTeam()
+            val setter = positionId(SETTER)
+            val id = createType("Friendly", "#249E6C", OFF_DEFAULT)
+
+            perform(
+                MockMvcRequestBuilders.put("/api/event-types/$id")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {"name": "Friendly Match", "color": "#F4B400", "rosterDefault":
+                          {"trackRoster": true, "totalTarget": null,
+                           "positionTargets": [{"positionId": "$setter", "count": 3}]}}
+                        """.trimIndent(),
+                    ),
+                ADMIN_USER_ID,
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.name").value("Friendly Match"))
+                .andExpect(jsonPath("$.color").value("#F4B400"))
+                .andExpect(jsonPath("$.rosterDefault.positionTargets[0].count").value(3))
+        }
+
+        // The whole point of resolving the requirement on read: an admin changes the shape of a
+        // Match once, and every inheriting Match follows without a single event row being rewritten.
+        test("editing a type's roster default moves the events that inherit it") {
+            seedTeam()
+            val setter = positionId(SETTER)
+            seedMember(MEMBER_USER_ID, "admin-member@test.com", SETTER)
+            val typeId = createType("Inheriting", null, OFF_DEFAULT)
+            val eventId = createEvent(typeId, "Follows the type")
+            attend(eventId, MEMBER_USER_ID)
+
+            // Tracking is off, so the event shows no panel.
+            detail(eventId).andExpect(jsonPath("$.roster.state").value("OFF"))
+
+            updateType(
+                typeId,
+                "Inheriting",
+                """
+                {"trackRoster": true, "totalTarget": null, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+                """.trimIndent(),
+            ).andExpect(status().isOk)
+
+            detail(eventId)
+                .andExpect(jsonPath("$.roster.state").value("SPOTS_OPEN"))
+                .andExpect(jsonPath("$.roster.openSlots").value(1))
+        }
+
+        test("archiving hides a type from the pickers while its events keep it and keep rendering") {
+            seedTeam()
+            val typeId = createType("Doomed", null, OFF_DEFAULT)
+            val eventId = createEvent(typeId, "Still here")
+
+            archive(typeId, migrateTo = null).andExpect(status().isOk)
+
+            // Gone from the default listing — which is what every create/edit picker reads…
+            listTypes().andExpect(jsonPath("$.eventTypes[?(@.id == '$typeId')]").isEmpty)
+            // …but present when the admin screen asks for archived ones too.
+            listTypes(includeArchived = true)
+                .andExpect(jsonPath("$.eventTypes[?(@.id == '$typeId')].archived").value(true))
+            // And the event neither vanished nor lost its type.
+            detail(eventId)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.eventType.name").value("Doomed"))
+        }
+
+        // The offer the admin gets before archiving: move the events somewhere they stay visible.
+        test("archiving with a migration target moves every event of that type first") {
+            seedTeam()
+            val fromId = createType("Old Match", null, OFF_DEFAULT)
+            val toId = createType("New Match", null, OFF_DEFAULT)
+            val a = createEvent(fromId, "Migrating A")
+            val b = createEvent(fromId, "Migrating B")
+            val untouched = createEvent(toId, "Already there")
+
+            archive(fromId, migrateTo = toId).andExpect(status().isOk)
+
+            detail(a).andExpect(jsonPath("$.eventType.id").value(toId.toString()))
+            detail(b).andExpect(jsonPath("$.eventType.id").value(toId.toString()))
+            detail(untouched).andExpect(jsonPath("$.eventType.id").value(toId.toString()))
+            eventCountOfType(fromId) shouldBe 0
+        }
+
+        // Without this a team can archive its way to zero types and then be unable to create an
+        // event at all, with no way back through the UI.
+        test("the last active type cannot be archived") {
+            seedTeam()
+            val ids = activeTypeIds()
+            // Archive everything but one, then try the last.
+            ids.dropLast(1).forEach { archive(it, migrateTo = ids.last()).andExpect(status().isOk) }
+
+            archive(ids.last(), migrateTo = null)
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("$.code").value("LAST_EVENT_TYPE"))
+
+            activeTypeIds().size shouldBe 1
+            // …and unarchiving puts one back in the pickers, which is what makes it a soft delete.
+            perform(MockMvcRequestBuilders.post("/api/event-types/${ids.first()}/unarchive"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.archived").value(false))
+            activeTypeIds().size shouldBe 2
+        }
+
+        test("a migration target that is archived, unknown or the type itself is rejected") {
+            seedTeam()
+            val fromId = createType("Source", null, OFF_DEFAULT)
+            val archivedId = createType("Archived Target", null, OFF_DEFAULT)
+            archive(archivedId, migrateTo = null).andExpect(status().isOk)
+
+            archive(fromId, migrateTo = archivedId).andExpect(status().isBadRequest)
+            archive(fromId, migrateTo = UUID.randomUUID()).andExpect(status().isBadRequest)
+            archive(fromId, migrateTo = fromId).andExpect(status().isBadRequest)
+
+            // Nothing was archived by a rejected attempt.
+            listTypes().andExpect(jsonPath("$.eventTypes[?(@.id == '$fromId')].archived").value(false))
+        }
+
+        test("event type names are unique per team, case-insensitively, archived ones included") {
+            seedTeam()
+            createType("Unique Name", null, OFF_DEFAULT)
+
+            perform(
+                MockMvcRequestBuilders.post("/api/event-types")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "unique name", "color": null, "rosterDefault": ${OFF_DEFAULT}}"""),
+                ADMIN_USER_ID,
+            )
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("$.code").value("EVENT_TYPE_NAME_TAKEN"))
+        }
+
+        // Without the value object's cap a 101-character name reaches VARCHAR(100) and surfaces as a
+        // 500; without the blank guard a whitespace name is stored as "". Both are 400s.
+        test("a blank or over-long name is rejected with 400, not a 500") {
+            seedTeam()
+
+            perform(
+                MockMvcRequestBuilders.post("/api/event-types")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "   ", "color": null, "rosterDefault": $OFF_DEFAULT}"""),
+                ADMIN_USER_ID,
+            ).andExpect(status().isBadRequest)
+
+            perform(
+                MockMvcRequestBuilders.post("/api/event-types")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "${"x".repeat(101)}", "color": null, "rosterDefault": $OFF_DEFAULT}"""),
+                ADMIN_USER_ID,
+            ).andExpect(status().isBadRequest)
+
+            eventTypeCountNamed("   ") shouldBe 0
+        }
+
+        test("a roster default naming an unknown position is rejected") {
+            seedTeam()
+
+            perform(
+                MockMvcRequestBuilders.post("/api/event-types")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {"name": "Ghost Targets", "color": null, "rosterDefault":
+                          {"trackRoster": true, "totalTarget": null,
+                           "positionTargets": [{"positionId": "${UUID.randomUUID()}", "count": 2}]}}
+                        """.trimIndent(),
+                    ),
+                ADMIN_USER_ID,
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("UNKNOWN_ROSTER_POSITION"))
+        }
+
+        // Config is admin-only; reading the vocabulary is not, because every picker and the roster
+        // panel need it.
+        test("a non-admin may read event types but may not write them") {
+            seedTeam()
+            seedMember(MEMBER_USER_ID, "admin-member@test.com", null)
+            val id = createType("Read Only", null, OFF_DEFAULT)
+
+            perform(MockMvcRequestBuilders.get("/api/event-types"), MEMBER_USER_ID).andExpect(status().isOk)
+
+            perform(
+                MockMvcRequestBuilders.post("/api/event-types")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Nope", "color": null, "rosterDefault": ${OFF_DEFAULT}}"""),
+                MEMBER_USER_ID,
+            ).andExpect(status().isForbidden)
+
+            perform(
+                MockMvcRequestBuilders.put("/api/event-types/$id")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Nope", "color": null, "rosterDefault": ${OFF_DEFAULT}}"""),
+                MEMBER_USER_ID,
+            ).andExpect(status().isForbidden)
+
+            archive(id, migrateTo = null, asUser = MEMBER_USER_ID).andExpect(status().isForbidden)
+        }
+
+        // What the delete confirmation reports before an admin agrees to it.
+        // Its own position, because the counts are cumulative: other tests in this spec target
+        // SETTER, and a shared one would make the expected numbers depend on execution order.
+        test("position usage reports the types, events and members that would be touched") {
+            seedTeam()
+            val counted = "Admin Counted"
+            val setter = positionId(counted)
+            seedMember(MEMBER_USER_ID, "admin-member@test.com", counted)
+            val targeting = """
+                {"trackRoster": true, "totalTarget": null, "positionTargets": [{"positionId": "$setter", "count": 2}]}
+            """.trimIndent()
+            val typeId = createType("Uses Setter", null, targeting)
+            createEventWithOverride(typeId, "Overrides too", targeting)
+
+            perform(MockMvcRequestBuilders.get("/api/positions/$setter/usage"), ADMIN_USER_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.eventTypeCount").value(1))
+                .andExpect(jsonPath("$.eventCount").value(1))
+                .andExpect(jsonPath("$.memberCount").value(1))
+        }
+
+        test("position usage is admin-only") {
+            seedTeam()
+            val setter = positionId(SETTER)
+            seedMember(MEMBER_USER_ID, "admin-member@test.com", null)
+
+            perform(MockMvcRequestBuilders.get("/api/positions/$setter/usage"), MEMBER_USER_ID)
+                .andExpect(status().isForbidden)
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private fun perform(builder: MockHttpServletRequestBuilder, userId: String) =
+        mockMvc.perform(builder.header("X-Team-Id", SCHEMA).header("X-User-Id", userId))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    // Tracking off, no targets: the default a type starts life with.
+
+    private fun listTypes(includeArchived: Boolean = false) = perform(
+        MockMvcRequestBuilders.get("/api/event-types?include-archived=$includeArchived"),
+        ADMIN_USER_ID,
+    ).andExpect(status().isOk)
+
+    private fun createType(name: String, color: String?, rosterDefault: String): UUID {
+        val body = """{"name": "$name", "color": ${color?.let { "\"$it\"" } ?: "null"}, "rosterDefault": $rosterDefault}"""
+        val response = perform(
+            MockMvcRequestBuilders.post("/api/event-types").contentType(MediaType.APPLICATION_JSON).content(body),
+            ADMIN_USER_ID,
+        ).andExpect(status().isCreated).andReturn().response.contentAsString
+        return UUID.fromString(Regex("\"id\"\\s*:\\s*\"([^\"]+)\"").find(response)!!.groupValues[1])
+    }
+
+    private fun updateType(id: UUID, name: String, rosterDefault: String) = perform(
+        MockMvcRequestBuilders.put("/api/event-types/$id")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "$name", "color": null, "rosterDefault": $rosterDefault}"""),
+        ADMIN_USER_ID,
+    )
+
+    private fun archive(id: UUID, migrateTo: UUID?, asUser: String = ADMIN_USER_ID) = perform(
+        MockMvcRequestBuilders.post("/api/event-types/$id/archive")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"migrateEventsTo": ${migrateTo?.let { "\"$it\"" } ?: "null"}}"""),
+        asUser,
+    )
+
+    private fun createEvent(typeId: UUID, title: String) = createEventWithOverride(typeId, title, null)
+
+    private fun createEventWithOverride(typeId: UUID, title: String, rosterOverride: String?): UUID {
+        val body = """
+            {
+              "eventTypeId": "$typeId", "title": "$title", "description": null,
+              "startTime": "2026-09-01T17:00:00Z", "endTime": "2026-09-01T18:30:00Z",
+              "location": null, "references": [], "rosterOverride": ${rosterOverride ?: "null"}
+            }
+        """.trimIndent()
+        val response = perform(
+            MockMvcRequestBuilders.post("/api/events").contentType(MediaType.APPLICATION_JSON).content(body),
+            ADMIN_USER_ID,
+        ).andExpect(status().isCreated).andReturn().response.contentAsString
+        return UUID.fromString(Regex("\"id\"\\s*:\\s*\"([^\"]+)\"").find(response)!!.groupValues[1])
+    }
+
+    private fun detail(id: UUID) = perform(MockMvcRequestBuilders.get("/api/events/$id"), ADMIN_USER_ID)
+
+    private fun attend(eventId: UUID, userId: String) {
+        perform(
+            MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$userId")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"state": "ATTENDING"}"""),
+            ADMIN_USER_ID,
+        ).andExpect(status().isOk)
+    }
+
+    private fun eventTypeCountNamed(name: String): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM $SCHEMA.event_types WHERE name = ?",
+            Long::class.java,
+            name,
+        )!!
+
+    private fun activeTypeIds(): List<UUID> =
+        jdbcTemplate.queryForList(
+            "SELECT uuid FROM $SCHEMA.event_types WHERE archived = false ORDER BY id",
+            UUID::class.java,
+        ).filterNotNull()
+
+    private fun eventCountOfType(id: UUID): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM $SCHEMA.events e JOIN $SCHEMA.event_types et ON et.id = e.event_type_id WHERE et.uuid = ?",
+            Long::class.java,
+            id,
+        )!!
+
+    // Positions are tenant rows since ADR-0025, so they belong in the schema this spec routes to
+    // (X-Team-Id: $SCHEMA), not in the platform schema. It is also where they have to be for a
+    // target to reference one — event_type_position_targets.position_id is a real foreign key now.
+    private fun positionId(label: String): UUID {
+        jdbcTemplate.update(
+            "INSERT INTO $SCHEMA.positions (id, label) VALUES (gen_random_uuid(), ?) ON CONFLICT DO NOTHING",
+            label,
+        )
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM $SCHEMA.positions WHERE lower(label) = lower(?)",
+            UUID::class.java,
+            label,
+        )!!
+    }
+
+    private fun seedTeam() {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        tenantSchemaAdapter.provisionTenantSchema(SCHEMA)
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Test Team', 'test-team', 'public')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.update("UPDATE $SCHEMA.team_settings SET season_start = NULL, season_end = NULL WHERE id = 1")
+        seedMember(ADMIN_USER_ID, "admin-admin@test.com", null, role = "ADMIN")
+    }
+
+    private fun seedMember(userId: String, email: String, position: String?, role: String = "USER") {
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.users (id, email, display_name)
+            VALUES ('$userId'::uuid, '$email', '$email')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        val label = position?.let { "'$it'" } ?: "NULL"
+        jdbcTemplate.execute("SELECT public.tb_add_member('$TEAM_ID'::uuid, '$userId'::uuid, '$role', $label)")
+        if (position != null) {
+            // tb_add_member seeds the profile into the team's own schema; this spec routes elsewhere
+            // by header, so the profile it reads back has to be written here explicitly.
+            jdbcTemplate.update(
+                "INSERT INTO $SCHEMA.member_profiles (user_id, display_name, position_id) " +
+                    "VALUES (?::uuid, ?, (SELECT id FROM $SCHEMA.positions WHERE lower(label) = lower(?))) " +
+                    "ON CONFLICT (user_id) DO UPDATE SET position_id = EXCLUDED.position_id",
+                userId,
+                email,
+                position,
+            )
+        }
+    }
+}

--- a/app/e2e-real/roster-config.spec.ts
+++ b/app/e2e-real/roster-config.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Real e2e: the admin roster-config write path (#219).
+ *
+ * Justified as a new flow because it is a genuinely new seam, not a variation on an existing one:
+ * an admin-gated write to a NEW resource (`/api/event-types`), behind an admin-only route guard,
+ * persisted and read back. Nothing else in the suite touches it.
+ *
+ * Deliberately NOT covered here: the card's chip and slot-pips panel. Those ride the existing events
+ * read, and every roster state is a Storybook story with a Chromatic baseline; the numbers behind
+ * them are pinned by RosterFillTest and RosterFillIT. Asserting them again through a browser would
+ * duplicate that coverage rather than add a seam. (It would also be awkward: the seeded e2e event is
+ * within the 7-day window, so Phase 1 renders it as the hero — which carries no roster panel — and
+ * the spec would have to manufacture a further-out event just to get a card on screen.)
+ *
+ * Starts authenticated as the seeded admin via the storageState fixture (auth.setup.ts).
+ *
+ * Mutation-tolerant: it drives the seeded Training type to a KNOWN configuration and asserts on
+ * that, rather than assuming what it started as, and restores it at the end — so re-runs against a
+ * warm local DB stay green and the other specs see Training as they expect it.
+ */
+// The seeded e2e team's slug. Team-scoped routes carry it since ADR-0023 made the Active Team
+// explicit rather than inferred, so a settings URL without it no longer resolves to a team.
+const TEAM_SLUG = 'e2e-test-team'
+
+test('admin configures an event type roster default and it persists', async ({ page }) => {
+  // 1. The admin-only settings screen — a route guard, not merely a hidden button.
+  await page.goto(`/t/${TEAM_SLUG}/team/settings`)
+  await expect(page.getByRole('heading', { name: 'Event types' })).toBeVisible()
+
+  // 2. Open the seeded Training type's editor.
+  await page.getByRole('button', { name: 'Edit Training' }).click()
+
+  // 3. Switch tracking on if it is off, so the spec reaches the same state either way.
+  const trackSwitch = page.getByRole('switch', { name: 'Track roster' })
+  if ((await trackSwitch.getAttribute('aria-checked')) !== 'true') {
+    await trackSwitch.click()
+  }
+  await expect(trackSwitch).toHaveAttribute('aria-checked', 'true')
+
+  // 4. Set a headcount and save — the tenant-schema write this flow exists for.
+  await page.getByLabel(/People needed in total/).fill('99')
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+  // 5. The row summarises the new default, so the write round-tripped through the API.
+  await expect(page.getByText('99 total')).toBeVisible({ timeout: 10_000 })
+
+  // 6. …and it survives a full reload, i.e. it was persisted rather than left in local state.
+  await page.reload()
+  await expect(page.getByText('99 total')).toBeVisible({ timeout: 10_000 })
+
+  // 7. Restore: back to untracked, so a re-run starts clean and other specs see Training untouched.
+  await page.getByRole('button', { name: 'Edit Training' }).click()
+  await page.getByRole('switch', { name: 'Track roster' }).click()
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await expect(page.getByText('No roster').first()).toBeVisible({ timeout: 10_000 })
+})

--- a/app/src/features/create-event/ui/CreateEventForm.tsx
+++ b/app/src/features/create-event/ui/CreateEventForm.tsx
@@ -4,12 +4,17 @@ import { Input } from '@shared/ui/input'
 import { Label } from '@shared/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shared/ui/select'
 import type { EventInput } from '@shared/api/events'
+import type { RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { RosterOverrideField } from '@features/manage-event-types/ui/RosterOverrideField'
 import type { EventTypeItem } from '@shared/api/event-types'
 import { ReferenceRowsEditor } from '@entities/event/ui/ReferenceRowsEditor'
 import { cleanReferences, type ReferenceRow } from '@entities/event/lib/references'
 
 interface CreateEventFormProps {
   eventTypes: EventTypeItem[]
+  /** The team's position vocabulary, so a customised roster can be authored per position. */
+  positions?: Position[]
   isPending: boolean
   onSubmit: (values: EventInput) => void
   /** Message to surface when the last create attempt failed; null/undefined hides the alert. */
@@ -34,17 +39,28 @@ const DEFAULT_DURATION_MINUTES = '120'
  * sheet open/close state live in the CreateEventSheet widget — so every form state (idle,
  * type-selected, submitting, no-types) is renderable in isolation (see CreateEventForm.stories.tsx).
  */
-export function CreateEventForm({ eventTypes, isPending, onSubmit, error }: CreateEventFormProps) {
+export function CreateEventForm({
+  eventTypes,
+  positions = [],
+  isPending,
+  onSubmit,
+  error,
+}: CreateEventFormProps) {
   const [selectedTypeId, setSelectedTypeId] = useState<string>('')
   const [title, setTitle] = useState('')
   const [titleTouched, setTitleTouched] = useState(false)
   const [durationMinutes, setDurationMinutes] = useState(DEFAULT_DURATION_MINUTES)
   const [references, setReferences] = useState<ReferenceRow[]>([])
+  // undefined = inherit the selected type's default, which is the common case and the default here.
+  const [rosterOverride, setRosterOverride] = useState<RosterRequirement | undefined>(undefined)
 
   const selectedType = eventTypes.find((t) => t.id === selectedTypeId)
 
   const handleTypeChange = (typeId: string) => {
     setSelectedTypeId(typeId)
+    // A customised roster was seeded from the OLD type's default and is meaningless against the new
+    // one, so changing type drops back to inheriting rather than submitting the wrong shape.
+    setRosterOverride(undefined)
     // Auto-suggest title based on type name — only if user hasn't typed their own title
     if (!titleTouched) {
       const type = eventTypes.find((t) => t.id === typeId)
@@ -67,6 +83,7 @@ export function CreateEventForm({ eventTypes, isPending, onSubmit, error }: Crea
       endTime: end.toISOString(),
       location: (form.get('location') as string) || undefined,
       references: cleanReferences(references),
+      rosterOverride,
     })
   }
 
@@ -149,6 +166,14 @@ export function CreateEventForm({ eventTypes, isPending, onSubmit, error }: Crea
 
       {/* Links (References) — repeatable label + url rows. Label optional; blank rows are dropped. */}
       <ReferenceRowsEditor rows={references} onChange={setReferences} />
+
+      <RosterOverrideField
+        value={rosterOverride}
+        eventType={selectedType}
+        positions={positions}
+        disabled={isPending}
+        onChange={setRosterOverride}
+      />
 
       {error && (
         <p role="alert" className="text-sm text-destructive">

--- a/app/src/features/edit-event/ui/EditEventDialog.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Button } from '@shared/ui/button'
 import { useUpdateEvent, type Event, type EventDetail } from '@shared/api/events'
 import { useEventTypes } from '@shared/api/event-types'
+import { usePositions } from '@shared/api/positions'
 import { EditEventDialogView } from './EditEventDialogView'
 
 interface EditEventDialogProps {
@@ -21,7 +22,11 @@ interface EditEventDialogProps {
  */
 export function EditEventDialog({ event, siblings = [] }: EditEventDialogProps) {
   const [open, setOpen] = useState(false)
-  const { data: eventTypes } = useEventTypes()
+  // Archived types included: an event may hold one that was archived without migration, and the
+  // picker must still be able to show the type this event actually has. The View narrows the
+  // choices back down to the active ones plus that.
+  const { data: eventTypes } = useEventTypes(true)
+  const { data: positions } = usePositions()
   const updateEvent = useUpdateEvent()
 
   return (
@@ -40,6 +45,7 @@ export function EditEventDialog({ event, siblings = [] }: EditEventDialogProps) 
           event={event}
           siblings={siblings}
           eventTypes={eventTypes}
+          positions={positions}
           isPending={updateEvent.isPending}
           isError={updateEvent.isError}
           onSubmit={(request) => updateEvent.mutate(request, { onSuccess: () => setOpen(false) })}

--- a/app/src/features/edit-event/ui/EditEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.tsx
@@ -4,6 +4,9 @@ import { Input } from '@shared/ui/input'
 import { Label } from '@shared/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shared/ui/select'
 import type { Event, EventDetail, EventInput, EventSeriesScope } from '@shared/api/events'
+import type { RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { RosterOverrideField } from '@features/manage-event-types/ui/RosterOverrideField'
 import type { EventTypeItem } from '@shared/api/event-types'
 import { ReferenceRowsEditor } from '@entities/event/ui/ReferenceRowsEditor'
 import { cleanReferences, toReferenceRows, type ReferenceRow } from '@entities/event/lib/references'
@@ -17,6 +20,8 @@ interface EditEventDialogViewProps {
   siblings?: Event[]
   /** Event types for the picker; defaults to an empty list while the container's query is in flight. */
   eventTypes?: EventTypeItem[]
+  /** The team's position vocabulary, so a customised roster can be authored per position. */
+  positions?: Position[]
   /** The update mutation is in flight — the submit button shows "Saving…" and is disabled. */
   isPending?: boolean
   /** The update mutation failed — render the inline error shell. */
@@ -54,6 +59,7 @@ export function EditEventDialogView({
   event,
   siblings = [],
   eventTypes = [],
+  positions = [],
   isPending,
   isError,
   onSubmit,
@@ -69,6 +75,15 @@ export function EditEventDialogView({
   // Seed the editor from the event's existing links — the update has replace-semantics, so the full
   // set must be sent back on every save or the links would be wiped.
   const [references, setReferences] = useState<ReferenceRow[]>(toReferenceRows(event.references))
+  // Seeded from what the event already carries, for the same replace-semantics reason as the links:
+  // whatever this form submits IS the event's new roster, so an untouched override must survive.
+  const [rosterOverride, setRosterOverride] = useState<RosterRequirement | undefined>(event.rosterOverride)
+
+  // Offer the active types, plus this event's own even when it has been archived: hiding it would
+  // leave the picker blank and — worse — leave the roster field with no type to read a default from,
+  // so "Customise" would seed tracking OFF instead of what the type actually asks for.
+  const selectableTypes = eventTypes.filter((t) => !t.archived || t.id === event.eventType.id)
+  const selectedEventType = eventTypes.find((t) => t.id === typeId)
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -85,10 +100,7 @@ export function EditEventDialogView({
       endTime: new Date(end).toISOString(),
       location: (form.get('location') as string) || undefined,
       references: cleanReferences(references),
-      // Carried through untouched. This form does not edit the roster override (that is the admin
-      // authoring surface), but the update is a whole replacement — omitting it would drop the event
-      // back to inheriting its type's default as a side effect of renaming it.
-      rosterOverride: event.rosterOverride,
+      rosterOverride,
     })
   }
 
@@ -110,7 +122,7 @@ export function EditEventDialogView({
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
           <SelectContent>
-            {eventTypes.map((t) => (
+            {selectableTypes.map((t) => (
               <SelectItem key={t.id} value={t.id}>
                 <div className="flex items-center gap-2">
                   <span className="inline-block h-3 w-3 rounded-full" style={{ backgroundColor: t.color ?? '#888' }} />
@@ -181,6 +193,14 @@ export function EditEventDialogView({
         <Input id="edit-description" name="description" defaultValue={event.description ?? ''} />
       </div>
       <ReferenceRowsEditor rows={references} onChange={setReferences} />
+
+      <RosterOverrideField
+        value={rosterOverride}
+        eventType={selectedEventType}
+        positions={positions}
+        disabled={isPending}
+        onChange={setRosterOverride}
+      />
       {isError && (
         <p className="rounded-lg border border-red/40 bg-red/10 px-3 py-2 text-sm text-red">
           Could not save changes. Please try again.

--- a/app/src/features/edit-event/ui/EditEventDialogView.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.tsx
@@ -77,7 +77,12 @@ export function EditEventDialogView({
   const [references, setReferences] = useState<ReferenceRow[]>(toReferenceRows(event.references))
   // Seeded from what the event already carries, for the same replace-semantics reason as the links:
   // whatever this form submits IS the event's new roster, so an untouched override must survive.
-  const [rosterOverride, setRosterOverride] = useState<RosterRequirement | undefined>(event.rosterOverride)
+  // `?? undefined` is load-bearing: an inheriting event arrives with rosterOverride NULL, which the
+  // generated type declares as `undefined`. Seeding the state with the raw value hands null to the
+  // roster field, which then reads it as "customised" and dereferences it.
+  const [rosterOverride, setRosterOverride] = useState<RosterRequirement | undefined>(
+    event.rosterOverride ?? undefined,
+  )
 
   // Offer the active types, plus this event's own even when it has been archived: hiding it would
   // leave the picker blank and — worse — leave the roster field with no type to read a default from,

--- a/app/src/features/manage-event-types/lib/editor-open.test.ts
+++ b/app/src/features/manage-event-types/lib/editor-open.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isEditorOpen } from './editor-open'
+
+describe('isEditorOpen', () => {
+  it('is closed with nothing being edited', () => {
+    expect(isEditorOpen({ hasDraft: false, submitted: false })).toBe(false)
+  })
+
+  it('is open while a draft is being edited', () => {
+    expect(isEditorOpen({ hasDraft: true, submitted: false })).toBe(true)
+  })
+
+  // Optimistic: the admin sees the save land immediately rather than watching a spinner.
+  it('closes as soon as the draft is submitted', () => {
+    expect(isEditorOpen({ hasDraft: true, submitted: true })).toBe(false)
+  })
+
+  // The point of the whole rule: a rejected save must not cost the admin what they typed.
+  it('comes back when the save is rejected, so the draft is not lost', () => {
+    expect(isEditorOpen({ hasDraft: true, submitted: true, errorCode: 'EVENT_TYPE_NAME_TAKEN' })).toBe(true)
+  })
+
+  // An error with nothing being edited is a failed archive, not a failed save — nothing to reopen.
+  it('stays closed for an error raised outside the editor', () => {
+    expect(isEditorOpen({ hasDraft: false, submitted: false, errorCode: 'LAST_EVENT_TYPE' })).toBe(false)
+  })
+})

--- a/app/src/features/manage-event-types/lib/editor-open.ts
+++ b/app/src/features/manage-event-types/lib/editor-open.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether the event-type editor is on screen.
+ *
+ * It hides optimistically the moment a save is submitted, and comes BACK if the server rejects it.
+ * Closing outright on submit would throw away the whole draft — name, colour, every roster target —
+ * at exactly the moment the admin needs it in front of them to fix and retry.
+ *
+ * A pure rule rather than an effect: "did the save succeed?" is derivable from the props the
+ * container already passes down, and deriving beats a setState watching a falling edge.
+ */
+export function isEditorOpen(args: {
+  hasDraft: boolean
+  submitted: boolean
+  errorCode?: string | null
+}): boolean {
+  return args.hasDraft && (!args.submitted || !!args.errorCode)
+}

--- a/app/src/features/manage-event-types/lib/roster-default-summary.test.ts
+++ b/app/src/features/manage-event-types/lib/roster-default-summary.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { rosterDefaultSummary } from './roster-default-summary'
+
+const POSITIONS: Position[] = [
+  { id: 'p1', label: 'Setter' },
+  { id: 'p2', label: 'Libero' },
+]
+
+const req = (overrides: Partial<RosterRequirement> = {}): RosterRequirement => ({
+  trackRoster: true,
+  totalTarget: undefined,
+  positionTargets: [],
+  ...overrides,
+})
+
+describe('rosterDefaultSummary', () => {
+  it('says so when the type tracks no roster', () => {
+    expect(rosterDefaultSummary(req({ trackRoster: false }), POSITIONS)).toBe('No roster')
+  })
+
+  // The state most easily mistaken for a bug: tracked, but nothing to fall short of. It has to say
+  // what it is rather than render as an empty cell.
+  it('names the tracked-but-unrequired state explicitly', () => {
+    expect(rosterDefaultSummary(req(), POSITIONS)).toBe('Tracked, nothing required')
+  })
+
+  it('lists the per-position counts', () => {
+    const r = req({ positionTargets: [{ positionId: 'p1', count: 2 }, { positionId: 'p2', count: 1 }] })
+    expect(rosterDefaultSummary(r, POSITIONS)).toBe('2 Setter · 1 Libero')
+  })
+
+  it('appends the total after the positions', () => {
+    const r = req({ totalTarget: 12, positionTargets: [{ positionId: 'p1', count: 2 }] })
+    expect(rosterDefaultSummary(r, POSITIONS)).toBe('2 Setter · 12 total')
+  })
+
+  it('shows a lone total on its own', () => {
+    expect(rosterDefaultSummary(req({ totalTarget: 8 }), POSITIONS)).toBe('8 total')
+  })
+
+  // A target can outlive its position for the instant between the delete's two writes. The summary
+  // skips it rather than printing a raw uuid at an admin.
+  it('skips a target whose position no longer exists', () => {
+    const r = req({ positionTargets: [{ positionId: 'gone', count: 2 }, { positionId: 'p1', count: 1 }] })
+    expect(rosterDefaultSummary(r, POSITIONS)).toBe('1 Setter')
+  })
+
+  it('falls back to the tracked-but-unrequired wording when every target is stale', () => {
+    const r = req({ positionTargets: [{ positionId: 'gone', count: 2 }] })
+    expect(rosterDefaultSummary(r, POSITIONS)).toBe('Tracked, nothing required')
+  })
+})

--- a/app/src/features/manage-event-types/lib/roster-default-summary.ts
+++ b/app/src/features/manage-event-types/lib/roster-default-summary.ts
@@ -1,0 +1,30 @@
+import type { RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+
+/**
+ * A one-line description of a roster requirement, for the admin list row — so an admin can read what
+ * each type needs without opening its editor.
+ *
+ * Deliberately not the card's status: that is what the *event* currently looks like, this is what the
+ * *type* asks for. Nothing is computed against attendance here.
+ */
+export function rosterDefaultSummary(requirement: RosterRequirement, positions: Position[]): string {
+  if (!requirement.trackRoster) return 'No roster'
+
+  const labelById = new Map(positions.map((p) => [p.id, p.label]))
+  // Unknown ids are skipped rather than rendered as a raw uuid: a target can outlive its position
+  // for the instant between a delete's two writes, and the summary is not the place to expose that.
+  const perPosition = requirement.positionTargets
+    .map((t) => {
+      const label = labelById.get(t.positionId)
+      return label ? `${t.count} ${label}` : null
+    })
+    .filter((s): s is string => s !== null)
+
+  const total = requirement.totalTarget != null ? `${requirement.totalTarget} total` : null
+  const parts = [...perPosition, total].filter((s): s is string => s !== null)
+
+  // Tracking on with nothing required is a real state, and the one most easily mistaken for a bug —
+  // so it says what it is rather than rendering an empty string.
+  return parts.length === 0 ? 'Tracked, nothing required' : parts.join(' · ')
+}

--- a/app/src/features/manage-event-types/ui/ManageEventTypes.tsx
+++ b/app/src/features/manage-event-types/ui/ManageEventTypes.tsx
@@ -1,0 +1,56 @@
+import {
+  EventTypeError,
+  useArchiveEventType,
+  useCreateEventType,
+  useEventTypes,
+  useUnarchiveEventType,
+  useUpdateEventType,
+} from '@shared/api/event-types'
+import { usePositions } from '@shared/api/positions'
+import { ManageEventTypesView } from './ManageEventTypesView'
+
+/**
+ * Container for event-type management: wires the event-type and position queries and the
+ * create/update/archive/unarchive mutations to the presentational view. Pure wiring — the
+ * load/error shells live in the View (props-driven), so this seam is covered by e2e, not a story.
+ * See ADR-0017.
+ *
+ * It asks for archived types too: this is the one screen that shows them, and the only place they
+ * can be restored from.
+ */
+export function ManageEventTypes() {
+  const { data: eventTypes, isLoading, error } = useEventTypes(true)
+  const { data: positions } = usePositions()
+  const createEventType = useCreateEventType()
+  const updateEventType = useUpdateEventType()
+  const archiveEventType = useArchiveEventType()
+  const unarchiveEventType = useUnarchiveEventType()
+
+  const activeError = [
+    createEventType.error,
+    updateEventType.error,
+    archiveEventType.error,
+    unarchiveEventType.error,
+  ].find((e): e is EventTypeError => e instanceof EventTypeError)
+
+  const isSaving =
+    createEventType.isPending ||
+    updateEventType.isPending ||
+    archiveEventType.isPending ||
+    unarchiveEventType.isPending
+
+  return (
+    <ManageEventTypesView
+      eventTypes={eventTypes}
+      positions={positions}
+      isLoading={isLoading}
+      isError={!!error}
+      isSaving={isSaving}
+      errorCode={activeError?.code ?? null}
+      onCreate={(draft) => createEventType.mutate(draft)}
+      onUpdate={(id, draft) => updateEventType.mutate({ id, ...draft })}
+      onArchive={(id, migrateEventsTo) => archiveEventType.mutate({ id, migrateEventsTo })}
+      onUnarchive={(id) => unarchiveEventType.mutate({ id })}
+    />
+  )
+}

--- a/app/src/features/manage-event-types/ui/ManageEventTypesView.stories.tsx
+++ b/app/src/features/manage-event-types/ui/ManageEventTypesView.stories.tsx
@@ -1,0 +1,213 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, within } from 'storybook/test'
+import type { EventTypeItem } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { makeEventType, ROSTER_OFF } from '@shared/testing/event-fixtures'
+import { ManageEventTypesView } from './ManageEventTypesView'
+
+// The admin surface behind the ManageEventTypes container: create / rename / recolor / archive, each
+// type carrying the roster default its events inherit. Prop-only, so every state — including the
+// destructive archive dialog and its migration offer — renders from props with no network (ADR-0017).
+const POSITIONS: Position[] = [
+  { id: 'p1', label: 'Setter' },
+  { id: 'p2', label: 'Libero' },
+]
+
+const TYPES: EventTypeItem[] = [
+  makeEventType({
+    id: 'et-1',
+    name: 'Match',
+    color: '#225C9C',
+    rosterDefault: {
+      trackRoster: true,
+      totalTarget: 12,
+      positionTargets: [{ positionId: 'p1', count: 2 }],
+    },
+  }),
+  makeEventType({ id: 'et-2', name: 'Training', color: '#249E6C', rosterDefault: ROSTER_OFF }),
+]
+
+const meta = {
+  title: 'features/manage-event-types/ManageEventTypesView',
+  component: ManageEventTypesView,
+  args: {
+    eventTypes: TYPES,
+    positions: POSITIONS,
+    onCreate: fn(),
+    onUpdate: fn(),
+    onArchive: fn(),
+    onUnarchive: fn(),
+  },
+} satisfies Meta<typeof ManageEventTypesView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Loading: Story = {
+  args: { isLoading: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Loading…')).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Add event type' })).not.toBeInTheDocument()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Couldn't load event types. Please try again.")).toBeInTheDocument()
+  },
+}
+
+export const Empty: Story = {
+  args: { eventTypes: [] },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('No event types yet. Add one below.')).toBeInTheDocument()
+  },
+}
+
+// Each row summarises what its type asks for, so an admin reads the whole configuration without
+// opening anything — including the tracked-but-unrequired state, which is easily mistaken for a bug.
+export const WithTypes: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Match')).toBeInTheDocument()
+    await expect(canvas.getByText('2 Setter · 12 total')).toBeInTheDocument()
+    await expect(canvas.getByText('No roster')).toBeInTheDocument()
+  },
+}
+
+export const CreateEventType: Story = {
+  args: { eventTypes: [] },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Add event type' }))
+    await userEvent.type(canvas.getByLabelText('Event type name'), 'Tournament')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(args.onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Tournament', rosterDefault: ROSTER_OFF }),
+    )
+  },
+}
+
+// The roster default is authored in the same editor the per-event override uses, so the two can't
+// disagree about what a blank field means.
+export const EditRosterDefault: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Training' }))
+    // Tracking starts off for Training, so the targets are hidden until it is switched on.
+    await expect(canvas.queryByLabelText('People needed in total')).not.toBeInTheDocument()
+
+    await userEvent.click(canvas.getByRole('switch', { name: 'Track roster' }))
+    await userEvent.type(canvas.getByLabelText(/People needed in total/), '10')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(args.onUpdate).toHaveBeenCalledWith(
+      'et-2',
+      expect.objectContaining({
+        name: 'Training',
+        rosterDefault: expect.objectContaining({ trackRoster: true, totalTarget: 10 }),
+      }),
+    )
+  },
+}
+
+// A zero is "no target", the same as blank — and the same as what the server does with one.
+export const ZeroTargetMeansNoTarget: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Match' }))
+    const setter = canvas.getByLabelText('Setter')
+    await userEvent.clear(setter)
+    await userEvent.type(setter, '0')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(args.onUpdate).toHaveBeenCalledWith(
+      'et-1',
+      expect.objectContaining({
+        rosterDefault: expect.objectContaining({ positionTargets: [] }),
+      }),
+    )
+  },
+}
+
+// The destructive path. It leads with the migration offer, because leaving events on a type no
+// picker shows is the fallback, not the default.
+export const ArchiveWithMigration: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Archive Match' }))
+    const dialog = within(document.body)
+    await expect(await dialog.findByText('Archive "Match"?')).toBeInTheDocument()
+    // Says plainly that no event is deleted — the fear this dialog has to answer.
+    await expect(dialog.getByText(/no event is deleted/i)).toBeInTheDocument()
+
+    await userEvent.selectOptions(dialog.getByLabelText(/Move its events/), 'et-2')
+    await userEvent.click(dialog.getByRole('button', { name: 'Archive' }))
+
+    await expect(args.onArchive).toHaveBeenCalledWith('et-1', 'et-2')
+  },
+}
+
+// Declining the migration is a real choice, not an oversight: the events keep the archived type.
+export const ArchiveWithoutMigration: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Archive Match' }))
+    const dialog = within(document.body)
+    await userEvent.click(await dialog.findByRole('button', { name: 'Archive' }))
+
+    await expect(args.onArchive).toHaveBeenCalledWith('et-1', undefined)
+  },
+}
+
+export const WithArchivedTypes: Story = {
+  args: {
+    eventTypes: [
+      ...TYPES,
+      makeEventType({ id: 'et-3', name: 'Old Social', archived: true, rosterDefault: ROSTER_OFF }),
+    ],
+  },
+  play: async ({ canvas, userEvent, args }) => {
+    // Archived types are listed apart, and cannot be edited — only restored.
+    await expect(canvas.getByText('Archived')).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Edit Old Social' })).not.toBeInTheDocument()
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Restore Old Social' }))
+    await expect(args.onUnarchive).toHaveBeenCalledWith('et-3')
+  },
+}
+
+export const NameTaken: Story = {
+  args: { errorCode: 'EVENT_TYPE_NAME_TAKEN' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('That event type already exists.')).toBeInTheDocument()
+  },
+}
+
+// The editor hides optimistically on submit — the admin sees the save land rather than watching a
+// spinner. That it comes BACK on a rejection (draft intact) is the pure rule in lib/editor-open,
+// unit-tested there; a story cannot change args mid-play to drive the second half.
+export const SubmitClosesTheEditorOptimistically: Story = {
+  args: { eventTypes: [] },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Add event type' }))
+    await userEvent.type(canvas.getByLabelText('Event type name'), 'Match')
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(canvas.queryByLabelText('Event type name')).not.toBeInTheDocument()
+  },
+}
+
+// Every code the container can produce says something. Silence would be indistinguishable from a
+// save that worked.
+export const UnhandledErrorStillSpeaks: Story = {
+  args: { errorCode: 'FORBIDDEN' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('You are not allowed to make this change.')).toBeInTheDocument()
+  },
+}
+
+// The rule that stops a team archiving its way to no types at all, and no way to create an event.
+export const LastEventTypeRefused: Story = {
+  args: { errorCode: 'LAST_EVENT_TYPE' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('A team must keep at least one active event type.')).toBeInTheDocument()
+  },
+}

--- a/app/src/features/manage-event-types/ui/ManageEventTypesView.stories.tsx
+++ b/app/src/features/manage-event-types/ui/ManageEventTypesView.stories.tsx
@@ -77,6 +77,9 @@ export const WithTypes: Story = {
 }
 
 export const CreateEventType: Story = {
+  // Behavioural twin of Empty — save closes the editor, so the post-play frame is the empty list
+  // again (ADR-0027 §2). The spy is the point; the picture is Empty's.
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { eventTypes: [] },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Add event type' }))
@@ -92,6 +95,10 @@ export const CreateEventType: Story = {
 // The roster default is authored in the same editor the per-event override uses, so the two can't
 // disagree about what a blank field means.
 export const EditRosterDefault: Story = {
+  // Behavioural twin of WithTypes — save closes the editor and settles back to the list
+  // (ADR-0027 §2). The mid-play frames (targets appearing when tracking is switched on) are
+  // exercised here but pictured by RosterOverrideField's own stories.
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Edit Training' }))
     // Tracking starts off for Training, so the targets are hidden until it is switched on.
@@ -113,6 +120,9 @@ export const EditRosterDefault: Story = {
 
 // A zero is "no target", the same as blank — and the same as what the server does with one.
 export const ZeroTargetMeansNoTarget: Story = {
+  // Behavioural twin of WithTypes — save closes the editor and settles back to the list
+  // (ADR-0027 §2). What is being proven is the dropped target in the payload, not a picture.
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Edit Match' }))
     const setter = canvas.getByLabelText('Setter')
@@ -132,6 +142,9 @@ export const ZeroTargetMeansNoTarget: Story = {
 // The destructive path. It leads with the migration offer, because leaving events on a type no
 // picker shows is the fallback, not the default.
 export const ArchiveWithMigration: Story = {
+  // Behavioural twin of WithTypes — confirming closes the dialog, so the post-play frame is the
+  // list again (ADR-0027 §2). The open dialog is pictured by ArchiveDialogOpen below.
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Archive Match' }))
     const dialog = within(document.body)
@@ -148,12 +161,30 @@ export const ArchiveWithMigration: Story = {
 
 // Declining the migration is a real choice, not an oversight: the events keep the archived type.
 export const ArchiveWithoutMigration: Story = {
+  // Behavioural twin of WithTypes — as above; this one proves the undefined migration target.
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Archive Match' }))
     const dialog = within(document.body)
     await userEvent.click(await dialog.findByRole('button', { name: 'Archive' }))
 
     await expect(args.onArchive).toHaveBeenCalledWith('et-1', undefined)
+  },
+}
+
+// The archive dialog is the one screen that has to answer "will this delete my events?", and it
+// leads with the migration offer rather than burying it. Both Archive stories above confirm, so the
+// dialog is gone before Chromatic shoots — this one opens it and stops, so that wording carries a
+// baseline (ADR-0027 §2).
+export const ArchiveDialogOpen: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Archive Match' }))
+    const dialog = within(document.body)
+    await expect(await dialog.findByText('Archive "Match"?')).toBeInTheDocument()
+    await expect(dialog.getByText(/no event is deleted/i)).toBeInTheDocument()
+    // The migration picker leads; leaving it unset is the fallback, not the default.
+    await expect(dialog.getByLabelText(/Move its events/)).toBeInTheDocument()
+    await expect(args.onArchive).not.toHaveBeenCalled()
   },
 }
 
@@ -185,6 +216,9 @@ export const NameTaken: Story = {
 // spinner. That it comes BACK on a rejection (draft intact) is the pure rule in lib/editor-open,
 // unit-tested there; a story cannot change args mid-play to drive the second half.
 export const SubmitClosesTheEditorOptimistically: Story = {
+  // Behavioural twin of Empty — asserts the editor is gone, which IS the empty-list picture
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { eventTypes: [] },
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Add event type' }))

--- a/app/src/features/manage-event-types/ui/ManageEventTypesView.tsx
+++ b/app/src/features/manage-event-types/ui/ManageEventTypesView.tsx
@@ -1,0 +1,350 @@
+import { useState } from 'react'
+import { Archive, ArchiveRestore, Pencil } from 'lucide-react'
+import type { EventTypeItem, RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@shared/ui/dialog'
+import { RosterRequirementEditor } from './RosterRequirementEditor'
+import { rosterDefaultSummary } from '../lib/roster-default-summary'
+import { isEditorOpen } from '../lib/editor-open'
+
+export interface EventTypeDraft {
+  name: string
+  color?: string
+  rosterDefault: RosterRequirement
+}
+
+interface ManageEventTypesViewProps {
+  eventTypes?: EventTypeItem[]
+  positions?: Position[]
+  isLoading?: boolean
+  isError?: boolean
+  isSaving?: boolean
+  /** Backend error discriminator from the container (e.g. EVENT_TYPE_NAME_TAKEN), shown inline. */
+  errorCode?: string | null
+  onCreate: (draft: EventTypeDraft) => void
+  onUpdate: (id: string, draft: EventTypeDraft) => void
+  onArchive: (id: string, migrateEventsTo?: string) => void
+  onUnarchive: (id: string) => void
+}
+
+const OFF: RosterRequirement = { trackRoster: false, totalTarget: undefined, positionTargets: [] }
+
+const PALETTE = ['#225C9C', '#249E6C', '#F4B400', '#7B5EA7', '#E87C3E', '#D93025']
+
+const FALLBACK_ERROR = 'Something went wrong. Please try again.'
+
+const ERROR_MESSAGES: Record<string, string> = {
+  EVENT_TYPE_NAME_TAKEN: 'That event type already exists.',
+  LAST_EVENT_TYPE: 'A team must keep at least one active event type.',
+  INVALID_REQUEST: "That didn't work — check the name and roster, then try again.",
+  FORBIDDEN: 'You are not allowed to make this change.',
+  NOT_FOUND: 'That event type no longer exists. Reload and try again.',
+}
+
+/**
+ * Presentational event-type management — the whole section, heading and all.
+ *
+ * Owns only local view state (which type is being edited, the draft in the form, the archive
+ * dialog's target and migration choice); the queries and mutations live in the ManageEventTypes
+ * container. The load/error shells are props-driven so every state is a story with no network
+ * (ADR-0017).
+ */
+export function ManageEventTypesView({
+  eventTypes = [],
+  positions = [],
+  isLoading,
+  isError,
+  isSaving,
+  errorCode,
+  onCreate,
+  onUpdate,
+  onArchive,
+  onUnarchive,
+}: ManageEventTypesViewProps) {
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState<EventTypeDraft | null>(null)
+  const [archiveTarget, setArchiveTarget] = useState<EventTypeItem | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  const active = eventTypes.filter((t) => !t.archived)
+  const archived = eventTypes.filter((t) => t.archived)
+
+  const startCreate = () => {
+    setEditingId('new')
+    setDraft({ name: '', color: PALETTE[0], rosterDefault: OFF })
+    setSubmitted(false)
+  }
+
+  const startEdit = (type: EventTypeItem) => {
+    setEditingId(type.id)
+    setDraft({ name: type.name, color: type.color, rosterDefault: type.rosterDefault })
+    setSubmitted(false)
+  }
+
+  const close = () => {
+    setEditingId(null)
+    setDraft(null)
+    setSubmitted(false)
+  }
+
+  const editorOpen = isEditorOpen({ hasDraft: draft !== null, submitted, errorCode })
+
+  const submit = () => {
+    if (!draft || draft.name.trim().length === 0) return
+    const payload = { ...draft, name: draft.name.trim() }
+    if (editingId === 'new') onCreate(payload)
+    else if (editingId) onUpdate(editingId, payload)
+    setSubmitted(true)
+  }
+
+  return (
+    <div>
+      <h2 className="font-display text-2xl font-bold">Event types</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Each type carries the roster an event of that kind needs. Events follow their type unless you
+        give one its own.
+      </p>
+
+      {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
+      {isError && (
+        <p className="mt-4 text-sm text-red">Couldn't load event types. Please try again.</p>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="mt-4 flex flex-col gap-3">
+          {/* Every code the container can hand down renders something. A save that failed and said
+              nothing is indistinguishable from one that worked. */}
+          {errorCode && <p className="text-sm text-red">{ERROR_MESSAGES[errorCode] ?? FALLBACK_ERROR}</p>}
+
+          {active.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No event types yet. Add one below.</p>
+          ) : (
+            <ul className="divide-y divide-border rounded-lg border border-border">
+              {active.map((type) => (
+                <li key={type.id} className="flex flex-wrap items-center gap-2 p-3">
+                  <span
+                    aria-hidden
+                    className="size-3 shrink-0 rounded-full"
+                    style={{ background: type.color ?? '#94A3B8' }}
+                  />
+                  <span className="text-sm font-semibold">{type.name}</span>
+                  <span className="text-[11.5px] text-muted-foreground">
+                    {rosterDefaultSummary(type.rosterDefault, positions)}
+                  </span>
+                  <div className="ml-auto flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isSaving}
+                      onClick={() => startEdit(type)}
+                      aria-label={`Edit ${type.name}`}
+                    >
+                      <Pencil size={14} />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={isSaving}
+                      onClick={() => setArchiveTarget(type)}
+                      aria-label={`Archive ${type.name}`}
+                    >
+                      <Archive size={14} />
+                      Archive
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!editorOpen && (
+            <Button className="self-start" disabled={isSaving} onClick={startCreate}>
+              Add event type
+            </Button>
+          )}
+
+          {editorOpen && draft && (
+            <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
+              <h3 className="text-sm font-semibold">
+                {editingId === 'new' ? 'New event type' : 'Edit event type'}
+              </h3>
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  aria-label="Event type name"
+                  className="w-48"
+                  value={draft.name}
+                  placeholder="e.g. Match"
+                  onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                />
+                <div className="flex gap-1.5" role="radiogroup" aria-label="Colour">
+                  {PALETTE.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      role="radio"
+                      aria-checked={draft.color === color}
+                      aria-label={`Colour ${color}`}
+                      onClick={() => setDraft({ ...draft, color })}
+                      style={{ background: color }}
+                      className={`size-6 rounded-full ring-offset-background transition-transform ${
+                        draft.color === color ? 'ring-2 ring-foreground ring-offset-2' : ''
+                      }`}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <RosterRequirementEditor
+                idPrefix="type-default"
+                value={draft.rosterDefault}
+                positions={positions}
+                disabled={isSaving}
+                onChange={(rosterDefault) => setDraft({ ...draft, rosterDefault })}
+              />
+
+              <div className="flex gap-2">
+                <Button disabled={isSaving || draft.name.trim().length === 0} onClick={submit}>
+                  Save
+                </Button>
+                <Button variant="outline" disabled={isSaving} onClick={close}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {archived.length > 0 && (
+            <div className="mt-2">
+              <h3 className="text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground">
+                Archived
+              </h3>
+              <ul className="mt-2 divide-y divide-border rounded-lg border border-dashed border-border">
+                {archived.map((type) => (
+                  <li key={type.id} className="flex items-center gap-2 p-3">
+                    <span className="text-sm text-muted-foreground">{type.name}</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="ml-auto"
+                      disabled={isSaving}
+                      onClick={() => onUnarchive(type.id)}
+                      aria-label={`Restore ${type.name}`}
+                    >
+                      <ArchiveRestore size={14} />
+                      Restore
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      <ArchiveDialog
+        target={archiveTarget}
+        alternatives={active.filter((t) => t.id !== archiveTarget?.id)}
+        isSaving={isSaving}
+        onCancel={() => setArchiveTarget(null)}
+        onConfirm={(id, migrateEventsTo) => {
+          onArchive(id, migrateEventsTo)
+          setArchiveTarget(null)
+        }}
+      />
+    </div>
+  )
+}
+
+interface ArchiveDialogProps {
+  target: EventTypeItem | null
+  alternatives: EventTypeItem[]
+  isSaving?: boolean
+  onCancel: () => void
+  onConfirm: (id: string, migrateEventsTo?: string) => void
+}
+
+/**
+ * The destructive confirmation. It leads with the migration offer rather than burying it, because
+ * moving the events somewhere still visible is almost always what an admin wants — keeping them on
+ * a type that no longer appears in any picker is the fallback, not the default.
+ *
+ * It cannot delete anything: an event's type is non-null, so archiving only ever hides the type.
+ */
+function ArchiveDialog({ target, alternatives, isSaving, onCancel, onConfirm }: ArchiveDialogProps) {
+  const [migrateTo, setMigrateTo] = useState<string>('')
+
+  return (
+    <Dialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          setMigrateTo('')
+          onCancel()
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive "{target?.name}"?</DialogTitle>
+          <DialogDescription>
+            It disappears from the event pickers. Existing events keep this type and still show — no
+            event is deleted.
+          </DialogDescription>
+        </DialogHeader>
+
+        {alternatives.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <label htmlFor="migrate-to" className="text-[13px] font-semibold">
+              Move its events to another type first?
+            </label>
+            <select
+              id="migrate-to"
+              className="rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              value={migrateTo}
+              onChange={(e) => setMigrateTo(e.target.value)}
+            >
+              <option value="">Leave them on "{target?.name}"</option>
+              {alternatives.map((t) => (
+                <option key={t.id} value={t.id}>
+                  Move to {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setMigrateTo('')
+              onCancel()
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={isSaving}
+            onClick={() => {
+              if (target) onConfirm(target.id, migrateTo || undefined)
+              setMigrateTo('')
+            }}
+          >
+            Archive
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
+++ b/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
@@ -44,6 +44,19 @@ export const Inheriting: Story = {
   },
 }
 
+// The server puts a literal `null` on the wire for an inheriting event, while wirespec types the
+// field as `undefined`. Before this was guarded, a null slipped past the `=== undefined` check, the
+// editor rendered as "customised", and reading `value.trackRoster` crashed the whole edit dialog.
+// The cast is the point of the story: TypeScript says this state is impossible, and the wire
+// produces it anyway.
+export const NullFromTheWireStillInherits: Story = {
+  args: { value: null as unknown as undefined },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('radio', { name: 'Inherit default' })).toBeChecked()
+    await expect(canvas.queryByRole('switch', { name: 'Track roster' })).not.toBeInTheDocument()
+  },
+}
+
 // Switching to Customise seeds from the type's current default, so the admin edits from where the
 // event already is rather than from an empty form.
 export const CustomiseSeedsFromTheTypeDefault: Story = {

--- a/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
+++ b/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import type { Position } from '@shared/api/positions'
+import { makeEventType } from '@shared/testing/event-fixtures'
+import { RosterOverrideField } from './RosterOverrideField'
+
+// "Inherit default / Customise" in the create and edit event forms. Prop-only: the value and the
+// selected event type come from the form around it, so both branches render with no network.
+const POSITIONS: Position[] = [
+  { id: 'p1', label: 'Setter' },
+  { id: 'p2', label: 'Libero' },
+]
+
+const MATCH = makeEventType({
+  id: 'et-1',
+  name: 'Match',
+  rosterDefault: {
+    trackRoster: true,
+    totalTarget: 12,
+    positionTargets: [{ positionId: 'p1', count: 2 }],
+  },
+})
+
+const meta = {
+  title: 'features/manage-event-types/RosterOverrideField',
+  component: RosterOverrideField,
+  args: { eventType: MATCH, positions: POSITIONS, onChange: fn() },
+} satisfies Meta<typeof RosterOverrideField>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// The default, and the one that needs explaining: inheriting is not a snapshot. It says so, and
+// names what the type currently asks for so the choice is informed.
+export const Inheriting: Story = {
+  args: { value: undefined },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('radio', { name: 'Inherit default' })).toBeChecked()
+    await expect(canvas.getByText(/Follows Match: 2 Setter · 12 total/)).toBeInTheDocument()
+    await expect(canvas.getByText(/Changing the type's default changes this event too/)).toBeInTheDocument()
+    // Nothing to edit while inheriting.
+    await expect(canvas.queryByRole('switch', { name: 'Track roster' })).not.toBeInTheDocument()
+  },
+}
+
+// Switching to Customise seeds from the type's current default, so the admin edits from where the
+// event already is rather than from an empty form.
+export const CustomiseSeedsFromTheTypeDefault: Story = {
+  args: { value: undefined },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('radio', { name: 'Customise' }))
+
+    await expect(args.onChange).toHaveBeenCalledWith({
+      trackRoster: true,
+      totalTarget: 12,
+      positionTargets: [{ positionId: 'p1', count: 2 }],
+    })
+  },
+}
+
+export const Customised: Story = {
+  args: {
+    value: { trackRoster: true, totalTarget: 8, positionTargets: [{ positionId: 'p2', count: 1 }] },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('radio', { name: 'Customise' })).toBeChecked()
+    await expect(canvas.getByLabelText(/People needed in total/)).toHaveValue(8)
+    await expect(canvas.getByLabelText('Libero')).toHaveValue(1)
+    await expect(canvas.getByLabelText('Setter')).toHaveValue(null)
+  },
+}
+
+// Going back to Inherit clears the override outright rather than keeping a stale copy of it.
+export const BackToInheriting: Story = {
+  args: { value: { trackRoster: true, totalTarget: 8, positionTargets: [] } },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('radio', { name: 'Inherit default' }))
+    await expect(args.onChange).toHaveBeenCalledWith(undefined)
+  },
+}
+
+// A customised event may switch tracking OFF even when its type tracks — "no panel on this one
+// occurrence" is a deliberate answer, not the absence of one.
+export const CustomisedTrackingOff: Story = {
+  args: { value: { trackRoster: false, totalTarget: undefined, positionTargets: [] } },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('switch', { name: 'Track roster' })).toHaveAttribute('aria-checked', 'false')
+    await expect(canvas.getByText(/no roster panel on the card/i)).toBeInTheDocument()
+  },
+}
+
+// With no positions configured, per-position targets are impossible — so the editor says why rather
+// than showing an empty list.
+export const NoPositionsYet: Story = {
+  args: {
+    positions: [],
+    value: { trackRoster: true, totalTarget: undefined, positionTargets: [] },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/Add positions below to require a specific lineup/)).toBeInTheDocument()
+  },
+}

--- a/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
+++ b/app/src/features/manage-event-types/ui/RosterOverrideField.stories.tsx
@@ -47,6 +47,11 @@ export const Inheriting: Story = {
 // Switching to Customise seeds from the type's current default, so the admin edits from where the
 // event already is rather than from an empty form.
 export const CustomiseSeedsFromTheTypeDefault: Story = {
+  // Behavioural twin of Inheriting — the field is controlled, so clicking Customise fires
+  // onChange without re-rendering: the post-play picture is still the inheriting one
+  // (ADR-0027 §2). BackToInheriting deliberately KEEPS its baseline — its customised-with-no-
+  // position-targets frame is a picture no sibling carries.
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { value: undefined },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('radio', { name: 'Customise' }))

--- a/app/src/features/manage-event-types/ui/RosterOverrideField.tsx
+++ b/app/src/features/manage-event-types/ui/RosterOverrideField.tsx
@@ -1,0 +1,92 @@
+import type { EventTypeItem, RosterRequirement } from '@shared/api/event-types'
+import type { Position } from '@shared/api/positions'
+import { RosterRequirementEditor } from './RosterRequirementEditor'
+import { rosterDefaultSummary } from '../lib/roster-default-summary'
+
+interface RosterOverrideFieldProps {
+  /** The event's own requirement, or undefined to inherit `eventType`'s default. */
+  value?: RosterRequirement
+  /** The type currently selected in the form — whose default is what "Inherit" means right now. */
+  eventType?: EventTypeItem
+  positions?: Position[]
+  disabled?: boolean
+  onChange: (next: RosterRequirement | undefined) => void
+}
+
+/**
+ * "Inherit default / Customise" for one event's roster (#219).
+ *
+ * Inherit is not a snapshot: an inheriting event follows its type's default as that default changes,
+ * which is what lets a recurring series track the team's shape without every occurrence being
+ * rewritten. Customising replaces the default outright rather than patching it — there is no partial
+ * inheritance to explain, and "what does this event need?" keeps a single answer.
+ *
+ * Switching to Customise seeds the form with the type's current default, so an admin edits from
+ * where the event already is rather than from an empty form.
+ */
+export function RosterOverrideField({
+  value,
+  eventType,
+  positions = [],
+  disabled,
+  onChange,
+}: RosterOverrideFieldProps) {
+  const inheriting = value === undefined
+  const typeDefault = eventType?.rosterDefault
+
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium">Roster</legend>
+
+      <div className="flex gap-2" role="radiogroup" aria-label="Roster">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={inheriting}
+          disabled={disabled}
+          onClick={() => onChange(undefined)}
+          className={`rounded-full border px-3 py-1.5 text-[13px] ${
+            inheriting ? 'border-foreground bg-foreground text-background' : 'border-border'
+          }`}
+        >
+          Inherit default
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={!inheriting}
+          disabled={disabled}
+          // Seeded from the type's current default so Customise starts where the event already is —
+          // but only on the way IN. Re-clicking the option you are already on is a no-op for a radio,
+          // and re-seeding here would silently discard everything the admin had just typed.
+          onClick={() => {
+            if (inheriting) {
+              onChange(typeDefault ?? { trackRoster: false, totalTarget: undefined, positionTargets: [] })
+            }
+          }}
+          className={`rounded-full border px-3 py-1.5 text-[13px] ${
+            !inheriting ? 'border-foreground bg-foreground text-background' : 'border-border'
+          }`}
+        >
+          Customise
+        </button>
+      </div>
+
+      {inheriting ? (
+        <p className="text-[11.5px] text-muted-foreground">
+          {eventType
+            ? `Follows ${eventType.name}: ${rosterDefaultSummary(eventType.rosterDefault, positions)}. Changing the type's default changes this event too.`
+            : 'Follows the event type’s default.'}
+        </p>
+      ) : (
+        <RosterRequirementEditor
+          idPrefix="event-override"
+          value={value}
+          positions={positions}
+          disabled={disabled}
+          onChange={onChange}
+        />
+      )}
+    </fieldset>
+  )
+}

--- a/app/src/features/manage-event-types/ui/RosterOverrideField.tsx
+++ b/app/src/features/manage-event-types/ui/RosterOverrideField.tsx
@@ -4,8 +4,14 @@ import { RosterRequirementEditor } from './RosterRequirementEditor'
 import { rosterDefaultSummary } from '../lib/roster-default-summary'
 
 interface RosterOverrideFieldProps {
-  /** The event's own requirement, or undefined to inherit `eventType`'s default. */
-  value?: RosterRequirement
+  /**
+   * The event's own requirement, or absent to inherit `eventType`'s default.
+   *
+   * Typed optional, but it is checked for null too: wirespec renders an optional field as
+   * `T | undefined` in TypeScript while the server puts a literal `null` on the wire, so an
+   * inheriting event really does arrive here as null however the type reads.
+   */
+  value?: RosterRequirement | null
   /** The type currently selected in the form — whose default is what "Inherit" means right now. */
   eventType?: EventTypeItem
   positions?: Position[]
@@ -31,7 +37,7 @@ export function RosterOverrideField({
   disabled,
   onChange,
 }: RosterOverrideFieldProps) {
-  const inheriting = value === undefined
+  const inheriting = value == null
   const typeDefault = eventType?.rosterDefault
 
   return (

--- a/app/src/features/manage-event-types/ui/RosterRequirementEditor.tsx
+++ b/app/src/features/manage-event-types/ui/RosterRequirementEditor.tsx
@@ -1,0 +1,139 @@
+import type { Position } from '@shared/api/positions'
+import type { RosterRequirement } from '@shared/api/event-types'
+import { Input } from '@shared/ui/input'
+
+interface RosterRequirementEditorProps {
+  value: RosterRequirement
+  positions: Position[]
+  disabled?: boolean
+  onChange: (next: RosterRequirement) => void
+  /** Distinguishes the field ids when two editors are on screen at once. */
+  idPrefix: string
+}
+
+/**
+ * Edits one roster requirement: the tracking switch, the total headcount, and a count per position.
+ *
+ * Shared by the event-type default and the per-event override, because they are the same value and
+ * must be authored the same way — two editors would be two chances to disagree about what a blank
+ * field means.
+ *
+ * Blank and zero both mean "no target", and the requirement carries neither: a total is dropped to
+ * undefined, and a position simply gets no entry. That is what the server does with a zero too, so
+ * the form and the API agree without the form having to know the rule twice.
+ */
+export function RosterRequirementEditor({
+  value,
+  positions,
+  disabled,
+  onChange,
+  idPrefix,
+}: RosterRequirementEditorProps) {
+  const targetFor = (positionId: string) =>
+    value.positionTargets.find((t) => t.positionId === positionId)?.count
+
+  const setTotal = (raw: string) => {
+    const n = Number.parseInt(raw, 10)
+    onChange({ ...value, totalTarget: Number.isFinite(n) && n > 0 ? n : undefined })
+  }
+
+  const setPositionTarget = (positionId: string, raw: string) => {
+    const n = Number.parseInt(raw, 10)
+    const others = value.positionTargets.filter((t) => t.positionId !== positionId)
+    onChange({
+      ...value,
+      positionTargets:
+        Number.isFinite(n) && n > 0 ? [...others, { positionId, count: n }] : others,
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[13.5px] font-semibold">Track roster</div>
+          <div className="mt-0.5 text-[11.5px] text-muted-foreground">
+            {value.trackRoster
+              ? 'On — the card shows who is covering which position'
+              : 'Off — no roster panel on the card'}
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={value.trackRoster}
+          aria-label="Track roster"
+          disabled={disabled}
+          // Targets are kept when tracking goes off, so switching it back on restores the lineup
+          // instead of handing back an empty form. The server keeps them for the same reason.
+          onClick={() => onChange({ ...value, trackRoster: !value.trackRoster })}
+          className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${
+            value.trackRoster ? 'bg-green' : 'bg-muted-foreground/30'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 size-5 rounded-full bg-white transition-transform ${
+              value.trackRoster ? 'translate-x-[22px]' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Hidden rather than disabled when tracking is off: there is nothing to configure, and a
+          greyed-out form invites fiddling with settings that have no effect. */}
+      {value.trackRoster && (
+        <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
+          <div className="flex items-center justify-between gap-3">
+            <label htmlFor={`${idPrefix}-total`} className="text-[13px]">
+              People needed in total
+              <span className="ml-1 text-[11.5px] text-muted-foreground">(optional)</span>
+            </label>
+            <Input
+              id={`${idPrefix}-total`}
+              type="number"
+              min={0}
+              max={200}
+              inputMode="numeric"
+              className="w-20"
+              disabled={disabled}
+              value={value.totalTarget ?? ''}
+              placeholder="—"
+              onChange={(e) => setTotal(e.target.value)}
+            />
+          </div>
+
+          {positions.length === 0 ? (
+            <p className="text-[12px] text-muted-foreground">
+              Add positions below to require a specific lineup.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <p className="text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground">
+                Per position
+              </p>
+              {positions.map((position) => (
+                <div key={position.id} className="flex items-center justify-between gap-3">
+                  <label htmlFor={`${idPrefix}-pos-${position.id}`} className="truncate text-[13px]">
+                    {position.label}
+                  </label>
+                  <Input
+                    id={`${idPrefix}-pos-${position.id}`}
+                    type="number"
+                    min={0}
+                    max={99}
+                    inputMode="numeric"
+                    className="w-20"
+                    disabled={disabled}
+                    value={targetFor(position.id) ?? ''}
+                    placeholder="—"
+                    onChange={(e) => setPositionTarget(position.id, e.target.value)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/features/manage-event-types/ui/RosterRequirementEditor.tsx
+++ b/app/src/features/manage-event-types/ui/RosterRequirementEditor.tsx
@@ -72,8 +72,10 @@ export function RosterRequirementEditor({
           }`}
         >
           <span
-            className={`absolute top-0.5 size-5 rounded-full bg-white transition-transform ${
-              value.trackRoster ? 'translate-x-[22px]' : 'translate-x-0.5'
+            // left is pinned explicitly: a bare `absolute` would fall back to the static position,
+            // which a button's centred text alignment drags to the middle of the track.
+            className={`absolute top-0.5 left-0.5 size-5 rounded-full bg-white shadow-sm transition-transform ${
+              value.trackRoster ? 'translate-x-5' : 'translate-x-0'
             }`}
           />
         </button>

--- a/app/src/features/manage-positions/ui/ManagePositions.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositions.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
+import type { Position } from '@shared/api/positions'
 import {
   PositionError,
   useCreatePosition,
   useDeletePosition,
+  usePositionUsage,
   usePositions,
   useRenamePosition,
 } from '@shared/api/positions'
@@ -18,6 +21,10 @@ export function ManagePositions() {
   const createPosition = useCreatePosition()
   const renamePosition = useRenamePosition()
   const deletePosition = useDeletePosition()
+  // The delete dialog's target, lifted here only so its usage can be fetched — the dialog itself
+  // stays the View's own local state.
+  const [usageTarget, setUsageTarget] = useState<Position | null>(null)
+  const { data: usage } = usePositionUsage(usageTarget?.id ?? null)
 
   const activeError = [createPosition.error, renamePosition.error, deletePosition.error].find(
     (e): e is PositionError => e instanceof PositionError,
@@ -28,6 +35,8 @@ export function ManagePositions() {
   return (
     <ManagePositionsView
       positions={positions}
+      usage={usageTarget ? usage : undefined}
+      onConfirmTargetChange={setUsageTarget}
       isLoading={isLoading}
       isError={!!error}
       isSaving={isSaving}

--- a/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
@@ -89,31 +89,65 @@ export const RenamePosition: Story = {
 
 export const DeleteConfirm: Story = {
   // Behavioural twin of WithItems — the confirm dialog closes on confirm and settles back to the
-  // items picture; the open-dialog frame keeps its own baseline via DeleteConfirmOpen below
-  // (#263, ADR-0027 §2).
+  // items picture; the open-dialog frames keep their own baselines below (#263, ADR-0027 §2) —
+  // three of them now, because #219 gives the dialog three states rather than one.
   parameters: { chromatic: { disableSnapshot: true } },
+  args: { usage: { eventTypeCount: 2, eventCount: 1, memberCount: 3 } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
     const dialog = within(document.body)
-    await expect(
-      await dialog.findByText(/Members with this position will become Unassigned/),
-    ).toBeInTheDocument()
+    // The dialog names what the delete will actually touch (#219) rather than warning in the
+    // abstract — a warning, not a veto: the Delete button is still live.
+    await expect(await dialog.findByText(/3 members become Unassigned/)).toBeInTheDocument()
+    await expect(dialog.getByText(/dropped from 2 event types/)).toBeInTheDocument()
+    await expect(dialog.getByText(/from 1 event with their own roster/)).toBeInTheDocument()
     await userEvent.click(dialog.getByRole('button', { name: 'Delete' }))
     await expect(args.onDelete).toHaveBeenCalledWith(POSITIONS[0])
   },
 }
 
-// Open-dialog baseline: the first row's Delete opens the confirm dialog (a portal); we stop with it
-// open — no confirm click — so the open dialog frame gets its own keep-baseline snapshot. The
-// DeleteConfirm spy above closes on confirm, so it never pictures the open dialog.
-export const DeleteConfirmOpen: Story = {
+// Open-dialog baselines. #264 added a single DeleteConfirmOpen here for the frame DeleteConfirm
+// cannot picture (its play confirms, so the dialog is gone before Chromatic shoots). #219 gives that
+// dialog three distinct states — the counts have arrived, they arrived as zero, or they are still in
+// flight — so the one story becomes three. Each opens the dialog and stops; none confirms.
+//
+// The populated one is the frame an admin actually reads before a destructive action, and it is why
+// the blast-radius work exists at all.
+export const DeleteConfirmUsageCounts: Story = {
+  args: { usage: { eventTypeCount: 2, eventCount: 1, memberCount: 3 } },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
+    const dialog = within(document.body)
+    await expect(await dialog.findByText(/3 members become Unassigned/)).toBeInTheDocument()
+    await expect(dialog.getByText(/dropped from 2 event types/)).toBeInTheDocument()
+    await expect(dialog.getByText(/from 1 event with their own roster/)).toBeInTheDocument()
+    // Deliberately not confirmed: a warning is not a veto, so the Delete button stays live and
+    // nothing has fired yet.
+    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeEnabled()
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    await expect(args.onDelete).not.toHaveBeenCalled()
+  },
+}
+
+// A position nothing uses reads as a clean removal rather than a list of three zeroes.
+export const DeleteConfirmUnused: Story = {
+  args: { usage: { eventTypeCount: 0, eventCount: 0, memberCount: 0 } },
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
     const dialog = within(document.body)
-    await expect(
-      await dialog.findByText(/Members with this position will become Unassigned/),
-    ).toBeInTheDocument()
-    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    await expect(await dialog.findByText('Nothing currently uses this position.')).toBeInTheDocument()
+  },
+}
+
+// The usage query is admin-only and fires when the dialog opens, so there is a moment with no
+// answer yet. It must not read as "nothing uses this".
+export const DeleteConfirmUsageLoading: Story = {
+  args: { usage: undefined },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
+    const dialog = within(document.body)
+    await expect(await dialog.findByText('Checking what uses this position…')).toBeInTheDocument()
+    await expect(dialog.queryByText(/Nothing currently uses/)).not.toBeInTheDocument()
   },
 }
 

--- a/app/src/features/manage-positions/ui/ManagePositionsView.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositionsView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { Position } from '@shared/api/positions'
+import type { Position, PositionUsage } from '@shared/api/positions'
 import { Button } from '@shared/ui/button'
 import { Input } from '@shared/ui/input'
 import {
@@ -14,6 +14,13 @@ import { validatePositionLabel } from '../lib/validate-position-label'
 
 interface ManagePositionsViewProps {
   positions?: Position[]
+  /**
+   * What deleting `confirmTarget` would touch, once the container has fetched it. Undefined while
+   * it is still loading — the dialog says so rather than implying "nothing".
+   */
+  usage?: PositionUsage
+  /** Told which position the delete dialog is asking about, so the container can fetch its usage. */
+  onConfirmTargetChange?: (position: Position | null) => void
   /** The positions query is in flight — render the loading shell instead of the form. */
   isLoading?: boolean
   /** The positions query failed — render the error shell instead of the form. */
@@ -37,6 +44,8 @@ interface ManagePositionsViewProps {
  */
 export function ManagePositionsView({
   positions = [],
+  usage,
+  onConfirmTargetChange,
   isLoading,
   isError,
   isSaving,
@@ -46,7 +55,11 @@ export function ManagePositionsView({
   onDelete,
 }: ManagePositionsViewProps) {
   const [newLabel, setNewLabel] = useState('')
-  const [confirmTarget, setConfirmTarget] = useState<Position | null>(null)
+  const [confirmTarget, setConfirmTargetState] = useState<Position | null>(null)
+  const setConfirmTarget = (position: Position | null) => {
+    setConfirmTargetState(position)
+    onConfirmTargetChange?.(position)
+  }
 
   const newLabelError = validatePositionLabel(newLabel)
 
@@ -114,9 +127,14 @@ export function ManagePositionsView({
               <DialogHeader>
                 <DialogTitle>Delete position</DialogTitle>
                 <DialogDescription>
-                  Delete "{confirmTarget?.label}"? Members with this position will become Unassigned.
+                  Delete "{confirmTarget?.label}"? This cannot be undone.
                 </DialogDescription>
               </DialogHeader>
+              {/* Names what the delete will actually touch. A warning, not a veto — the delete
+                  proceeds either way, but an admin should not have to guess the blast radius. */}
+              <p className="text-sm text-muted-foreground">
+                {usage ? deleteImpact(usage) : 'Checking what uses this position…'}
+              </p>
               <DialogFooter>
                 <Button variant="outline" onClick={() => setConfirmTarget(null)}>
                   Cancel
@@ -174,4 +192,22 @@ function PositionRow({ position, isSaving, onRename, onRequestDelete }: Position
       </Button>
     </li>
   )
+}
+
+/**
+ * Plain-language blast radius for a position delete. Only the non-zero parts are named, so a
+ * position nothing uses reads as a clean removal rather than a list of three zeroes.
+ */
+function deleteImpact(usage: PositionUsage): string {
+  const parts: string[] = []
+  if (usage.memberCount > 0) {
+    parts.push(`${usage.memberCount} ${usage.memberCount === 1 ? 'member becomes' : 'members become'} Unassigned`)
+  }
+  if (usage.eventTypeCount > 0) {
+    parts.push(`it is dropped from ${usage.eventTypeCount} event ${usage.eventTypeCount === 1 ? 'type' : 'types'}`)
+  }
+  if (usage.eventCount > 0) {
+    parts.push(`and from ${usage.eventCount} ${usage.eventCount === 1 ? 'event' : 'events'} with their own roster`)
+  }
+  return parts.length === 0 ? 'Nothing currently uses this position.' : `${parts.join(', ')}.`
 }

--- a/app/src/routes/t/$slug/team/settings.tsx
+++ b/app/src/routes/t/$slug/team/settings.tsx
@@ -5,6 +5,7 @@ import { teamRoutes } from '@shared/lib/team-routes'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
 import { TeamSettings } from '@features/team-settings/ui/TeamSettings'
 import { ManagePositions } from '@features/manage-positions/ui/ManagePositions'
+import { ManageEventTypes } from '@features/manage-event-types/ui/ManageEventTypes'
 import { ActAsRecords } from '@features/act-as/ui/ActAsRecords'
 
 export const Route = createFileRoute('/t/$slug/team/settings')({
@@ -26,12 +27,15 @@ export const Route = createFileRoute('/t/$slug/team/settings')({
 })
 
 function TeamSettingsPage() {
-  // Admin manage surface: member management (the editable roster), then positions, then team
-  // settings, then platform access. The read-only view of the same roster lives on /team.
+  // Admin manage surface: member management (the editable roster), then positions, then the event
+  // types whose roster defaults reference those positions, then team settings, then platform access.
+  // Event types come after positions deliberately — a roster default is authored in terms of the
+  // vocabulary above it. The read-only view of the same roster lives on /team.
   return (
     <div className="flex flex-col gap-10">
       <MemberRoster canManage />
       <ManagePositions />
+      <ManageEventTypes />
       <TeamSettings />
       {/* Admin-only, and last: platform access is rare and, to someone who has never heard of it,
           alarming out of context. It sits below the settings an Admin actually came here for. */}

--- a/app/src/shared/api/event-types.ts
+++ b/app/src/shared/api/event-types.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from './wirespec-client'
 
 // Re-export the generated contract types so consumers have a single source of truth. The roster
@@ -8,14 +8,135 @@ export type { EventTypeItem } from './generated/model/EventTypeItem'
 export type { RosterRequirement } from './generated/model/RosterRequirement'
 export type { PositionTarget } from './generated/model/PositionTarget'
 
-export function useEventTypes() {
+import type { EventTypeItem } from './generated/model/EventTypeItem'
+import type { RosterRequirement } from './generated/model/RosterRequirement'
+
+// An event-type mutation can fail in ways the UI must tell apart: a taken name is recoverable and
+// shown inline, archiving the last active type is a rule the admin needs explained, and a bad
+// migration target means the picker offered something stale. Mirrors PositionError in positions.ts.
+export class EventTypeError extends Error {
+  constructor(
+    public readonly code:
+      | 'EVENT_TYPE_NAME_TAKEN'
+      | 'LAST_EVENT_TYPE'
+      | 'INVALID_REQUEST'
+      | 'FORBIDDEN'
+      | 'NOT_FOUND',
+    message: string,
+  ) {
+    super(message)
+    this.name = 'EventTypeError'
+  }
+}
+
+// A 409 means one of two very different things, and the caller has to say which — the server sends a
+// discriminating `code`, but the generated client models the body as Unit, so the status is all we
+// have here. The archive path is the only one that can hit LAST_EVENT_TYPE, so it maps its own.
+const nameTaken = () => new EventTypeError('EVENT_TYPE_NAME_TAKEN', 'That event type already exists.')
+// The 400s this surface can produce: a blank or over-long name, a roster target naming a position
+// that is not this team's, or a migration target that went stale between rendering and clicking.
+// Declared in the contract precisely so they arrive here as a classified error rather than as an
+// undeclared-status throw the UI cannot tell from a network failure.
+const invalid = () => new EventTypeError('INVALID_REQUEST', "That didn't work — check the name and roster, then try again.")
+const forbidden = () => new EventTypeError('FORBIDDEN', 'You are not allowed to make this change.')
+const notFound = () => new EventTypeError('NOT_FOUND', 'Event type not found.')
+
+/**
+ * The team's event types. Archived ones are excluded unless asked for, so every picker gets exactly
+ * the types a team can still choose; only the admin screen passes `includeArchived`.
+ *
+ * Keyed by that flag so the two lists cache separately — an admin screen showing archived types must
+ * not poison the picker's cache with rows it should never offer.
+ */
+export function useEventTypes(includeArchived = false) {
   return useQuery({
-    queryKey: ['event-types'],
+    queryKey: ['event-types', { includeArchived }],
     queryFn: async () => {
-      const res = await api.ListEventTypes()
+      const res = await api.ListEventTypes({ 'include-archived': includeArchived })
       return res.body
     },
     select: (data) => data.eventTypes,
     staleTime: Infinity,
   })
+}
+
+interface EventTypeInput {
+  name: string
+  color?: string
+  rosterDefault: RosterRequirement
+}
+
+export function useCreateEventType() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: EventTypeInput) => {
+      const res = await api.CreateEventType({ body: input as EventTypeItem })
+      if (res.status === 400) throw invalid()
+      if (res.status === 409) throw nameTaken()
+      if (res.status === 403) throw forbidden()
+      return res.body
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+export function useUpdateEventType() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, ...input }: EventTypeInput & { id: string }) => {
+      const res = await api.UpdateEventType({ id, body: input as EventTypeItem })
+      if (res.status === 400) throw invalid()
+      if (res.status === 409) throw nameTaken()
+      if (res.status === 403) throw forbidden()
+      if (res.status === 404) throw notFound()
+      return res.body
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+/**
+ * Archive (soft delete), optionally moving this type's events onto another active one first.
+ *
+ * A 409 here is the last-active-type rule rather than a name clash — archiving carries no name — and
+ * a 400 means the migration target went stale between the picker rendering and the click.
+ */
+export function useArchiveEventType() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, migrateEventsTo }: { id: string; migrateEventsTo?: string }) => {
+      const res = await api.ArchiveEventType({ id, body: { migrateEventsTo } })
+      if (res.status === 400) throw invalid()
+      if (res.status === 409) {
+        throw new EventTypeError('LAST_EVENT_TYPE', 'A team must keep at least one active event type.')
+      }
+      if (res.status === 403) throw forbidden()
+      if (res.status === 404) throw notFound()
+      return res.body
+    },
+    // Archiving moves events onto another type, so the events cache is stale too.
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+export function useUnarchiveEventType() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id }: { id: string }) => {
+      const res = await api.UnarchiveEventType({ id })
+      if (res.status === 409) throw nameTaken()
+      if (res.status === 403) throw forbidden()
+      if (res.status === 404) throw notFound()
+      return res.body
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+// Both event-type lists AND the events themselves: a type's roster default is resolved into every
+// inheriting event's computed roster, so editing one changes the events payload without touching an
+// event row. Archiving with a migration rewrites the events' type outright.
+function invalidate(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ['event-types'] })
+  queryClient.invalidateQueries({ queryKey: ['events'] })
 }

--- a/app/src/shared/api/positions.ts
+++ b/app/src/shared/api/positions.ts
@@ -1,8 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from './wirespec-client'
 
-// Re-export the generated contract type so the app has a single source of truth.
+// Re-export the generated contract types so the app has a single source of truth.
 export type { Position } from './generated/model/Position'
+export type { PositionUsage } from './generated/model/PositionUsage'
 
 // A position mutation can fail in ways the UI must distinguish: a taken label is recoverable and
 // shown inline; a 403/404 is not. Mirrors MemberUpdateError in members.ts.
@@ -23,6 +24,22 @@ export function usePositions() {
       // A 401 is handled globally (redirect to login) by the fetch handler; fall back to empty here.
       return res.body?.positions ?? []
     },
+  })
+}
+
+/**
+ * What deleting a position would touch — the type defaults and event overrides naming it, and the
+ * members holding it. Read only when the delete dialog opens (`enabled`), because it is admin-only
+ * and every member can see the rest of this screen.
+ */
+export function usePositionUsage(id: string | null) {
+  return useQuery({
+    queryKey: ['positions', id, 'usage'],
+    queryFn: async () => {
+      const res = await api.GetPositionUsage({ id: id as string })
+      return res.body
+    },
+    enabled: id !== null,
   })
 }
 

--- a/app/src/widgets/create-event/ui/CreateEventSheet.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheet.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react'
 import { Button } from '@shared/ui/button'
 import { Sheet, SheetContent, SheetTrigger } from '@shared/ui/sheet'
 import { useEventTypes } from '@shared/api/event-types'
+import { usePositions } from '@shared/api/positions'
 import { useSeason } from '@shared/api/season'
 import { useCreateEvent, type EventInput } from '@shared/api/events'
 import {
@@ -25,6 +26,7 @@ type Mode = 'closed' | CreateEventMode
 export function CreateEventSheet() {
   const [mode, setMode] = useState<Mode>('closed')
   const { data: eventTypes } = useEventTypes()
+  const { data: positions } = usePositions()
   const { data: season } = useSeason()
   const createEvent = useCreateEvent()
   const createSeries = useCreateRecurringEvents()
@@ -64,6 +66,7 @@ export function CreateEventSheet() {
           <CreateEventSheetView
             mode={mode}
             eventTypes={eventTypes}
+            positions={positions}
             season={season}
             today={today}
             isCreatingSingle={createEvent.isPending}

--- a/app/src/widgets/create-event/ui/CreateEventSheetView.tsx
+++ b/app/src/widgets/create-event/ui/CreateEventSheetView.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from 'lucide-react'
 import { SheetDescription, SheetTitle } from '@shared/ui/sheet'
 import type { EventInput } from '@shared/api/events'
+import type { Position } from '@shared/api/positions'
 import type { EventTypeItem } from '@shared/api/event-types'
 import type { Season } from '@shared/api/season'
 import type { CreateRecurringEventsRequest } from '@shared/api/recurring-events'
@@ -26,6 +27,8 @@ interface CreateEventSheetViewProps {
   mode: CreateEventMode
   /** Event types for the pickers; defaults to an empty list while the container's query is in flight. */
   eventTypes?: EventTypeItem[]
+  /** The team's position vocabulary, for authoring a per-event roster override. */
+  positions?: Position[]
   season?: Season
   today: string
   isCreatingSingle?: boolean
@@ -52,6 +55,7 @@ interface CreateEventSheetViewProps {
 export function CreateEventSheetView({
   mode,
   eventTypes = [],
+  positions = [],
   season,
   today,
   isCreatingSingle,
@@ -87,6 +91,7 @@ export function CreateEventSheetView({
       {mode === 'single' && (
         <CreateEventForm
           eventTypes={eventTypes}
+          positions={positions}
           isPending={!!isCreatingSingle}
           onSubmit={onSubmitSingle}
           error={singleError}


### PR DESCRIPTION
Step 4 of 4 for #219, and the last. #225, #226 and #227 have all **merged**, so this is now based on `main` and the diff is just the admin surface.

This is the authoring for what the first three PRs model, compute and render. **Closes #219.**

## Event-type CRUD

Full CRUD on `/t/:slug/team/settings`: create, rename, recolor, archive — each type carrying the roster default its events inherit.

The roster-default editor and the per-event override are the **same component**, because they are the same value; two editors would be two chances to disagree about what a blank field means. Blank and zero both mean "no target" on both axes, matching what the server already does with a zero.

## Archiving is a soft delete, and says so

The type disappears from every picker; existing events keep it and keep rendering. The dialog **leads with** the offer to move those events onto another active type rather than burying it — leaving them on a type no picker shows is the fallback, not the default. That migration and the archive commit in **one transaction**, so a failure can't leave events pointing at a hidden type. An event's `eventType` is non-null, so neither path can orphan or delete an event, and the dialog says that in as many words.

Restoring is there too — without it, "soft delete" would be permanent from the UI.

Two rules stop a team locking itself out:
- **the last active type cannot be archived** (with none left, creating an event is impossible and there's no way back through the UI)
- a **migration target must be a different, still-active type**

## Per-event override

"Inherit default / Customise" in the create and edit forms. Inherit is not a snapshot — the event follows its type's default *as that default changes*, which is what lets a recurring series track the team's shape without rewriting every occurrence — and the field says so, naming what the type currently asks for. Customising seeds from that default, so an admin edits from where the event already is.

## Position delete now names its blast radius

How many members become Unassigned, and how many type defaults and event overrides it's dropped from. A **warning, not a veto** — the delete still goes ahead — but an admin shouldn't have to guess. "Checking…" is a distinct state from "nothing uses this", which would otherwise be indistinguishable while the query is in flight.

Since #245 the clearing itself is a foreign key (`ON DELETE CASCADE` on both target tables, `SET NULL` on `member_profiles`), so these counts report what the database will do rather than what the service is about to do.

## Testing

- **Testcontainers IT** (`EventTypeAdminIT`) — create/rename/recolor/archive against real Postgres: that editing a type's default moves the events that inherit it, that archiving hides the type while its events keep rendering, that a migration moves every event first, that the last active type is refused, that a blank or 101-char name is a 400 rather than a 500, that config is admin-only while *reading* stays open to everyone, and the three position-usage counts. It runs in its **own tenant schema**, because it archives types and event types are tenant rows — doing that in `public` would hide the seeded types from every other spec.
- **Vitest** — the roster-default summary (including the tracked-but-unrequired state and stale targets) and the editor-open rule.
- **Storybook** — both new views with `fn()` spies: create, edit-default, zero-means-no-target, archive with and without migration, restore, optimistic close, and every error code; plus every branch of the inherit/customise field.
- **One new e2e** — the admin roster-config write path, which the issue names as *the* example of a justified new seam: an admin-gated write to a new resource behind a route guard, persisted and read back across a reload. The card's chip and panel deliberately stay out of it (they ride the existing events read and are covered by stories + the compute IT).

Verified on the rebased branch: **639 frontend tests / 97 files** (main's baseline is 605 / 93), **616 backend / 82 classes** (main's is 601 / 81 — this adds `EventTypeAdminIT`), plus the `processAot` build gate, detekt, `tsc` and ESLint clean.

**Chromatic will want baselines accepted for the new stories.**

## Two things I'd flag

- **Unarchive isn't in the issue's list** (it says create / rename / recolor / archive). I added it because without it a soft delete is permanent from the UI, which contradicts calling it soft. Easy to drop if you'd rather keep the surface smaller.
- **The Next Up hero shows no roster status.** The disclosure attaches to the date-block card per #214, and the hero is a different component — so the most imminent event, the one most worth chasing people for, is the one card with no chip. Out of scope here, but a gap worth naming rather than silently leaving.

Refs #219.