### PR TITLE
feat(app): make the whole Next Up hero clickable, not just its title

### DIFF
--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
@@ -28,6 +28,19 @@ const meta = {
   args: { event: EVENT, now: NOW, myState: 'NOT_RESPONDED', onRespond: fn() },
 } satisfies Meta<typeof NextEventHeroView>
 
+/**
+ * What is actually on top at the centre of `el` — a real hit-test, not a DOM-tree lookup.
+ *
+ * These stories run in headless Chromium (Vitest browser mode), so `elementFromPoint` resolves the
+ * stretched-link overlay, `z-index` and `pointer-events` exactly as a thumb would. That is the only
+ * honest way to prove "this area is clickable": the overlay is a pseudo-element, so it is invisible
+ * to queries and to `userEvent`'s own targeting.
+ */
+function topmostAtCentreOf(el: Element): Element | null {
+  const { left, top, width, height } = el.getBoundingClientRect()
+  return document.elementFromPoint(left + width / 2, top + height / 2)
+}
+
 export default meta
 
 type Story = StoryObj<typeof meta>
@@ -120,6 +133,55 @@ export const Saving: Story = {
     await expect(canvas.getByRole('button', { name: /Can't make it/ })).toBeDisabled()
     await userEvent.click(canvas.getByRole('button', { name: /I'm in/ }))
     await expect(args.onRespond).not.toHaveBeenCalled()
+  },
+}
+
+// The hero is one big target: everything that isn't its own control opens the event. The title
+// carries a stretched-link overlay, so the passive rows (countdown, date, headcount, padding) all
+// hit that link instead of dead text — the same pattern EventCard already uses in the list below.
+export const WholeCardIsClickable: Story = {
+  play: async ({ canvas, canvasElement }) => {
+    const cardLink = canvas.getByRole('link', { name: EVENT.title })
+    const hero = canvasElement.querySelector('section')!
+
+    // Passive rows: each one hits the card link, not the text node under the cursor.
+    for (const passive of [
+      canvas.getByText('Next up'),
+      canvas.getByText('2d'), // the countdown block sits above the overlay but lets taps through
+      canvas.getByText(/20:00/), // the date · time row
+      canvas.getByText(/10 going/),
+    ]) {
+      await expect(topmostAtCentreOf(passive)).toBe(cardLink)
+    }
+
+    // Bare padding — the strip below the buttons — is part of the target too.
+    const { left, bottom, width } = hero.getBoundingClientRect()
+    await expect(document.elementFromPoint(left + width / 2, bottom - 4)).toBe(cardLink)
+  },
+}
+
+// The other half of the bargain: widening the target must not swallow the controls inside it.
+// A stretched overlay covering the RSVP buttons would make the hero's whole point unreachable, and
+// `userEvent` alone would not notice — it dispatches at the button either way.
+export const ControlsStayAboveTheOverlay: Story = {
+  play: async ({ canvas, canvasElement }) => {
+    for (const name of [/I'm in/, /Can't make it/]) {
+      const button = canvas.getByRole('button', { name })
+      await expect(topmostAtCentreOf(button)?.closest('button')).toBe(button)
+    }
+
+    // (The matching hover affordance — the card washes and the title underlines over the passive
+    // rows, but stays quiet over these buttons — hangs off the link's own :hover, since the overlay
+    // is the link's hit area. It is not asserted here: `userEvent` is synthetic and never moves a
+    // real cursor, so CSS :hover cannot be driven at this layer.)
+
+    // The location opens maps, so it stays its own target — and stays a *sibling* of the card link
+    // rather than a nested <a>, which is invalid HTML.
+    const maps = canvas.getByRole('link', { name: EVENT.location })
+    await expect(topmostAtCentreOf(maps)?.closest('a')).toBe(maps)
+    await expect(maps).toHaveAttribute('href', expect.stringContaining('maps.google.com'))
+    await expect(maps).toHaveAttribute('target', '_blank')
+    await expect(canvasElement.querySelectorAll('a a')).toHaveLength(0)
   },
 }
 

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
@@ -59,24 +59,41 @@ export function NextEventHeroView({
         className="pointer-events-none absolute -right-8 -top-10 h-[150px] w-[150px] rounded-full bg-white/15 blur-sm"
       />
 
-      <div className="absolute right-4 top-4 z-10 text-right">
+      {/* pointer-events-none: this block sits above the title's stretched overlay (z-10 keeps it
+          clear of the decorative blur), so without it the countdown would be a dead patch. */}
+      <div className="pointer-events-none absolute right-4 top-4 z-10 text-right">
         <span className="font-display block text-[22px] font-extrabold leading-none">
           {countdown.value}
         </span>
         <span className="text-[10px] uppercase tracking-[0.08em] opacity-85">{countdown.unit}</span>
       </div>
 
-      <p className="pr-12 text-[11px] font-bold uppercase tracking-[0.14em] opacity-90">Next up</p>
+      {/* The passive rows fade with a colour alpha (text-white/xx), never with `opacity`: an
+          element with opacity < 1 forms its own stacking context and would paint *above* the
+          title's stretched overlay, punching a dead hole in the card's hit area. */}
+      <p className="pr-12 text-[11px] font-bold uppercase tracking-[0.14em] text-white/90">
+        Next up
+      </p>
 
       <h3 className="font-display mb-1 mt-2 pr-12 text-[21px] font-extrabold leading-[1.08]">
-        {/* The hero title is the way into the event; the RSVP buttons stay separate, so no
-            stretched-link overlay here — a full-card overlay would swallow their taps. */}
-        <Link to="/events/$eventId" params={{ eventId: event.id }} className="hover:underline">
+        {/* Stretched-link pattern, as EventCard uses in the list below: the card is not an anchor,
+            the title's after:inset-0 overlay makes the whole hero open the event. The controls that
+            live inside it — the RSVP buttons, the maps link — are lifted back above the overlay with
+            relative z-10, so widening the target costs none of them.
+            Hover and focus hang off this link rather than a `group` on the card, because the overlay
+            *is* the link's own hit area: the wash and the underline then answer exactly where a tap
+            would navigate, and stay quiet over the controls, which are not part of it. The ring is
+            inset so `overflow-hidden` can't clip it, and traces the real target — the whole card. */}
+        <Link
+          to="/events/$eventId"
+          params={{ eventId: event.id }}
+          className="after:absolute after:inset-0 after:rounded-3xl after:bg-white/0 after:transition-colors after:duration-200 hover:underline hover:after:bg-white/[0.07] focus-visible:outline-none focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-white"
+        >
           {event.title}
         </Link>
       </h3>
 
-      <p className="flex flex-wrap items-center gap-1.5 text-[13px] opacity-95">
+      <p className="flex flex-wrap items-center gap-1.5 text-[13px] text-white/95">
         <Clock size={13} className="shrink-0" />
         {date.toLocaleDateString('nl-NL', { weekday: 'short', day: 'numeric', month: 'short' })}
         {' · '}
@@ -84,19 +101,29 @@ export function NextEventHeroView({
       </p>
 
       {event.location && (
-        <p className="mt-1 flex flex-wrap items-center gap-1.5 text-[13px] opacity-95">
+        <p className="mt-1 flex flex-wrap items-center gap-1.5 text-[13px] text-white/95">
           <MapPin size={13} className="shrink-0" />
-          {event.location}
+          {/* An address is worth a tap of its own, exactly as in the list card below. It is a
+              sibling of the card link rather than nested inside it (an <a> in an <a> is invalid
+              HTML), and relative z-10 lifts it above the stretched overlay. */}
+          <a
+            href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="relative z-10 underline decoration-white/30 underline-offset-2 transition-colors hover:decoration-white"
+          >
+            {event.location}
+          </a>
         </p>
       )}
 
-      <p className="mt-2.5 text-[13px] opacity-90">
+      <p className="mt-2.5 text-[13px] text-white/90">
         {event.attendanceSummary.attending} going · {MY_STATE_TEXT[myState]}
       </p>
 
       {/* The answer the viewer has given is the solid button; the other one recedes. With no answer
           yet, "I'm in" is solid because it is the invitation, not because it has been chosen. */}
-      <div className="mt-3.5 flex gap-2">
+      <div className="relative z-10 mt-3.5 flex gap-2">
         <button
           aria-pressed={going}
           disabled={isSaving}


### PR DESCRIPTION
The hero's title was the only way into the event: the countdown, the date,
the location, the headcount and all the surrounding padding were dead text,
even though the identical card in the list below has been a full-card target
all along (EventCard's stretched link).

Adopt that same pattern here. The title carries an after:inset-0 overlay so
the whole hero opens the event, and the controls that live inside it are
lifted back above the overlay with relative z-10, so widening the target
costs none of them:

- RSVP buttons keep their own taps ("I'm in" / "Can't make it")
- the location becomes a maps link, as it already is in the list card, and a
  sibling of the card link rather than a nested <a>
- the countdown gets pointer-events-none so it passes taps through instead of
  being a dead patch above the overlay

The passive rows had to move from `opacity` to a colour alpha (text-white/xx):
an element with opacity < 1 forms its own stacking context and painted above
the overlay, which would have left holes in the new hit area.

Hover and focus hang off the link itself rather than a group on the card,
since the overlay is the link's own hit area — so the wash and underline
answer exactly where a tap would navigate, and stay quiet over the buttons.
The focus ring is drawn inset on the overlay, tracing the real target.

Covered by two stories that hit-test with document.elementFromPoint in the
real headless browser — the overlay is a pseudo-element, so it is invisible
to ordinary queries and to userEvent's targeting. No new e2e: this introduces
no seam the attendance flow does not already cover.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01936ZJ9NDZz1ZUkESb93tfc