### PR TITLE
docs: ADR-0021 & ADR-0022 — Active Team & Platform Admin Act-as

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,13 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 
 - **Team** — A group of people who play together and share events and a money pool.
   Private/invite-only. The unit of tenancy (one tenant schema per team).
+- **Active Team** — The one Team a request is scoped to. **Explicitly selected, never
+  inferred**: carried on the session, chosen by the member (or by opening a team-scoped
+  link), and remembered as their default between logins. A Member of several Teams has
+  exactly one Active Team at a time; authorization for it comes either from their real
+  membership or, for a **Platform Admin**, from **Act-as**
+  ([ADR-0021](docs/adr/0021-active-team-explicit-tenant-resolution.md)).
+  _Avoid_: current team, selected tenant, team context.
 - **Member** — A person belonging to a Team. Has exactly one **Role** and at most one
   **Position**.
 - **Role** — A Member's permission tier within a Team: **Admin** or **User**. Every
@@ -121,14 +128,39 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   _Avoid_: OAuth login, social login, password.
 - **Invite Link** — A single shareable link an admin generates to onboard members into
   an existing Team. Clicking it → enter email → Magic Link → joined. One link, many
-  joiners; can expire/rotate.
+  joiners; can expire/rotate. Carries the **Role** it grants on acceptance — ordinarily
+  **User**, but an **Admin**-granting link is how a memberless Team gets its first Admin
+  ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)).
 - **Team creation** — Provisioning a new Team. Self-service: a logged-in, teamless user
   creates their Team from a name + slug + one-time **creation code**, which provisions the
   tenant schema inline (see [ADR-0019](docs/adr/0019-self-service-team-onboarding.md)).
-  Back-office onboarding is now just minting a creation code.
+  Back-office onboarding is now just minting a creation code. A **Platform Admin** may also
+  create a Team **memberless** — no founding Admin — and hand it over with an Admin-granting
+  **Invite Link** ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)).
 
 ### Platform & integrations
 
+- **Platform Admin** — A platform-level identity that operates *across* Teams: mints creation
+  codes, and enters Teams via **Act-as**. Held by an allowlist (`teambalance.platform-admins`),
+  fail-closed. Structurally **teamless** — a Platform Admin is never a **Member** of any Team,
+  so a human who both runs the platform and plays keeps two separate accounts. Not a **Role**:
+  **Admin** is a Member's tier *within* a Team, and the two are unrelated.
+  _Avoid_: platform owner, superadmin, owner, god mode.
+- **Act-as** — An explicitly entered, time-boxed state in which a **Platform Admin** operates
+  inside one Team as if they were an Admin of it. Full read *and* write. Always visible while
+  active, always exited deliberately, and always recorded — see **Act-as Record**
+  ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)). _Avoid_: impersonation, spy mode,
+  support mode, sudo.
+- **Virtual Member** — The synthesized **Admin** authorization a **Platform Admin** holds inside
+  a Team during **Act-as**. Exists only for the duration of the request: no `team_members` row is
+  ever written, so a Virtual Member never appears on the roster, in an **Event Attendance**
+  denominator, in the **Position** breakdown, or in the **Hall of Shame**.
+  _Avoid_: ghost member, shadow admin, temporary member.
+- **Act-as Record** — The team-visible account of what a **Platform Admin** did inside a Team.
+  Scoped to the **Act-as** session rather than to individual rows, because most tenant tables carry
+  no authorship column. Attributes the actor generically (the platform, not a named person), while
+  the underlying `created_by` keeps the real user id for forensics. _Avoid_: audit log (that is the
+  separate, broader feature), access log, trail.
 - **Tenant schema** — Per-team Postgres schema holding events, attendances,
   transactions, etc.
 - **Platform schema** (`public`) — Cross-team data: users, teams, team_members,

--- a/docs/adr/0019-self-service-team-onboarding.md
+++ b/docs/adr/0019-self-service-team-onboarding.md
@@ -4,6 +4,10 @@
 - Date: 2026-08-03
 - Amends: [ADR-0001](0001-product-ambition-hobby-tool-built-to-grow.md) (team creation is back-office in v1)
 - Relates to: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (magic-link auth, invite onboarding), [ADR-0013](0013-member-profile-position-role-management.md) (member/position/role)
+- Amended by: [ADR-0021](0021-active-team-explicit-tenant-resolution.md) (§3's one-team-per-user guard
+  lifted; §6's singular `team` on `/auth/me` becomes `teams[]` + `activeTeam`), and
+  [ADR-0022](0022-platform-admin-act-as.md) (§5's "creator becomes founding admin" no longer holds when
+  a Platform Admin creates a team memberless)
 
 > Numbering note: the originating PRD (#154) named this ADR-0015. By the time it was written, 0015
 > was already taken (session lifetime), so it lands at **0019**. Shipped code that referenced
@@ -149,7 +153,10 @@ flows). Net e2e count unchanged.
   The runbook (`docs/ops/provision-team.md`) is rewritten around this; the manual per-team
   docker-Flyway step is retired.
 - **One-team-per-user** matches routing's `ORDER BY … LIMIT 1`. Multi-team membership + a team
-  switcher are deferred to **#143**. Public/www marketing signup + a resetting demo team are **#152**.
+  switcher were deferred to **#143** and are now decided in
+  [ADR-0021](0021-active-team-explicit-tenant-resolution.md) — which also records that this guard never
+  actually closed the hole: it lives only in `createTeam`, while the invite path (`addMember`) has
+  always been able to create a second membership. Public/www marketing signup + a resetting demo team are **#152**.
 - **Boot cost rises slightly** (tenant migrations run at startup). Kept cheap by idempotency, but see
   §1: the runner is currently fail-fast, so a broken tenant migration downs the app — revisit the
   isolate-and-continue design before scaling tenant count. A prior prod outage was a scale-to-zero DB

--- a/docs/adr/0021-active-team-explicit-tenant-resolution.md
+++ b/docs/adr/0021-active-team-explicit-tenant-resolution.md
@@ -4,7 +4,8 @@
 - Date: 2026-08-22
 - Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§3 one-team-per-user, §6 `/auth/me`'s singular `team`)
 - Relates to: [ADR-0014](0014-jdbc-backed-shared-sessions-survive-restart.md) (JDBC sessions), [ADR-0015](0015-session-lifetime-long-sliding-idle-plus-absolute-cap.md) (session lifetime), [ADR-0022](0022-platform-admin-act-as.md) (act-as rides this seam)
-- Resolves: #143
+- Resolves: [#143](https://github.com/ZzAve/teambalance-app/issues/143)
+- Enables: [#239](https://github.com/ZzAve/teambalance-app/issues/239) (act-as), [#240](https://github.com/ZzAve/teambalance-app/issues/240) (club rollout)
 
 ## Context
 
@@ -27,7 +28,7 @@ The routing query then picks between them by **UUID order** — arbitrary, and t
 error; it silently does not exist for them. #143 recorded this as unreachable. It was not.
 
 This is latent while there is one team per club and becomes real the moment a club runs several
-teams — the Tovo rollout ([#239](https://github.com/ZzAve/teambalance-app/issues/239)) — where
+teams — the club rollout ([#240](https://github.com/ZzAve/teambalance-app/issues/240)) — where
 double membership (a player who also trains another squad, a season-long fill-in) is ordinary.
 
 ## Decision

--- a/docs/adr/0021-active-team-explicit-tenant-resolution.md
+++ b/docs/adr/0021-active-team-explicit-tenant-resolution.md
@@ -1,0 +1,112 @@
+# ADR-0021: The Active Team — explicit, session-carried tenant resolution
+
+- Status: Accepted
+- Date: 2026-08-22
+- Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§3 one-team-per-user, §6 `/auth/me`'s singular `team`)
+- Relates to: [ADR-0014](0014-jdbc-backed-shared-sessions-survive-restart.md) (JDBC sessions), [ADR-0015](0015-session-lifetime-long-sliding-idle-plus-absolute-cap.md) (session lifetime), [ADR-0022](0022-platform-admin-act-as.md) (act-as rides this seam)
+- Resolves: #143
+
+## Context
+
+Tenant routing was hard-wired to one team per user. `findTeamRoutingByUserId` resolved it as:
+
+```sql
+SELECT tm.team_id, t.schema_name FROM public.team_members tm
+JOIN public.teams t ON t.id = tm.team_id
+WHERE tm.user_id = :userId AND tm.active
+ORDER BY tm.team_id LIMIT 1
+```
+
+ADR-0019 §3 matched that constraint by rejecting create-team with `409 ALREADY_IN_TEAM`.
+
+**That guard never closed the hole.** It lives only in `TeamService.createTeam`; the invite path does
+not have it. `JpaTeamMemberRepositoryAdapter.addMember` checks membership *of the team being joined*
+and nothing else, so accepting an invite to a second team writes a second `team_members` row today.
+The routing query then picks between them by **UUID order** — arbitrary, and then *sticky*, because
+`TenantRoutingSession` memoizes the resolved pair on the session. The member's other team does not
+error; it silently does not exist for them. #143 recorded this as unreachable. It was not.
+
+This is latent while there is one team per club and becomes real the moment a club runs several
+teams — the Tovo rollout ([#239](https://github.com/ZzAve/teambalance-app/issues/239)) — where
+double membership (a player who also trains another squad, a season-long fill-in) is ordinary.
+
+## Decision
+
+### 1. One mechanism: the Active Team
+
+A request is scoped to exactly one **Active Team**, **explicitly selected and never inferred**.
+`AuthorizationService`'s `findRole(teamId, userId)` remains the single authorization chokepoint and
+answers from one of two sources: a real `team_members` row, or the **Virtual Member** synthesized by
+**Act-as** (ADR-0022).
+
+`ORDER BY … LIMIT 1` is **deleted, not sidestepped**. `findTeamRoutingByUserId` and
+`findTeamIdByUserId` stop meaning "resolve the user's team" and become "resolve *this* team for this
+user, and verify they may have it" — the team id is an input, not a discovery.
+
+A single seam was chosen over letting act-as add a parallel resolution path. Two tenant-resolution
+paths in a schema-per-tenant app is the shape cross-tenant leaks are made of: the day one path is
+fixed and the other is not, a write lands in the wrong schema and nothing in the type system notices.
+
+### 2. Session-carried, with the team slug in the URL
+
+The Active Team lives on the session. Team-scoped URLs carry the team **slug** (`/t/:slug/…`) so a
+link shared by a teammate opens for anyone entitled to it; opening one performs an **authorized
+switch** of the Active Team. The slug is already unique and already the team's public address
+(ADR-0019 §2); `schema_name` stays hidden.
+
+**Rejected: request-carried tenancy** (every API call names its team, no session Active Team). It is
+the better fit on two counts — it deletes the memo-staleness problem below rather than solving it,
+and it lets two browser tabs sit in different teams. It was rejected because the app is an installed
+**PWA**: a deep link opening in the PWA would need the team threaded through every subsequent in-app
+navigation, and `scope`/`start_url` handling gets awkward. Keeping the installed app's navigation
+team-less won. Revisit if tab-per-team ergonomics become a real complaint.
+
+Consequence accepted deliberately: `TenantRoutingSession`'s memoized `(schema, teamId)` pair is now a
+**correctness** concern, not just a cache. It must be invalidated on every switch, and any future
+team-keyed cache inherits that obligation.
+
+### 3. Last-used is remembered; there is one kind of switch
+
+The Active Team is persisted per user (`public.users.last_active_team_id`, nullable) and written on
+every switch — including a switch caused by opening a shared link. On login: the remembered team if it
+is still a valid active membership → otherwise their sole membership → otherwise force a choice.
+
+Persisting per user rather than per session is deliberate: a session-only memory is lost exactly when
+it is most useful, at a fresh magic-link login on a phone.
+
+**One kind of switch** was chosen over distinguishing deliberate switches from link-induced ones. The
+cost is real and known: tapping a teammate's link for your secondary team re-homes your default, so
+you may open the app later and find yourself in the other team. That is a one-tap correction and it is
+*self-evident from the UI*, because the switcher always names the current team. The alternative buys
+marginally better defaults at the price of a rule no user can see and every future contributor has to
+rediscover.
+
+### 4. Contract changes
+
+- **ADR-0019 §3 is lifted**: `409 ALREADY_IN_TEAM` no longer gates create-team.
+- **ADR-0019 §6 is amended**: `/auth/me`'s `team: TeamRef?` becomes `teams: TeamRef[]` plus an
+  `activeTeam`. The frontend route gate's question changes from "do you have a team" to "do you have
+  *any* team, and which is active", and gains a third branch for a teamless **Platform Admin**
+  (ADR-0022).
+- **`AuthorizationService`'s security-contract comment is reworded.** It currently forbids `teamId`
+  from being "a raw request parameter". Under this ADR the team id *is* a caller-influenced input,
+  made safe by being validated at the one chokepoint. The prohibition it should carry instead: a
+  supplied team id that fails `findRole` resolves to **no tenant**, and "not yours" must be
+  indistinguishable from "does not exist" so the id space cannot be probed.
+- **`acceptInvitation` stops being fire-and-forget**: joining a team makes it the Active Team, so the
+  member lands where they just accepted.
+
+## Non-goals
+
+No cross-team data views or aggregation. No simultaneously-active roles across teams — one Active
+Team, one role, at a time. No cross-team identity merging (see ADR-0022: the two accounts a
+platform-running player holds must never be linked or auto-switched between).
+
+## Consequences
+
+- The silent-misrouting bug is fixed by construction rather than guarded against, and the `LIMIT 1`
+  leaves the codebase.
+- Every team-scoped screen gains a team slug in its route, and the switcher becomes permanent UI.
+- Session memo invalidation is now load-bearing; a missed invalidation is a cross-tenant read.
+- Act-as (ADR-0022) builds no tenant-resolution machinery of its own — it supplies a second
+  authorization source to this one.

--- a/docs/adr/0022-platform-admin-act-as.md
+++ b/docs/adr/0022-platform-admin-act-as.md
@@ -5,6 +5,7 @@
 - Builds on: [ADR-0021](0021-active-team-explicit-tenant-resolution.md) (the Active Team seam)
 - Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§4 platform-admin identity, §5 founder becomes a member)
 - Relates to: [#237](https://github.com/ZzAve/teambalance-app/issues/237) (general audit log — deliberately decoupled)
+- Resolves: [#239](https://github.com/ZzAve/teambalance-app/issues/239); §5 is delivered by [#240](https://github.com/ZzAve/teambalance-app/issues/240)
 
 ## Context
 

--- a/docs/adr/0022-platform-admin-act-as.md
+++ b/docs/adr/0022-platform-admin-act-as.md
@@ -1,0 +1,135 @@
+# ADR-0022: Platform Admin Act-as — entering a team you are not a member of
+
+- Status: Accepted
+- Date: 2026-08-22
+- Builds on: [ADR-0021](0021-active-team-explicit-tenant-resolution.md) (the Active Team seam)
+- Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§4 platform-admin identity, §5 founder becomes a member)
+- Relates to: [#237](https://github.com/ZzAve/teambalance-app/issues/237) (general audit log — deliberately decoupled)
+
+## Context
+
+Running the platform means setting teams up for people: provisioning a club's squads and prepping a
+season of events so members arrive to something ready rather than empty. That is **writing inside a
+team you do not play in**.
+
+The obvious route — join all of them — is wrong for a reason the domain makes plain. Per
+[ADR-0009](0009-attendance-model-roles-in-audience-deferred.md) the attendance summary's denominator
+is the *full roster*, so an operator sitting in twelve rosters is permanently Not Responded in twelve
+teams' event summaries, and lands in twelve Halls of Shame. Membership is a claim about playing
+together; the operator is staff.
+
+Something adjacent already exists: `PlatformAdminGateway` / `PlatformAdminAllowlist`, a fail-closed
+config allowlist (`teambalance.platform-admins`) gating the creation-codes surface (ADR-0019 §4). It
+authorizes platform-level *actions*. It has never authorized entering a tenant.
+
+## Decision
+
+### 1. Act-as, not membership — and full write
+
+A **Platform Admin** enters a Team via **Act-as**: an explicitly entered state granting full read
+*and* write for that team.
+
+**Rejected: read-only.** The work that motivates this — creating events, configuring the Season,
+curating Positions — is entirely writes. A read-only mode would not do the job and a second mechanism
+would follow immediately.
+
+**Rejected: read-only with an elevation step.** Elevation ceremonies earn their cost when a *second*
+party audits the elevation. With a single Platform Admin there is no second party, so it is a speed
+bump that gets routed around and then resented. The safety budget is spent on visibility (§4) instead
+of on gates.
+
+### 2. Virtual Member — synthesized, never written
+
+Authorization inside act-as comes from a **Virtual Member**: `findRole(teamId, userId)` — the single
+chokepoint from ADR-0021 — returns `ADMIN`. **No `team_members` row is ever written.** The team's
+roster, attendance denominators, Position breakdown and contributor rankings are untouched.
+
+**The synthesis keys off an actively-entered act-as state, never off `isPlatformAdmin(userId)`
+alone.** If the chokepoint learned "ADMIN when the caller is a platform admin", an ordinary session
+would silently be admin of every tenant it happened to be routed to, and act-as would stop being a
+mode you enter and become a property you carry. That is the same class of mistake as the `LIMIT 1`
+ADR-0021 removes: a rule invisible at the call site and only wrong later.
+
+**Rejected: per-call-site bypasses** (`… || isPlatformAdmin`), which turn one chokepoint into N, and
+the one that gets forgotten is the vulnerability. **Rejected: a real-but-hidden `team_members` row**,
+which makes every roster, count and summary query responsible for remembering to filter it out.
+
+### 3. A Platform Admin is structurally teamless
+
+A Platform Admin is **never** a Member of any Team. A human who both runs the platform and plays
+volleyball holds **two separate accounts**, and they must never be linked or auto-switched between.
+
+This makes act-as expiry **fail-safe rather than fail-dangerous**. There is no fallback membership to
+silently drop back into, so a lapsed act-as resolves to no tenant at all — and `TenantContext`
+deliberately routes that to `__no_tenant__`, "a schema that intentionally does not exist, so an
+unqualified table reference fails loudly instead of silently hitting `public`". A write can never be
+misdirected by a lapse; it can only fail.
+
+It also amends **ADR-0019 §5**: a Platform Admin creating a team must *not* become its founding
+admin. See §5 below.
+
+### 4. Visible while active, recorded for the team
+
+- **60 minutes, sliding on activity.** Sessions themselves last four weeks (ADR-0015) precisely so
+  nobody thinks about them; act-as riding that unchanged would mean "I popped into Dames 5 on Tuesday"
+  is still true on Friday. The box keeps act-as something you *just* did deliberately.
+- **A persistent banner naming the team**, with one-click **Exit**. The team name is not decoration:
+  twelve near-identically-named club squads is the exact condition under which a season gets prepped
+  into the wrong one.
+- **Lapse is legible.** The server refuses with a distinct `ACT_AS_EXPIRED` — not a generic 403 — and
+  the frontend returns the admin to the console. This comes nearly free: a lapsed teamless Platform
+  Admin reports no active team, and the route gate's third branch sends teamless-plus-platform-admin
+  to the console rather than to `/welcome`.
+- **An Act-as Record, visible to the team.** Scoped to the **act-as session, not to individual rows**
+  — a necessity, not a preference: only `events` and `attendances` carry authorship
+  (`created_by`, `changed_by`). `team_settings`, `team_positions`, `event_types` and invitations carry
+  none, so per-row attribution structurally cannot cover Season configuration or Position curation,
+  which is most of what setup *is*.
+- **The actor is rendered generically** ("the platform") via an `actor_kind` of `MEMBER` |
+  `PLATFORM_ADMIN`. No name resolution is needed — convenient, since `findMemberSummariesByUserIds`
+  joins `public.team_members` and would resolve a non-member to nothing — and the team-visible surface
+  never exposes an operator's email. `created_by` keeps the real user id underneath for forensics; it
+  is never disguised as the team's own admin, and never collapsed to a synthetic system user while a
+  real human is behind it.
+
+**Decoupled from a general audit log** ([#237](https://github.com/ZzAve/teambalance-app/issues/237)).
+That feature's hard problems — attendance volume drowning the log, tenant-vs-`public` placement,
+what counts as an action — are unrelated to act-as and would hold it hostage. Act-as records are
+expected to fold in later as one `action_type`; that migration is the accepted price.
+
+### 5. Memberless team creation + an Admin-granting Invite Link
+
+A Platform Admin creates a Team with **no members at all**, acts in to prepare it, and hands it over
+with an **Invite Link that grants `ADMIN`** on acceptance (`invitations` records the granted Role;
+`acceptInvitation` honours it instead of always adding a plain User). The recipient clicks one link
+and arrives as Admin of a prepared team.
+
+**Rejected: naming the founding admin by email**, which needs a real `users` row and therefore eager
+user creation or a pending-membership concept, plus correct email addresses up front.
+**Rejected: having each captain self-create** with a creation code — it works and needs no new code,
+but it puts a setup step in front of every recipient, which is the opposite of the point. It remains
+available as a zero-code fallback.
+
+The adminless window is a **new state the app has never seen**: empty roster, an attendance
+denominator of zero, an empty Position breakdown. It is transient, and act-as is what covers it — but
+it is a new class of empty state across several screens.
+
+### 6. The console lists every team
+
+The platform console lives under the existing `/admin` route group beside `/admin/creation-codes` —
+same allowlist, same gateway, no new auth surface — and lists **all** teams. Restricting the *list*
+would be theatre: a Platform Admin owns the database. What makes this defensible is that *entering* is
+explicit, time-boxed, and leaves a record the team can read.
+
+Deliberately deferred: a team-level right to refuse platform access. The trigger for revisiting is
+concrete — the first team whose members have never met the operator. Until then this is a club
+running its own squads.
+
+## Consequences
+
+- The most security-sensitive path in the app now exists. Its safety rests on two invariants worth
+  guarding with tests: the chokepoint synthesizes `ADMIN` **only** under an active act-as state, and
+  no `team_members` row is ever written by it.
+- Teams can exist with zero members; empty states must handle it.
+- ADR-0019 §5's "creator becomes founding admin" no longer holds for Platform Admin creation.
+- Operating the platform and playing in a team now requires two accounts, permanently and by design.


### PR DESCRIPTION
## Summary

Documents two foundational architectural decisions for multi-team membership and platform administration:

- **ADR-0021**: Introduces the **Active Team** — an explicitly selected, session-carried tenant context that replaces implicit routing. Fixes the silent cross-tenant misrouting bug where users with multiple team memberships could be routed to the wrong team by UUID order.
- **ADR-0022**: Defines **Act-as** — a time-boxed, visible mechanism for Platform Admins to enter and operate inside teams they don't belong to, without becoming members. Includes Virtual Members (synthesized authorization), memberless team creation, and Admin-granting invite links.

Both ADRs amend ADR-0019 (self-service team onboarding) and are prerequisites for the club rollout (#240) and multi-team support (#143).

## Key changes

- **ADR-0021** (`docs/adr/0021-active-team-explicit-tenant-resolution.md`):
  - Replaces implicit `ORDER BY … LIMIT 1` routing with explicit Active Team selection
  - Active Team lives on session, persisted per user, switched via team-slug URLs
  - Lifts the one-team-per-user guard; enables multi-team membership
  - Amends ADR-0019 §3 (removes `409 ALREADY_IN_TEAM`) and §6 (`/auth/me` contract: `team` → `teams[]` + `activeTeam`)
  - Single authorization chokepoint (`findRole`) remains; Act-as supplies a second source to it

- **ADR-0022** (`docs/adr/0022-platform-admin-act-as.md`):
  - Platform Admins are structurally teamless; never Members of any Team
  - Act-as grants full read+write via Virtual Member (synthesized `ADMIN` role, no `team_members` row written)
  - 60-minute sliding expiry, persistent banner, distinct `ACT_AS_EXPIRED` error on lapse
  - Act-as Records scoped to session (not per-row), actor rendered generically ("the platform")
  - Memberless team creation + Admin-granting Invite Links for handoff
  - Amends ADR-0019 §5: Platform Admin creating a team does not become its founding admin

- **CONTEXT.md** updated with new terminology:
  - Active Team, Platform Admin, Act-as, Virtual Member, Act-as Record
  - Clarified Invite Link now carries Role on acceptance
  - Clarified team creation paths (self-service vs. Platform Admin memberless)

## Implementation notes

- Both ADRs are decision documents only; no code changes in this PR
- ADR-0021 is the prerequisite seam; ADR-0022 builds on it
- The security-critical invariants in ADR-0022 (Virtual Member synthesis only under active act-as, no `team_members` writes) are explicitly called out as test-worthy in Consequences
- Deliberately decoupled from general audit log (#237); Act-as Records are expected to fold in as one `action_type` later
- No cross-team data views, simultaneous multi-team roles, or identity merging between platform and player accounts

https://claude.ai/code/session_01FJ88MbwnNYUKbgeKZzMdvc