### PR TITLE
chore(deps): bump wirespec to 0.19.7 (plugin + integration together)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("plugin.jpa") version "2.4.10" apply false
     id("org.springframework.boot") version "4.0.4" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
-    id("community.flock.wirespec.plugin.gradle") version "0.19.6" apply false
+    id("community.flock.wirespec.plugin.gradle") version "0.19.7" apply false
     id("dev.detekt") version "2.0.0-alpha.6" apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configuration-cache=true
 
 # Dependency versions
 javaVersion=25
-wirespecVersion=0.19.6
+wirespecVersion=0.19.7
 testcontainersVersion=1.21.4
 flockDetektVersion=1.2.0
 kotestVersion=5.9.1


### PR DESCRIPTION
Supersedes #209 and #212. Renovate split the wirespec 0.19.7 update into two PRs — the Gradle plugin (#209) and the `spring-jvm` integration (#212) — but they share the wirespec compiler's `Emitted` API (its constructor gained a `test` field in 0.19.7). Bumping either side alone throws `NoSuchMethodError` at wirespec codegen, so neither PR can go green in isolation. This bumps both together.

Verified: `./gradlew build -x test` green.

Closes #209
Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)