### PR TITLE
chore(deps): update Spring Boot to 4.1.0

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SchemaMultiTenantConnectionProvider.kt
@@ -33,7 +33,7 @@ class SchemaMultiTenantConnectionProvider(
 
     override fun supportsAggressiveRelease(): Boolean = false
 
-    override fun isUnwrappableAs(unwrapType: Class<*>?): Boolean = false
+    override fun isUnwrappableAs(unwrapType: Class<*>): Boolean = false
 
-    override fun <T : Any?> unwrap(unwrapType: Class<T>?): T? = null
+    override fun <T : Any> unwrap(unwrapType: Class<T>): T? = null
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "2.4.10" apply false
     kotlin("plugin.spring") version "2.4.10" apply false
     kotlin("plugin.jpa") version "2.4.10" apply false
-    id("org.springframework.boot") version "4.0.4" apply false
+    id("org.springframework.boot") version "4.1.0" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("community.flock.wirespec.plugin.gradle") version "0.19.6" apply false
     id("dev.detekt") version "2.0.0-alpha.6" apply false


### PR DESCRIPTION
Supersedes #147. Boot 4.1 ships a newer Hibernate whose `MultiTenantConnectionProvider` tightened `isUnwrappableAs`/`unwrap` to non-null `Class` params, so the previous nullable overrides in `SchemaMultiTenantConnectionProvider` no longer matched and `compileKotlin` failed. This drops the nullability to match the new interface — no behavioural change.

Verified: `:api:test` — 412 tests, 0 failures.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)