### PR TITLE
ci: publish Storybook to GitHub Pages only from main

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,9 +1,11 @@
 name: Storybook
 
 # Deploys the component catalog to GitHub Pages (branch-based, gh-pages):
-#   push to main             -> gh-pages root       -> https://storybook.teambalance.nl
-#   PR (own-repo, app diff)  -> gh-pages/pr-preview/pr-<n>/ + a comment on the PR
-#   PR closed                -> that preview dir is removed
+#   push to main -> gh-pages root -> https://storybook.teambalance.nl
+#
+# Main only, on purpose: per-PR review of the catalog happens in Chromatic
+# (chromatic.yml), which publishes a browsable Storybook per PR build alongside the
+# visual diff. A second per-PR copy on gh-pages was duplicate work with no extra signal.
 #
 # Kept separate from ci.yml on purpose: this needs `contents: write` (to push the
 # gh-pages branch), whereas ci.yml is deliberately read-only.
@@ -14,21 +16,14 @@ on:
     paths:
       - 'app/**'
       - 'design-tokens/**'
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    paths:
-      - 'app/**'
-      - 'design-tokens/**'
   workflow_dispatch:
 
 permissions:
   contents: write        # push the built Storybook to the gh-pages branch
-  pull-requests: write   # pr-preview-action comments the preview URL on the PR
 
 jobs:
   # Canonical Storybook for main -> served at storybook.teambalance.nl
   deploy-main:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     concurrency:
       group: storybook-main
@@ -62,86 +57,20 @@ jobs:
         working-directory: app
 
       # CNAME binds the custom domain on every publish (clean would drop it otherwise);
-      # robots.txt at the gh-pages root keeps the whole domain (previews included) out
-      # of search engines.
+      # robots.txt keeps the domain out of search engines.
       - name: Add CNAME + robots.txt
         working-directory: app/storybook-static
         run: |
           echo 'storybook.teambalance.nl' > CNAME
           printf 'User-agent: *\nDisallow: /\n' > robots.txt
 
+      # `clean: true` with no exclusions: the gh-pages branch now holds nothing but the
+      # main build, so the first run after this change also sweeps away the leftover
+      # pr-preview/ dirs from the retired PR-preview job.
       - name: Publish to gh-pages root
         uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         with:
           folder: app/storybook-static
           branch: gh-pages
           clean: true
-          clean-exclude: pr-preview/   # never wipe live PR previews
           commit-message: 'docs(storybook): deploy main ${{ github.sha }}'
-
-  # Per-PR preview. Own-repo branches only: fork PRs run without write access/secrets,
-  # so we skip them rather than reach for pull_request_target.
-  deploy-preview:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    concurrency:
-      group: storybook-preview-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24.19.0'
-          cache: npm
-          cache-dependency-path: app/package-lock.json
-
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
-
-      - name: Generate Wirespec TypeScript client
-        run: ./gradlew :api:wirespec-typescript
-
-      - name: Build Storybook
-        run: |
-          npm ci
-          npm run build-storybook
-        working-directory: app
-
-      # Deploys to gh-pages/pr-preview/pr-<n>/, comments the URL, preserves the root
-      # site + other previews. Storybook's Vite build already uses relative asset
-      # paths (base: './'), so it serves correctly from the subpath.
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
-        with:
-          source-dir: app/storybook-static
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-
-  # PR closed -> remove its preview dir (no build needed).
-  cleanup-preview:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    concurrency:
-      group: storybook-preview-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Remove preview
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
-        with:
-          source-dir: app/storybook-static
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          action: remove


### PR DESCRIPTION
Per-PR Storybook previews on `gh-pages` duplicated what Chromatic already publishes per PR build, so the GitHub Pages publish is now main-only.

## Changes

`.github/workflows/storybook.yml`:

- Removed the `pull_request` trigger — the workflow fires on `push` to `main` and `workflow_dispatch` only.
- Deleted the `deploy-preview` job (built and published each PR to `gh-pages/pr-preview/pr-<n>/` and commented the URL on the PR).
- Deleted the `cleanup-preview` job that removed those directories when a PR closed.
- Dropped `pull-requests: write` from `permissions`; only `contents: write` remains.
- Dropped `clean-exclude: pr-preview/` from the main deploy, so the next push to `main` sweeps away the leftover preview directories on `gh-pages` instead of leaving them stranded.
- Removed the now-redundant `if:` guard on `deploy-main` and refreshed the header comment.

`chromatic.yml` is untouched — it still runs on every PR, and its per-build published Storybook is the PR review surface now.

## Testing

CI-config only, no application code touched. Verified the workflow still parses and resolves to the intended shape:

```
triggers: ['push', 'workflow_dispatch']
jobs: ['deploy-main']
permissions: {'contents': 'write'}
```

Grepped the repo for references to the removed jobs and to `pr-preview` — the workflow file was the only place either appeared, so no docs or configs needed updating. No new e2e is justified: this introduces no new application seam.

## Note for the reviewer

If `deploy-preview` or `cleanup-preview` is configured as a **required status check** in branch protection for `main`, PRs will now wait forever on a check that never reports. That setting lives outside the repo, so it needs to be checked and cleared manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCrsmnDQXuMAeRPiArPg1j)_