### PR TITLE
feat: the Active Team — multi-team membership, explicit tenant resolution, and the switcher (#143)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   link), and remembered as their default between logins. A Member of several Teams has
   exactly one Active Team at a time; authorization for it comes either from their real
   membership or, for a **Platform Admin**, from **Act-as**
-  ([ADR-0021](docs/adr/0021-active-team-explicit-tenant-resolution.md)).
+  ([ADR-0023](docs/adr/0023-active-team-explicit-tenant-resolution.md)).
   _Avoid_: current team, selected tenant, team context.
 - **Member** — A person belonging to a Team. Has exactly one **Role** and at most one
   **Position**.
@@ -96,7 +96,7 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   safe to re-tap as new events appear), **future-only** (past events are skipped), and scoped
   **per Event Type**: one button per type that currently has blanks, each naming its own scope
   ("Attend 12 trainings", "Attend 3 matches"), so no filtering is needed to make a legible tap
-  ([ADR-0021](docs/adr/0021-bulk-attend-one-button-per-event-type.md) amends the original
+  ([ADR-0023](docs/adr/0021-bulk-attend-one-button-per-event-type.md) amends the original
   "currently shown" scoping; the **Event Type** filter still narrows what is on screen, and so
   what the buttons cover).
   Self-in-practice (no UI to Bulk Attend for others, though the endpoint stays trust-based per
@@ -133,13 +133,13 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
   an existing Team. Clicking it → enter email → Magic Link → joined. One link, many
   joiners; can expire/rotate. Carries the **Role** it grants on acceptance — ordinarily
   **User**, but an **Admin**-granting link is how a memberless Team gets its first Admin
-  ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)).
+  ([ADR-0024](docs/adr/0024-platform-admin-act-as.md)).
 - **Team creation** — Provisioning a new Team. Self-service: a logged-in, teamless user
   creates their Team from a name + slug + one-time **creation code**, which provisions the
   tenant schema inline (see [ADR-0019](docs/adr/0019-self-service-team-onboarding.md)).
   Back-office onboarding is now just minting a creation code. A **Platform Admin** may also
   create a Team **memberless** — no founding Admin — and hand it over with an Admin-granting
-  **Invite Link** ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)).
+  **Invite Link** ([ADR-0024](docs/adr/0024-platform-admin-act-as.md)).
 
 ### Platform & integrations
 
@@ -152,7 +152,7 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 - **Act-as** — An explicitly entered, time-boxed state in which a **Platform Admin** operates
   inside one Team as if they were an Admin of it. Full read *and* write. Always visible while
   active, always exited deliberately, and always recorded — see **Act-as Record**
-  ([ADR-0022](docs/adr/0022-platform-admin-act-as.md)). _Avoid_: impersonation, spy mode,
+  ([ADR-0024](docs/adr/0024-platform-admin-act-as.md)). _Avoid_: impersonation, spy mode,
   support mode, sudo.
 - **Virtual Member** — The synthesized **Admin** authorization a **Platform Admin** holds inside
   a Team during **Act-as**. Exists only for the duration of the request: no `team_members` row is

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
@@ -11,7 +11,7 @@ import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 
 /**
- * The Active Team (ADR-0021): the one Team a request is scoped to, **explicitly selected and never
+ * The Active Team (ADR-0023): the one Team a request is scoped to, **explicitly selected and never
  * inferred**. This is the single tenant-resolution seam — every path that decides which Team a caller
  * is working in goes through here, so there is exactly one place where "may they have it?" is asked.
  *
@@ -23,10 +23,10 @@ import com.github.zzave.teambalance.api.domain.port.UserRepository
  *    the caller has to choose. That is what replaced `ORDER BY team_id LIMIT 1`, which chose by UUID.
  *  - [activate] performs a **switch** to a *named* Team. It verifies membership, remembers the choice,
  *    and re-pins the session routing. Every switch is the same kind of switch — a deliberate one and a
- *    link-induced one are indistinguishable here, deliberately (ADR-0021 §3).
+ *    link-induced one are indistinguishable here, deliberately (ADR-0023 §3).
  *
  * Nothing here answers "not yours" differently from "does not exist": both are null, so the Team id
- * space cannot be probed. Act-as (ADR-0022) will plug a second *authorization* source into the
+ * space cannot be probed. Act-as (ADR-0024) will plug a second *authorization* source into the
  * membership check without adding a second resolution path.
  */
 class ActiveTeamService(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
@@ -1,0 +1,88 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.model.Slug
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
+import com.github.zzave.teambalance.api.domain.model.TenantRouting
+import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+
+/**
+ * The Active Team (ADR-0021): the one Team a request is scoped to, **explicitly selected and never
+ * inferred**. This is the single tenant-resolution seam — every path that decides which Team a caller
+ * is working in goes through here, so there is exactly one place where "may they have it?" is asked.
+ *
+ * Two operations, and the difference between them is the whole design:
+ *
+ *  - [resolveLanding] answers "where does this caller land when they haven't said?" — the remembered
+ *    Team if it is *still* a valid active membership, else their sole membership, else nothing. It
+ *    never picks between several Teams: with more than one and none remembered, the answer is null and
+ *    the caller has to choose. That is what replaced `ORDER BY team_id LIMIT 1`, which chose by UUID.
+ *  - [activate] performs a **switch** to a *named* Team. It verifies membership, remembers the choice,
+ *    and re-pins the session routing. Every switch is the same kind of switch — a deliberate one and a
+ *    link-induced one are indistinguishable here, deliberately (ADR-0021 §3).
+ *
+ * Nothing here answers "not yours" differently from "does not exist": both are null, so the Team id
+ * space cannot be probed. Act-as (ADR-0022) will plug a second *authorization* source into the
+ * membership check without adding a second resolution path.
+ */
+class ActiveTeamService(
+    private val teamMemberRepository: TeamMemberRepository,
+    private val teamRepository: TeamRepository,
+    private val userRepository: UserRepository,
+    private val tenantRoutingGateway: TenantRoutingGateway,
+) {
+    /** Every Team the user is an active Member of — what the switcher lists. Empty for a teamless user. */
+    fun teamsOf(userId: UserId): List<TeamSummary> = teamRepository.findTeamsOf(userId.value)
+
+    /**
+     * Where the caller lands with no Team named: their remembered Active Team while it is still a
+     * valid active membership, otherwise their sole membership, otherwise nothing.
+     *
+     * The remembered id is re-verified rather than trusted. Sessions slide for four weeks and survive
+     * restarts (ADR-0014/0015), so a remembered Team can outlive the membership behind it; verifying
+     * turns that into "force a choice" instead of a route into a tenant they were removed from.
+     */
+    fun resolveLanding(userId: UserId): TenantRouting? =
+        userRepository.findLastActiveTeamId(userId)
+            ?.let { teamMemberRepository.findTenantRouting(it, userId) }
+            ?: teamMemberRepository.findSoleTenantRouting(userId)
+
+    /**
+     * Switches the caller's Active Team to [teamId] and returns the routing it resolved to, or null
+     * when they may not have that Team (which reads the same as "no such Team").
+     */
+    fun activate(userId: UserId, teamId: TeamId): TenantRouting? =
+        teamMemberRepository.findTenantRouting(teamId, userId)?.also { adopt(userId, it) }
+
+    /**
+     * Switches the caller's Active Team to the Team addressed by [slug] — the authorized switch a
+     * shared `/t/:slug/…` link performs — and returns it, or null when the slug is unknown *or* not
+     * theirs. The two cases are deliberately indistinguishable.
+     */
+    fun activateBySlug(userId: UserId, slug: Slug): TeamSummary? =
+        teamRepository.findBySlug(slug)?.takeIf { activate(userId, it.id) != null }
+
+    /**
+     * Resolves and pins the caller's landing Team at sign-in, returning it. A teamless user — or one
+     * with several Teams and none remembered — pins nothing and lands on a choice instead.
+     */
+    fun pinLanding(userId: UserId): TeamId? =
+        resolveLanding(userId)?.also(tenantRoutingGateway::pinRouting)?.teamId
+
+    /**
+     * Makes [routing] the caller's Active Team: remembered on the user, then re-pinned on the session.
+     *
+     * The re-pin is not a cache refresh — it is the **invalidation**. `TenantRoutingSession` memoizes
+     * `(schema, teamId)` as a pair and every later request reads it back without touching the
+     * database, so a switch that failed to overwrite it would leave the caller reading and writing the
+     * previous tenant. That is why pinning is part of this method and not left to the caller.
+     */
+    private fun adopt(userId: UserId, routing: TenantRouting) {
+        userRepository.rememberActiveTeam(userId, routing.teamId)
+        tenantRoutingGateway.pinRouting(routing)
+    }
+}

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
@@ -11,23 +11,12 @@ import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 
 /**
- * The Active Team (ADR-0023): the one Team a request is scoped to, **explicitly selected and never
- * inferred**. This is the single tenant-resolution seam — every path that decides which Team a caller
- * is working in goes through here, so there is exactly one place where "may they have it?" is asked.
+ * The Active Team (ADR-0023): the one Team a request is scoped to, explicitly selected and never
+ * inferred. The single tenant-resolution seam — every path deciding which Team a caller works in
+ * comes through here.
  *
- * Two operations, and the difference between them is the whole design:
- *
- *  - [resolveLanding] answers "where does this caller land when they haven't said?" — the remembered
- *    Team if it is *still* a valid active membership, else their sole membership, else nothing. It
- *    never picks between several Teams: with more than one and none remembered, the answer is null and
- *    the caller has to choose. That is what replaced `ORDER BY team_id LIMIT 1`, which chose by UUID.
- *  - [activate] performs a **switch** to a *named* Team. It verifies membership, remembers the choice,
- *    and re-pins the session routing. Every switch is the same kind of switch — a deliberate one and a
- *    link-induced one are indistinguishable here, deliberately (ADR-0023 §3).
- *
- * Nothing here answers "not yours" differently from "does not exist": both are null, so the Team id
- * space cannot be probed. Act-as (ADR-0024) will plug a second *authorization* source into the
- * membership check without adding a second resolution path.
+ * Every "may they have it?" answers null for both "not yours" and "no such Team", so the Team id
+ * space cannot be probed.
  */
 class ActiveTeamService(
     private val teamMemberRepository: TeamMemberRepository,
@@ -35,45 +24,30 @@ class ActiveTeamService(
     private val userRepository: UserRepository,
     private val tenantRoutingGateway: TenantRoutingGateway,
 ) {
-    /** Every Team the user is an active Member of — what the switcher lists. Empty for a teamless user. */
     fun teamsOf(userId: UserId): List<TeamSummary> = teamRepository.findTeamsOf(userId.value)
 
     /**
-     * Where the caller lands with no Team named: their remembered Active Team while it is still a
-     * valid active membership, otherwise their sole membership, otherwise nothing.
+     * Where the caller lands with no Team named. Null when they have several and remember none —
+     * there is no defensible pick, so the choice becomes theirs.
      *
-     * The remembered id is re-verified rather than trusted. Sessions slide for four weeks and survive
-     * restarts (ADR-0014/0015), so a remembered Team can outlive the membership behind it; verifying
-     * turns that into "force a choice" instead of a route into a tenant they were removed from.
+     * The remembered Team is re-verified rather than trusted: sessions slide for four weeks
+     * (ADR-0015), long enough to outlive the membership behind them.
      */
     fun resolveLanding(userId: UserId): TenantRouting? =
         userRepository.findLastActiveTeamId(userId)
             ?.let { teamMemberRepository.findTenantRouting(it, userId) }
             ?: teamMemberRepository.findSoleTenantRouting(userId)
 
-    /**
-     * Switches the caller's Active Team to [teamId] and returns the routing it resolved to, or null
-     * when they may not have that Team (which reads the same as "no such Team").
-     */
     fun activate(userId: UserId, teamId: TeamId): TenantRouting? =
-        teamMemberRepository.findTenantRouting(teamId, userId)?.also { adopt(userId, it) }
+        teamMemberRepository.findTenantRouting(teamId, userId)?.also { makeActive(userId, it) }
 
-    /**
-     * Switches the caller's Active Team to the Team addressed by [slug] — the authorized switch a
-     * shared `/t/:slug/…` link performs — and returns it, or null when the slug is unknown *or* not
-     * theirs. The two cases are deliberately indistinguishable.
-     */
+    /** The authorized switch a shared `/t/:slug/…` link performs. */
     fun activateBySlug(userId: UserId, slug: Slug): TeamSummary? =
         teamRepository.findBySlug(slug)?.takeIf { activate(userId, it.id) != null }
 
     /**
-     * Resolves and pins the caller's landing Team at sign-in, returning it. A teamless user — or one
-     * with several Teams and none remembered — pins nothing and lands on a choice instead.
-     *
-     * The clear is unconditional and comes first, precisely *because* the pin is conditional. A
-     * sign-in can land on a session that already carries someone else's routing (a shared phone, a
-     * second magic link in the same browser); resolving to nothing would then leave that routing in
-     * place and hand the new caller the previous caller's tenant.
+     * Signs the caller into their landing Team. Clearing is unconditional precisely because pinning
+     * is not: a sign-in over a live session would otherwise inherit the previous caller's tenant.
      */
     fun pinLanding(userId: UserId): TeamId? {
         tenantRoutingGateway.clearRouting()
@@ -81,14 +55,10 @@ class ActiveTeamService(
     }
 
     /**
-     * Makes [routing] the caller's Active Team: remembered on the user, then re-pinned on the session.
-     *
-     * The re-pin is not a cache refresh — it is the **invalidation**. `TenantRoutingSession` memoizes
-     * `(schema, teamId)` as a pair and every later request reads it back without touching the
-     * database, so a switch that failed to overwrite it would leave the caller reading and writing the
-     * previous tenant. That is why pinning is part of this method and not left to the caller.
+     * Re-pinning is the session-memo invalidation, not a cache refresh — later requests read the memo
+     * without touching the database, so a switch that skipped this would keep serving the old tenant.
      */
-    private fun adopt(userId: UserId, routing: TenantRouting) {
+    private fun makeActive(userId: UserId, routing: TenantRouting) {
         userRepository.rememberActiveTeam(userId, routing.teamId)
         tenantRoutingGateway.pinRouting(routing)
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamService.kt
@@ -69,9 +69,16 @@ class ActiveTeamService(
     /**
      * Resolves and pins the caller's landing Team at sign-in, returning it. A teamless user — or one
      * with several Teams and none remembered — pins nothing and lands on a choice instead.
+     *
+     * The clear is unconditional and comes first, precisely *because* the pin is conditional. A
+     * sign-in can land on a session that already carries someone else's routing (a shared phone, a
+     * second magic link in the same browser); resolving to nothing would then leave that routing in
+     * place and hand the new caller the previous caller's tenant.
      */
-    fun pinLanding(userId: UserId): TeamId? =
-        resolveLanding(userId)?.also(tenantRoutingGateway::pinRouting)?.teamId
+    fun pinLanding(userId: UserId): TeamId? {
+        tenantRoutingGateway.clearRouting()
+        return resolveLanding(userId)?.also(tenantRoutingGateway::pinRouting)?.teamId
+    }
 
     /**
      * Makes [routing] the caller's Active Team: remembered on the user, then re-pinned on the session.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -57,28 +57,17 @@ class AuthService(
 
     fun findUserById(id: UserId): User? = userRepository.findById(id)
 
-    /**
-     * Every Team the user is an active Member of — the has-any-team gate signal on `/auth/me`. Plural
-     * since #143: membership of several Teams is ordinary, and which one is *active* is a separate
-     * question, answered by the Active Team ([ActiveTeamService]) rather than by this list's order.
-     */
+    /** The has-any-team gate signal on `/auth/me`. Which one is *active* is a separate question. */
     fun findTeamsFor(userId: UserId): List<TeamSummary> = activeTeamService.teamsOf(userId)
 
     /**
-     * The user's Role **in their Active Team**, or null when no Team is active for this request — the
-     * `role` field of the authenticated-user payload. Identity-shaped ("who is this caller, here?"),
-     * unlike [AuthorizationService], which answers "may this caller do X on team Y?". Takes the Active
-     * Team as an argument rather than resolving one: with several memberships a caller has several
-     * Roles, and only the active one is theirs for this request.
+     * Identity-shaped ("who is this caller, here?"), unlike [AuthorizationService], which answers
+     * "may this caller do X on team Y?". The Active Team is an argument because a caller with several
+     * memberships has several Roles, and only the active one is theirs for this request.
      */
     fun findRoleIn(teamId: TeamId, userId: UserId): Role? = teamMemberRepository.findRole(teamId, userId)
 
-    /**
-     * Signs [userId] in: opens their session, then pins the Active Team they land in (team id + schema
-     * from one row, so the tenant lookup can't diverge or race) and returns it. Null when nothing could
-     * be resolved — a teamless user, or one with several Teams and none remembered, who is asked to
-     * choose instead of being given an arbitrary one.
-     */
+    /** Opens the session and returns the Active Team pinned for it, or null if none resolved. */
     fun startSession(userId: UserId): TeamId? {
         authSessionGateway.startSession(userId)
         return activeTeamService.pinLanding(userId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthService.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
 import com.github.zzave.teambalance.api.domain.model.MagicLinkToken
 import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.model.User
@@ -13,8 +14,6 @@ import com.github.zzave.teambalance.api.domain.port.EmailGateway
 import com.github.zzave.teambalance.api.domain.port.MagicLinkTokenRepository
 import com.github.zzave.teambalance.api.domain.port.PlatformAdminGateway
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
-import com.github.zzave.teambalance.api.domain.port.TeamRepository
-import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -27,12 +26,11 @@ import java.util.UUID
 class AuthService(
     private val magicLinkTokenRepository: MagicLinkTokenRepository,
     private val userRepository: UserRepository,
-    private val teamRepository: TeamRepository,
     private val teamMemberRepository: TeamMemberRepository,
+    private val activeTeamService: ActiveTeamService,
     private val emailGateway: EmailGateway,
     private val platformAdminGateway: PlatformAdminGateway,
     private val authSessionGateway: AuthSessionGateway,
-    private val tenantRoutingGateway: TenantRoutingGateway,
     private val clock: Clock,
 ) {
     companion object {
@@ -59,24 +57,31 @@ class AuthService(
 
     fun findUserById(id: UserId): User? = userRepository.findById(id)
 
-    /** The team the user belongs to, or null if teamless — the has-a-team gate signal on `/auth/me`. */
-    fun findTeamFor(userId: UserId): TeamSummary? = teamRepository.findByUserId(userId.value)
+    /**
+     * Every Team the user is an active Member of — the has-any-team gate signal on `/auth/me`. Plural
+     * since #143: membership of several Teams is ordinary, and which one is *active* is a separate
+     * question, answered by the Active Team ([ActiveTeamService]) rather than by this list's order.
+     */
+    fun findTeamsFor(userId: UserId): List<TeamSummary> = activeTeamService.teamsOf(userId)
 
     /**
-     * The user's role on the team they belong to, or null when they are teamless or have no active
-     * membership — the `role` field of the authenticated-user payload. Identity-shaped ("who is this
-     * caller?"), unlike [AuthorizationService], which answers "may this caller do X on team Y?".
+     * The user's Role **in their Active Team**, or null when no Team is active for this request — the
+     * `role` field of the authenticated-user payload. Identity-shaped ("who is this caller, here?"),
+     * unlike [AuthorizationService], which answers "may this caller do X on team Y?". Takes the Active
+     * Team as an argument rather than resolving one: with several memberships a caller has several
+     * Roles, and only the active one is theirs for this request.
      */
-    fun findRoleFor(userId: UserId): Role? =
-        teamMemberRepository.findTeamId(userId)?.let { teamId -> teamMemberRepository.findRole(teamId, userId) }
+    fun findRoleIn(teamId: TeamId, userId: UserId): Role? = teamMemberRepository.findRole(teamId, userId)
 
     /**
-     * Signs [userId] in: opens their session, then pins where their work happens (team id + schema
-     * from one row, so the tenant lookup can't diverge or race). A teamless user has nothing to pin.
+     * Signs [userId] in: opens their session, then pins the Active Team they land in (team id + schema
+     * from one row, so the tenant lookup can't diverge or race) and returns it. Null when nothing could
+     * be resolved — a teamless user, or one with several Teams and none remembered, who is asked to
+     * choose instead of being given an arbitrary one.
      */
-    fun startSession(userId: UserId) {
+    fun startSession(userId: UserId): TeamId? {
         authSessionGateway.startSession(userId)
-        teamMemberRepository.findTenantRouting(userId)?.let(tenantRoutingGateway::pinRouting)
+        return activeTeamService.pinLanding(userId)
     }
 
     /** The caller behind the current session, or null when unauthenticated — what `/auth/me` answers on. */

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 /**
  * Team-scoped authorization checks — the single chokepoint every team-scoped decision passes through
- * (ADR-0021 §1). Act-as (ADR-0022) will add a second *source* of a Role here (a synthesized Virtual
+ * (ADR-0023 §1). Act-as (ADR-0024) will add a second *source* of a Role here (a synthesized Virtual
  * Member) rather than a second path around it.
  *
  * SECURITY CONTRACT — this primitive is only as safe as its arguments:

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -10,18 +10,16 @@ import java.util.UUID
 
 /**
  * Team-scoped authorization checks — the single chokepoint every team-scoped decision passes through
- * (ADR-0023 §1). Act-as (ADR-0024) will add a second *source* of a Role here (a synthesized Virtual
- * Member) rather than a second path around it.
+ * (ADR-0023 §1).
  *
  * SECURITY CONTRACT — this primitive is only as safe as its arguments:
  * - [userId] MUST be the authenticated principal (from the session, e.g. `UserContext.get()`),
  *   never a user-supplied id from a request body/path/query — otherwise this is trivially bypassed.
  * - [teamId] MAY be caller-influenced — a slug in a shared link, a Team picked in the switcher — and
- *   is made safe by being validated *here* rather than by never reaching here. What that requires of
- *   callers: a team id that fails [findRole][TeamMemberRepository.findRole] must resolve to **no
- *   tenant** (`TenantContext.NO_TENANT_SCHEMA`), never to `public` and never to the caller's previous
- *   Team; and the rejection must be indistinguishable from "no such team", so the id space cannot be
- *   probed for which Teams exist.
+ *   is made safe by being validated here rather than by never reaching here. A team id that fails
+ *   [findRole][TeamMemberRepository.findRole] must resolve to **no tenant**
+ *   (`TenantContext.NO_TENANT_SCHEMA`), never to `public` and never to the caller's previous Team,
+ *   and must be indistinguishable from "no such team".
  *
  * The check is fail-closed: a missing, inactive, or wrong-team membership yields no role and is
  * therefore neither a member nor an admin.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/AuthorizationService.kt
@@ -9,13 +9,19 @@ import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import java.util.UUID
 
 /**
- * Team-scoped authorization checks.
+ * Team-scoped authorization checks — the single chokepoint every team-scoped decision passes through
+ * (ADR-0021 §1). Act-as (ADR-0022) will add a second *source* of a Role here (a synthesized Virtual
+ * Member) rather than a second path around it.
  *
  * SECURITY CONTRACT — this primitive is only as safe as its arguments:
  * - [userId] MUST be the authenticated principal (from the session, e.g. `UserContext.get()`),
  *   never a user-supplied id from a request body/path/query — otherwise this is trivially bypassed.
- * - [teamId] MUST be the server-resolved tenant for that request, never a raw request parameter —
- *   otherwise a user can probe or act on teams they don't belong to (IDOR).
+ * - [teamId] MAY be caller-influenced — a slug in a shared link, a Team picked in the switcher — and
+ *   is made safe by being validated *here* rather than by never reaching here. What that requires of
+ *   callers: a team id that fails [findRole][TeamMemberRepository.findRole] must resolve to **no
+ *   tenant** (`TenantContext.NO_TENANT_SCHEMA`), never to `public` and never to the caller's previous
+ *   Team; and the rejection must be indistinguishable from "no such team", so the id space cannot be
+ *   probed for which Teams exist.
  *
  * The check is fail-closed: a missing, inactive, or wrong-team membership yields no role and is
  * therefore neither a member nor an admin.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -56,15 +56,10 @@ class InvitationService(
     }
 
     /**
-     * Joins the presenting user to the invitation's team **and makes it their Active Team**, so a
-     * joiner lands where they just accepted rather than back in whichever Team they were in before
-     * (ADR-0023 §4). That second half is why accepting is no longer fire-and-forget: since #143 a
-     * joiner may already be a Member somewhere, and joining without switching would leave them
-     * looking at the wrong Team.
+     * Joins the presenting user to the invitation's team and makes it their Active Team, so a joiner
+     * who was already a Member elsewhere lands where they just accepted (ADR-0023 §4).
      *
-     * Returns null for an unknown or expired token (rotated/revoked tokens read the same way once #38
-     * lands) so the controller can answer with a plain 404 — no distinction is made between "never
-     * existed" and "expired" to avoid leaking which is the case.
+     * Returns null for an unknown or expired token — no distinction, to avoid leaking which it is.
      */
     fun acceptInvitation(token: String, userId: UserId): TeamId? {
         val now = Instant.now(clock)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -58,7 +58,7 @@ class InvitationService(
     /**
      * Joins the presenting user to the invitation's team **and makes it their Active Team**, so a
      * joiner lands where they just accepted rather than back in whichever Team they were in before
-     * (ADR-0021 §4). That second half is why accepting is no longer fire-and-forget: since #143 a
+     * (ADR-0023 §4). That second half is why accepting is no longer fire-and-forget: since #143 a
      * joiner may already be a Member somewhere, and joining without switching would leave them
      * looking at the wrong Team.
      *

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -22,6 +22,7 @@ class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val teamMemberRepository: TeamMemberRepository,
     private val authorizationService: AuthorizationService,
+    private val activeTeamService: ActiveTeamService,
     private val clock: Clock,
     // App-wide secret mixed into the token hash. Read from teambalance.invitation.token-salt by the
     // composition root — INVITATION_TOKEN_SALT in live environments (see application.yml), a
@@ -55,10 +56,15 @@ class InvitationService(
     }
 
     /**
-     * Joins the presenting user to the invitation's team. Returns null for an unknown or expired
-     * token (rotated/revoked tokens will read the same way once #38 lands) so the controller can
-     * answer with a plain 404 — no distinction is made between "never existed" and "expired" to
-     * avoid leaking which is the case.
+     * Joins the presenting user to the invitation's team **and makes it their Active Team**, so a
+     * joiner lands where they just accepted rather than back in whichever Team they were in before
+     * (ADR-0021 §4). That second half is why accepting is no longer fire-and-forget: since #143 a
+     * joiner may already be a Member somewhere, and joining without switching would leave them
+     * looking at the wrong Team.
+     *
+     * Returns null for an unknown or expired token (rotated/revoked tokens read the same way once #38
+     * lands) so the controller can answer with a plain 404 — no distinction is made between "never
+     * existed" and "expired" to avoid leaking which is the case.
      */
     fun acceptInvitation(token: String, userId: UserId): TeamId? {
         val now = Instant.now(clock)
@@ -66,6 +72,7 @@ class InvitationService(
             ?.takeIf { it.expiresAt.isAfter(now) }
             ?: return null
         teamMemberRepository.addMember(invitation.teamId, userId)
+        activeTeamService.activate(userId, invitation.teamId)
         return invitation.teamId
     }
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -36,10 +36,8 @@ data class CreatedTeam(val id: TeamId, val name: TeamName, val slug: Slug)
  * or slug collision) the only residue is a harmless empty orphan schema, self-healed by the startup
  * migration runner. Notifications are best-effort and can never fail a committed creation.
  *
- * The founder no longer has to be teamless. ADR-0019 §3 rejected an existing member with
- * `409 ALREADY_IN_TEAM` to match a routing layer that could only hold one Team per user; ADR-0023
- * lifted that guard along with the routing constraint behind it, so someone already playing in one
- * Team can start another.
+ * The founder need not be teamless: ADR-0023 lifted ADR-0019 §3's `409 ALREADY_IN_TEAM` along with
+ * the one-team routing constraint behind it.
  */
 class TeamService(
     private val teamRepository: TeamRepository,
@@ -73,9 +71,7 @@ class TeamService(
             now = now,
         )
 
-        // The founder is a Member of the new Team as of register(), so this switch resolves — and it
-        // has to happen here rather than being left to the client: without it a founder who already
-        // plays elsewhere would create a Team and stay routed to their old one.
+        // Without this a founder who already plays elsewhere stays routed to their old Team.
         activeTeamService.activate(founderId, teamId)
 
         notifyBestEffort(founderId, names.name, names.slug)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -1,6 +1,5 @@
 package com.github.zzave.teambalance.api.application
 
-import com.github.zzave.teambalance.api.domain.exception.AlreadyInTeamException
 import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
 import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
 import com.github.zzave.teambalance.api.domain.model.CreationCode
@@ -13,7 +12,6 @@ import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
 import com.github.zzave.teambalance.api.domain.port.TeamNotificationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRegistrationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.TenantProvisioningGateway
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import org.slf4j.LoggerFactory
@@ -28,30 +26,34 @@ data class CreatedTeam(val id: TeamId, val name: TeamName, val slug: Slug)
  * name + a one-time creation code and becomes its founding admin.
  *
  * Ordering is deliberately provision-first so a partial failure never strands a consumed code:
- *  1. reject if the caller already belongs to a team (v1 one-team-per-user, #143);
- *  2. validate the name + user-supplied slug and derive the tenant schema name (bad name/slug → 400);
- *  3. pre-check slug uniqueness and code redeemability (fast, clean 409 / opaque 403 before any writes);
- *  4. provision the tenant schema (idempotent, on its own connection — commits independently);
- *  5. atomically consume the code and insert the team + founding admin ([TeamRegistrationGateway]).
+ *  1. validate the name + user-supplied slug and derive the tenant schema name (bad name/slug → 400);
+ *  2. pre-check slug uniqueness and code redeemability (fast, clean 409 / opaque 403 before any writes);
+ *  3. provision the tenant schema (idempotent, on its own connection — commits independently);
+ *  4. atomically consume the code and insert the team + founding admin ([TeamRegistrationGateway]);
+ *  5. make the new Team the founder's Active Team, so they land in what they just created.
  *
- * If step 4 fails nothing is consumed and the user simply retries. If step 5 loses a race (code taken
+ * If step 3 fails nothing is consumed and the user simply retries. If step 4 loses a race (code taken
  * or slug collision) the only residue is a harmless empty orphan schema, self-healed by the startup
  * migration runner. Notifications are best-effort and can never fail a committed creation.
+ *
+ * The founder no longer has to be teamless. ADR-0019 §3 rejected an existing member with
+ * `409 ALREADY_IN_TEAM` to match a routing layer that could only hold one Team per user; ADR-0021
+ * lifted that guard along with the routing constraint behind it, so someone already playing in one
+ * Team can start another.
  */
 class TeamService(
-    private val teamMemberRepository: TeamMemberRepository,
     private val teamRepository: TeamRepository,
     private val creationCodeRepository: TeamCreationCodeRepository,
     private val tenantProvisioningGateway: TenantProvisioningGateway,
     private val teamRegistrationGateway: TeamRegistrationGateway,
     private val userRepository: UserRepository,
     private val teamNotificationGateway: TeamNotificationGateway,
+    private val activeTeamService: ActiveTeamService,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(TeamService::class.java)
 
     fun createTeam(founderId: UserId, rawName: String, rawSlug: String, creationCode: CreationCode): CreatedTeam {
-        requireTeamless(founderId)
         val names = TeamNaming.validate(rawName, rawSlug)
         requireSlugAvailable(names.slug)
 
@@ -71,19 +73,19 @@ class TeamService(
             now = now,
         )
 
+        // The founder is a Member of the new Team as of register(), so this switch resolves — and it
+        // has to happen here rather than being left to the client: without it a founder who already
+        // plays elsewhere would create a Team and stay routed to their old one.
+        activeTeamService.activate(founderId, teamId)
+
         notifyBestEffort(founderId, names.name, names.slug)
 
         return CreatedTeam(id = teamId, name = names.name, slug = names.slug)
     }
 
-    private fun requireTeamless(founderId: UserId) {
-        teamMemberRepository.findTeamId(founderId)?.let { throw AlreadyInTeamException(founderId.value) }
-    }
-
     private fun requireSlugAvailable(slug: Slug) {
         if (teamRepository.existsBySlug(slug)) {
-            // The exception carries the slug for its message only, so it takes the primitive — the
-            // same treatment AlreadyInTeamException already gets from requireTeamless above.
+            // The exception carries the slug for its message only, so it takes the primitive.
             throw TeamSlugTakenException(slug.value)
         }
     }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -37,7 +37,7 @@ data class CreatedTeam(val id: TeamId, val name: TeamName, val slug: Slug)
  * migration runner. Notifications are best-effort and can never fail a committed creation.
  *
  * The founder no longer has to be teamless. ADR-0019 §3 rejected an existing member with
- * `409 ALREADY_IN_TEAM` to match a routing layer that could only hold one Team per user; ADR-0021
+ * `409 ALREADY_IN_TEAM` to match a routing layer that could only hold one Team per user; ADR-0023
  * lifted that guard along with the routing constraint behind it, so someone already playing in one
  * Team can start another.
  */

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -97,11 +97,6 @@ class LastAdminException(teamId: TeamId) :
 class PositionLabelTakenException(label: String) :
     ConflictException("Position '$label' already exists in this team", "POSITION_LABEL_TAKEN")
 
-// The founder already belongs to a team. v1 is one-team-per-user (routing does ORDER BY … LIMIT 1);
-// multi-team membership + switcher is deferred to #143.
-class AlreadyInTeamException(userId: UUID) :
-    ConflictException("User $userId already belongs to a team", "ALREADY_IN_TEAM")
-
 // A team with this slug (and therefore this derived schema) already exists. No auto-suffixing — the
 // caller picks a different name.
 class TeamSlugTakenException(slug: String) :

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
@@ -3,6 +3,12 @@ package com.github.zzave.teambalance.api.domain.port
 import com.github.zzave.teambalance.api.domain.model.TeamId
 
 interface CurrentTeamGateway {
-    /** The team resolved for the current request, or throws if the caller has no active team. */
+    /** The Active Team for the current request, or throws if the caller has no active team. */
     fun requireCurrentTeamId(): TeamId
+
+    /**
+     * The Active Team for the current request, or null when none is resolved. The nullable read for
+     * the one caller that must describe a teamless user rather than reject them (`/auth/me`).
+     */
+    fun findCurrentTeamId(): TeamId?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/CurrentTeamGateway.kt
@@ -6,9 +6,6 @@ interface CurrentTeamGateway {
     /** The Active Team for the current request, or throws if the caller has no active team. */
     fun requireCurrentTeamId(): TeamId
 
-    /**
-     * The Active Team for the current request, or null when none is resolved. The nullable read for
-     * the one caller that must describe a teamless user rather than reject them (`/auth/me`).
-     */
+    /** The Active Team for the current request, or null when none is resolved. */
     fun findCurrentTeamId(): TeamId?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -22,25 +22,18 @@ interface TeamMemberRepository {
     fun findRole(teamId: TeamId, userId: UserId): Role?
 
     /**
-     * The tenant routing (team id + schema) for **this** team and this user, resolved from ONE row,
-     * or null when they have no active membership of it (ADR-0023 §1). The team id is an input, not a
-     * discovery: this asks "resolve this team for this user, and verify they may have it" — it never
-     * picks a team on the caller's behalf.
-     *
-     * Null is the *only* failure mode, and it covers both "no such team" and "not yours" — the caller
-     * cannot tell them apart, so the team id space cannot be probed.
+     * Team id and schema for this team and this user, from ONE row. Null covers both "no such team"
+     * and "not yours", indistinguishably, so the team id space cannot be probed (ADR-0023 §1).
      */
     fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting?
 
-    /**
-     * The tenant routing of the user's **only** active membership, or null when they have none — or
-     * more than one. Deliberately not "their first team": with several memberships there is no
-     * defensible pick, so this answers null and the Active Team has to be chosen explicitly
-     * (ADR-0023 §3). This is what replaced the `ORDER BY team_id LIMIT 1` that used to choose by UUID.
-     */
+    /** Null for none and for several: with several there is no defensible pick (ADR-0023 §3). */
     fun findSoleTenantRouting(userId: UserId): TenantRouting?
 
-    /** Joins the user to the team as a USER. No-op if already an active member of this team. */
+    /**
+     * Joins the user to the team as a USER, whether or not they were a member before. No-op if they
+     * already are one. A previously removed member comes back as a USER, never at their old role.
+     */
     fun addMember(teamId: TeamId, userId: UserId)
 
     /** Sets the permission [role] for an active member. */

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -21,15 +21,24 @@ interface TeamMemberRepository {
     /** The user's role on the team, or null if they have no active membership there. */
     fun findRole(teamId: TeamId, userId: UserId): Role?
 
-    /** The team the user actively belongs to, or null if they have no team (v1: one team per user). */
-    fun findTeamId(userId: UserId): TeamId?
+    /**
+     * The tenant routing (team id + schema) for **this** team and this user, resolved from ONE row,
+     * or null when they have no active membership of it (ADR-0021 §1). The team id is an input, not a
+     * discovery: this asks "resolve this team for this user, and verify they may have it" — it never
+     * picks a team on the caller's behalf.
+     *
+     * Null is the *only* failure mode, and it covers both "no such team" and "not yours" — the caller
+     * cannot tell them apart, so the team id space cannot be probed.
+     */
+    fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting?
 
     /**
-     * The user's tenant routing (team id + schema) resolved from ONE row, or null if they have no
-     * active team. Lets the login path pin both onto the session together so authenticated requests
-     * read them back instead of racing to memoize them. Null-safe for a teamless user.
+     * The tenant routing of the user's **only** active membership, or null when they have none — or
+     * more than one. Deliberately not "their first team": with several memberships there is no
+     * defensible pick, so this answers null and the Active Team has to be chosen explicitly
+     * (ADR-0021 §3). This is what replaced the `ORDER BY team_id LIMIT 1` that used to choose by UUID.
      */
-    fun findTenantRouting(userId: UserId): TenantRouting?
+    fun findSoleTenantRouting(userId: UserId): TenantRouting?
 
     /** Joins the user to the team as a USER. No-op if already an active member of this team. */
     fun addMember(teamId: TeamId, userId: UserId)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -23,7 +23,7 @@ interface TeamMemberRepository {
 
     /**
      * The tenant routing (team id + schema) for **this** team and this user, resolved from ONE row,
-     * or null when they have no active membership of it (ADR-0021 §1). The team id is an input, not a
+     * or null when they have no active membership of it (ADR-0023 §1). The team id is an input, not a
      * discovery: this asks "resolve this team for this user, and verify they may have it" — it never
      * picks a team on the caller's behalf.
      *
@@ -36,7 +36,7 @@ interface TeamMemberRepository {
      * The tenant routing of the user's **only** active membership, or null when they have none — or
      * more than one. Deliberately not "their first team": with several memberships there is no
      * defensible pick, so this answers null and the Active Team has to be chosen explicitly
-     * (ADR-0021 §3). This is what replaced the `ORDER BY team_id LIMIT 1` that used to choose by UUID.
+     * (ADR-0023 §3). This is what replaced the `ORDER BY team_id LIMIT 1` that used to choose by UUID.
      */
     fun findSoleTenantRouting(userId: UserId): TenantRouting?
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -7,8 +7,8 @@ import java.util.UUID
 
 /**
  * Read-side access to platform-level teams. Slice 1 needed only the tenant schema names to keep every
- * team migrated at boot; create-team added the slug pre-check; #158 adds the per-user lookup that powers
- * `/auth/me`'s has-a-team gate signal.
+ * team migrated at boot; create-team added the slug pre-check; #158 added the per-user lookup that powers
+ * `/auth/me`; #143 turned that lookup into a *list*, because a user may be a Member of several Teams.
  */
 interface TeamRepository {
     /** Schema names of all teams — the source of truth for which tenant schemas must exist. */
@@ -21,6 +21,17 @@ interface TeamRepository {
      */
     fun existsBySlug(slug: Slug): Boolean
 
-    /** The team the user actively belongs to, or null if teamless (v1: one team per user). */
-    fun findByUserId(userId: UUID): TeamSummary?
+    /**
+     * Every team the user is an active Member of, by name, or empty when they belong to none. Ordered
+     * so a switcher listing them is stable between requests; the order carries no other meaning — in
+     * particular it is *not* a fallback for "which team is active" (ADR-0021 §1).
+     */
+    fun findTeamsOf(userId: UUID): List<TeamSummary>
+
+    /**
+     * The team addressed by [slug], regardless of who is asking — the slug is a Team's public address
+     * (ADR-0019 §2), so this says nothing about membership. Authorization is a separate step: resolving
+     * a slug here and failing the membership check must be indistinguishable from an unknown slug.
+     */
+    fun findBySlug(slug: Slug): TeamSummary?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -5,11 +5,7 @@ import com.github.zzave.teambalance.api.domain.model.Slug
 import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import java.util.UUID
 
-/**
- * Read-side access to platform-level teams. Slice 1 needed only the tenant schema names to keep every
- * team migrated at boot; create-team added the slug pre-check; #158 added the per-user lookup that powers
- * `/auth/me`; #143 turned that lookup into a *list*, because a user may be a Member of several Teams.
- */
+/** Read-side access to platform-level teams. */
 interface TeamRepository {
     /** Schema names of all teams — the source of truth for which tenant schemas must exist. */
     fun findAllSchemaNames(): List<SchemaName>
@@ -22,16 +18,11 @@ interface TeamRepository {
     fun existsBySlug(slug: Slug): Boolean
 
     /**
-     * Every team the user is an active Member of, by name, or empty when they belong to none. Ordered
-     * so a switcher listing them is stable between requests; the order carries no other meaning — in
-     * particular it is *not* a fallback for "which team is active" (ADR-0023 §1).
+     * Every team the user is an active Member of, in a stable display order. That order is not a
+     * fallback for "which team is active" (ADR-0023 §1).
      */
     fun findTeamsOf(userId: UUID): List<TeamSummary>
 
-    /**
-     * The team addressed by [slug], regardless of who is asking — the slug is a Team's public address
-     * (ADR-0019 §2), so this says nothing about membership. Authorization is a separate step: resolving
-     * a slug here and failing the membership check must be indistinguishable from an unknown slug.
-     */
+    /** The team at this slug, regardless of who is asking — membership is a separate check. */
     fun findBySlug(slug: Slug): TeamSummary?
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRepository.kt
@@ -24,7 +24,7 @@ interface TeamRepository {
     /**
      * Every team the user is an active Member of, by name, or empty when they belong to none. Ordered
      * so a switcher listing them is stable between requests; the order carries no other meaning — in
-     * particular it is *not* a fallback for "which team is active" (ADR-0021 §1).
+     * particular it is *not* a fallback for "which team is active" (ADR-0023 §1).
      */
     fun findTeamsOf(userId: UUID): List<TeamSummary>
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantRoutingGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantRoutingGateway.kt
@@ -17,13 +17,8 @@ interface TenantRoutingGateway {
     fun pinRouting(routing: TenantRouting)
 
     /**
-     * Drops any pinned routing, leaving the caller with **no** tenant rather than a stale one.
-     *
-     * Sign-in must call this before it pins, because pinning is conditional: a caller with no Team,
-     * or with several and none remembered, resolves to nothing and pins nothing. Signing in over a
-     * live session — a shared phone, a second magic link in the same browser — would otherwise leave
-     * the previous caller's `(schema, teamId)` pair sitting on the session for the new one to
-     * inherit. Clearing is the only operation that cannot be skipped.
+     * Drops any pinned routing, leaving no tenant rather than a stale one. Sign-in clears before it
+     * pins, because pinning is conditional and would otherwise inherit the previous caller's tenant.
      */
     fun clearRouting()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantRoutingGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TenantRoutingGateway.kt
@@ -15,4 +15,15 @@ interface TenantRoutingGateway {
      * back instead of several of them racing to memoize it (#205). Pinning it again is harmless.
      */
     fun pinRouting(routing: TenantRouting)
+
+    /**
+     * Drops any pinned routing, leaving the caller with **no** tenant rather than a stale one.
+     *
+     * Sign-in must call this before it pins, because pinning is conditional: a caller with no Team,
+     * or with several and none remembered, resolves to nothing and pins nothing. Signing in over a
+     * live session — a shared phone, a second magic link in the same browser — would otherwise leave
+     * the previous caller's `(schema, teamId)` pair sitting on the session for the new one to
+     * inherit. Clearing is the only operation that cannot be skipped.
+     */
+    fun clearRouting()
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 
@@ -8,4 +9,17 @@ interface UserRepository {
     fun findById(id: UserId): User?
     fun findByEmail(email: Email): User?
     fun save(user: User): User
+
+    /**
+     * The Team this user last had active, or null when nothing is remembered yet. It is a *hint*, not
+     * an authorization: the membership behind it may since have been revoked, so a reader must
+     * re-verify it before routing anything to that tenant (ADR-0021 §3).
+     */
+    fun findLastActiveTeamId(userId: UserId): TeamId?
+
+    /**
+     * Remembers [teamId] as the user's Active Team, so a later sign-in — on another device, weeks
+     * later — lands them back where they were. Written on every switch, link-induced ones included.
+     */
+    fun rememberActiveTeam(userId: UserId, teamId: TeamId)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
@@ -13,7 +13,7 @@ interface UserRepository {
     /**
      * The Team this user last had active, or null when nothing is remembered yet. It is a *hint*, not
      * an authorization: the membership behind it may since have been revoked, so a reader must
-     * re-verify it before routing anything to that tenant (ADR-0021 §3).
+     * re-verify it before routing anything to that tenant (ADR-0023 §3).
      */
     fun findLastActiveTeamId(userId: UserId): TeamId?
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/UserRepository.kt
@@ -10,16 +10,9 @@ interface UserRepository {
     fun findByEmail(email: Email): User?
     fun save(user: User): User
 
-    /**
-     * The Team this user last had active, or null when nothing is remembered yet. It is a *hint*, not
-     * an authorization: the membership behind it may since have been revoked, so a reader must
-     * re-verify it before routing anything to that tenant (ADR-0023 §3).
-     */
+    /** A hint, not an authorization: the membership behind it may since have been revoked. */
     fun findLastActiveTeamId(userId: UserId): TeamId?
 
-    /**
-     * Remembers [teamId] as the user's Active Team, so a later sign-in — on another device, weeks
-     * later — lands them back where they were. Written on every switch, link-induced ones included.
-     */
+    /** Written on every switch, link-induced ones included, so a later sign-in lands back here. */
     fun rememberActiveTeam(userId: UserId, teamId: TeamId)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
@@ -27,7 +27,7 @@ import java.time.Clock
  *
  * [ActiveTeamService] is declared here for the same reason: the Active Team is part of "who is
  * calling, and where", and every other area (team creation, invitations, the tenant filter) takes it
- * as a constructor parameter rather than building a resolution path of its own (ADR-0021 §1).
+ * as a constructor parameter rather than building a resolution path of its own (ADR-0023 §1).
  */
 @Configuration
 class AuthCompositionRoot {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
@@ -25,9 +25,8 @@ import java.time.Clock
  * [AuthorizationService] is the one service every other area depends on — the sibling roots take it
  * as a constructor parameter and Spring resolves it to the bean declared here.
  *
- * [ActiveTeamService] is declared here for the same reason: the Active Team is part of "who is
- * calling, and where", and every other area (team creation, invitations, the tenant filter) takes it
- * as a constructor parameter rather than building a resolution path of its own (ADR-0023 §1).
+ * [ActiveTeamService] is declared here for the same reason: every other area takes it as a
+ * constructor parameter rather than building a resolution path of its own (ADR-0023 §1).
  */
 @Configuration
 class AuthCompositionRoot {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/AuthCompositionRoot.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.infrastructure.config
 
+import com.github.zzave.teambalance.api.application.ActiveTeamService
 import com.github.zzave.teambalance.api.application.AuthService
 import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.domain.port.AuthSessionGateway
@@ -23,30 +24,45 @@ import java.time.Clock
  *
  * [AuthorizationService] is the one service every other area depends on — the sibling roots take it
  * as a constructor parameter and Spring resolves it to the bean declared here.
+ *
+ * [ActiveTeamService] is declared here for the same reason: the Active Team is part of "who is
+ * calling, and where", and every other area (team creation, invitations, the tenant filter) takes it
+ * as a constructor parameter rather than building a resolution path of its own (ADR-0021 §1).
  */
 @Configuration
 class AuthCompositionRoot {
 
     @Bean
+    fun activeTeamService(
+        teamMemberRepository: TeamMemberRepository,
+        teamRepository: TeamRepository,
+        userRepository: UserRepository,
+        tenantRoutingGateway: TenantRoutingGateway,
+    ) = ActiveTeamService(
+        teamMemberRepository = teamMemberRepository,
+        teamRepository = teamRepository,
+        userRepository = userRepository,
+        tenantRoutingGateway = tenantRoutingGateway,
+    )
+
+    @Bean
     fun authService(
         magicLinkTokenRepository: MagicLinkTokenRepository,
         userRepository: UserRepository,
-        teamRepository: TeamRepository,
         teamMemberRepository: TeamMemberRepository,
+        activeTeamService: ActiveTeamService,
         emailGateway: EmailGateway,
         platformAdminGateway: PlatformAdminGateway,
         authSessionGateway: AuthSessionGateway,
-        tenantRoutingGateway: TenantRoutingGateway,
         clock: Clock,
     ) = AuthService(
         magicLinkTokenRepository = magicLinkTokenRepository,
         userRepository = userRepository,
-        teamRepository = teamRepository,
         teamMemberRepository = teamMemberRepository,
+        activeTeamService = activeTeamService,
         emailGateway = emailGateway,
         platformAdminGateway = platformAdminGateway,
         authSessionGateway = authSessionGateway,
-        tenantRoutingGateway = tenantRoutingGateway,
         clock = clock,
     )
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InvitationCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/InvitationCompositionRoot.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.infrastructure.config
 
+import com.github.zzave.teambalance.api.application.ActiveTeamService
 import com.github.zzave.teambalance.api.application.AuthorizationService
 import com.github.zzave.teambalance.api.application.InvitationService
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
@@ -26,12 +27,14 @@ class InvitationCompositionRoot {
         invitationRepository: InvitationRepository,
         teamMemberRepository: TeamMemberRepository,
         authorizationService: AuthorizationService,
+        activeTeamService: ActiveTeamService,
         clock: Clock,
         @Value("\${teambalance.invitation.token-salt}") tokenSalt: String,
     ) = InvitationService(
         invitationRepository = invitationRepository,
         teamMemberRepository = teamMemberRepository,
         authorizationService = authorizationService,
+        activeTeamService = activeTeamService,
         clock = clock,
         tokenSalt = tokenSalt,
     )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
@@ -1,10 +1,10 @@
 package com.github.zzave.teambalance.api.infrastructure.config
 
+import com.github.zzave.teambalance.api.application.ActiveTeamService
 import com.github.zzave.teambalance.api.application.CreationCodeAdminService
 import com.github.zzave.teambalance.api.application.TeamService
 import com.github.zzave.teambalance.api.domain.port.PlatformAdminGateway
 import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.TeamNotificationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRegistrationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
@@ -25,22 +25,22 @@ class TeamCompositionRoot {
 
     @Bean
     fun teamService(
-        teamMemberRepository: TeamMemberRepository,
         teamRepository: TeamRepository,
         creationCodeRepository: TeamCreationCodeRepository,
         tenantProvisioningGateway: TenantProvisioningGateway,
         teamRegistrationGateway: TeamRegistrationGateway,
         userRepository: UserRepository,
         teamNotificationGateway: TeamNotificationGateway,
+        activeTeamService: ActiveTeamService,
         clock: Clock,
     ) = TeamService(
-        teamMemberRepository = teamMemberRepository,
         teamRepository = teamRepository,
         creationCodeRepository = creationCodeRepository,
         tenantProvisioningGateway = tenantProvisioningGateway,
         teamRegistrationGateway = teamRegistrationGateway,
         userRepository = userRepository,
         teamNotificationGateway = teamNotificationGateway,
+        activeTeamService = activeTeamService,
         clock = clock,
     )
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/e2e/E2eEnvironmentInitializer.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/e2e/E2eEnvironmentInitializer.kt
@@ -20,10 +20,8 @@ import javax.sql.DataSource
  * execute after context initialization — i.e. after [PlatformSchemaInitializer] has run the
  * platform Flyway migrations. Ordering: Flyway → provision → seed.
  *
- * There are **two** tenants, not one. The team-switching flow (#143) needs a caller to be a Member
- * of two Teams and needs each Team's data to be visibly different, which only a second real tenant
- * schema gives you — a second team row pointing at the same schema would show the same events and
- * prove nothing about routing.
+ * Two tenants, not one: the team-switching flow needs each Team's data to be visibly different, and
+ * a second team row on the same schema would show the same events and prove nothing about routing.
  *
  * Interim mechanism: once an admin API for team/tenant provisioning exists, the SQL fixture
  * is replaced by API calls in Playwright global-setup and this hook is absorbed into the

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/e2e/E2eEnvironmentInitializer.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/e2e/E2eEnvironmentInitializer.kt
@@ -14,11 +14,16 @@ import javax.sql.DataSource
 /**
  * E2e-profile-only bootstrap for full-stack Playwright runs.
  *
- * Provisions the `team_test` tenant schema through the real code path
+ * Provisions the tenant schemas through the real code path
  * ([TenantProvisioningGateway.provisionTenant]) and applies the pure-INSERT seed fixture
- * (known team + user + membership). Runs as an [ApplicationRunner] so it is guaranteed to
+ * (known teams + users + memberships). Runs as an [ApplicationRunner] so it is guaranteed to
  * execute after context initialization — i.e. after [PlatformSchemaInitializer] has run the
  * platform Flyway migrations. Ordering: Flyway → provision → seed.
+ *
+ * There are **two** tenants, not one. The team-switching flow (#143) needs a caller to be a Member
+ * of two Teams and needs each Team's data to be visibly different, which only a second real tenant
+ * schema gives you — a second team row pointing at the same schema would show the same events and
+ * prove nothing about routing.
  *
  * Interim mechanism: once an admin API for team/tenant provisioning exists, the SQL fixture
  * is replaced by API calls in Playwright global-setup and this hook is absorbed into the
@@ -33,8 +38,9 @@ class E2eEnvironmentInitializer(
     private val log = LoggerFactory.getLogger(E2eEnvironmentInitializer::class.java)
 
     override fun run(args: ApplicationArguments) {
-        log.info("Provisioning e2e tenant schema 'team_test' and applying seed fixture")
+        log.info("Provisioning e2e tenant schemas 'team_test' + 'team_test_two' and applying seed fixture")
         tenantProvisioningGateway.provisionTenant(SchemaName("team_test"))
+        tenantProvisioningGateway.provisionTenant(SchemaName("team_test_two"))
         ResourceDatabasePopulator(ClassPathResource("db/e2e/seed.sql")).execute(dataSource)
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/CurrentTeamContextAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/CurrentTeamContextAdapter.kt
@@ -7,9 +7,9 @@ import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import org.springframework.stereotype.Component
 
 /**
- * Reads the team resolved for this request by [SessionTenantContextFilter] (the same row that pinned
- * the tenant schema), rather than re-querying — so the authorized team id and the write schema always
- * agree, with no second round-trip. Lives next to [CurrentTeamContext] because that request-scoped
+ * Reads the Active Team for this request, resolved by [SessionTenantContextFilter] (the same row that
+ * pinned the tenant schema), rather than re-querying — so the authorized team id and the write schema
+ * always agree, with no second round-trip. Lives next to [CurrentTeamContext] because that request-scoped
  * holder is the thing it adapts; the failing user id comes from the [CurrentUserGateway] port so this
  * adapter never reaches into the identity adapters.
  */
@@ -18,5 +18,7 @@ class CurrentTeamContextAdapter(
     private val currentUser: CurrentUserGateway,
 ) : CurrentTeamGateway {
     override fun requireCurrentTeamId(): TeamId =
-        CurrentTeamContext.get()?.let(::TeamId) ?: throw NoTeamMembershipException(currentUser.requireCurrentUserId())
+        findCurrentTeamId() ?: throw NoTeamMembershipException(currentUser.requireCurrentUserId())
+
+    override fun findCurrentTeamId(): TeamId? = CurrentTeamContext.get()?.let(::TeamId)
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -26,11 +26,6 @@ class SessionTenantContextFilter(
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        // SessionUserContextFilter (order +2) already resolved and parsed the session user —
-        // read it back through the gateway rather than re-parsing the session, to avoid duplicating
-        // that logic. Schema and team id are resolved together (one row) so they can never diverge; a
-        // caller with no Active Team resolves to nothing (no silent "public" fallback for
-        // tenant-scoped work).
         currentUserGateway.getCurrentUserId()?.let { userId ->
             resolveRouting(request, userId)?.let { routing ->
                 // Respect a tenant already pinned upstream (the test-profile X-Team-Id shim).
@@ -47,36 +42,16 @@ class SessionTenantContextFilter(
     }
 
     /**
-     * The Active Team is carried on the session, so read the memo first: schema + team id are memoized
-     * *together* and later requests read the cached pair, avoiding a `team_members JOIN teams`
-     * round-trip on every authenticated call. Both are cached as a unit so a cached schema can never be
-     * paired with a freshly-queried team id.
+     * Schema and team id are memoized on the session as a pair, so a cached schema can never be
+     * paired with a freshly-queried team id. Since ADR-0023 §2 that memo decides which Team the
+     * request is scoped to, so [ActiveTeamService] overwrites it on every switch; a missed overwrite
+     * is a cross-tenant read, not a slow request.
      *
-     * Since #143 that memo is a **correctness** concern, not a cache (ADR-0023 §2): it is what says
-     * which Team the request is scoped to, so every switch must overwrite it — [ActiveTeamService]
-     * owns that, by re-pinning through [TenantRoutingGatewayAdapter] on the way through. A missed
-     * overwrite here is a cross-tenant read, not a slow request.
+     * A hit is not re-verified against `team_members`, so a Member removed mid-session keeps tenant
+     * reads until their session ends. Per-action authorization still runs every request.
      *
-     * On a miss — a session predating the pin, or a caller who was teamless when they signed in and
-     * has since joined — fall back to the same landing resolution sign-in uses: the remembered Active
-     * Team while it is still a valid membership, else a sole membership, else nothing. It never picks
-     * between several Teams; a caller with several and none remembered simply has no tenant here and
-     * is asked to choose.
-     *
-     * A memo hit is NOT re-verified against `team_members` — that is what makes it a memo rather than
-     * a query. The membership was verified when it was written (at sign-in, or by the switch that
-     * pinned it), so a caller removed from a Team mid-session keeps tenant access until their session
-     * ends, which under a four-week sliding window (ADR-0015) is a long time. That is unchanged by
-     * #143 and out of its scope; removing a Member is not yet a session-invalidating event anywhere.
-     * Authorization for individual actions still runs per request through
-     * [AuthorizationService][com.github.zzave.teambalance.api.application.AuthorizationService], so
-     * what a removed Member retains is reads, not admin rights.
-     *
-     * The memo's attribute names and formats live in [TenantRoutingSession], shared with
-     * [TenantRoutingGatewayAdapter], which pins the same memo at sign-in and on every switch. This
-     * filter reads the session off the request it is handed rather than through that adapter's port:
-     * it runs at `HIGHEST_PRECEDENCE + 3`, long before Spring binds the request-scoped proxy the
-     * adapter needs.
+     * The session is read off the request rather than through [TenantRoutingGatewayAdapter]'s port
+     * because this filter runs long before Spring binds the request-scoped proxy that adapter needs.
      */
     private fun resolveRouting(request: HttpServletRequest, userId: UserId): TenantRouting? {
         val session = request.getSession(false)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -63,6 +63,15 @@ class SessionTenantContextFilter(
      * between several Teams; a caller with several and none remembered simply has no tenant here and
      * is asked to choose.
      *
+     * A memo hit is NOT re-verified against `team_members` — that is what makes it a memo rather than
+     * a query. The membership was verified when it was written (at sign-in, or by the switch that
+     * pinned it), so a caller removed from a Team mid-session keeps tenant access until their session
+     * ends, which under a four-week sliding window (ADR-0015) is a long time. That is unchanged by
+     * #143 and out of its scope; removing a Member is not yet a session-invalidating event anywhere.
+     * Authorization for individual actions still runs per request through
+     * [AuthorizationService][com.github.zzave.teambalance.api.application.AuthorizationService], so
+     * what a removed Member retains is reads, not admin rights.
+     *
      * The memo's attribute names and formats live in [TenantRoutingSession], shared with
      * [TenantRoutingGatewayAdapter], which pins the same memo at sign-in and on every switch. This
      * filter reads the session off the request it is handed rather than through that adapter's port:

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -52,7 +52,7 @@ class SessionTenantContextFilter(
      * round-trip on every authenticated call. Both are cached as a unit so a cached schema can never be
      * paired with a freshly-queried team id.
      *
-     * Since #143 that memo is a **correctness** concern, not a cache (ADR-0021 §2): it is what says
+     * Since #143 that memo is a **correctness** concern, not a cache (ADR-0023 §2): it is what says
      * which Team the request is scoped to, so every switch must overwrite it — [ActiveTeamService]
      * owns that, by re-pinning through [TenantRoutingGatewayAdapter] on the way through. A missed
      * overwrite here is a cross-tenant read, not a slow request.

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilter.kt
@@ -1,9 +1,9 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
+import com.github.zzave.teambalance.api.application.ActiveTeamService
 import com.github.zzave.teambalance.api.domain.model.TenantRouting
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -17,7 +17,7 @@ private const val FILTER_ORDER = Ordered.HIGHEST_PRECEDENCE + 3
 @Component
 @Order(FILTER_ORDER)
 class SessionTenantContextFilter(
-    private val teamMemberRepository: TeamMemberRepository,
+    private val activeTeamService: ActiveTeamService,
     private val currentUserGateway: CurrentUserGateway,
 ) : OncePerRequestFilter() {
 
@@ -28,8 +28,9 @@ class SessionTenantContextFilter(
     ) {
         // SessionUserContextFilter (order +2) already resolved and parsed the session user —
         // read it back through the gateway rather than re-parsing the session, to avoid duplicating
-        // that logic. Resolve schema and team id together (one row) so they can never diverge; a user
-        // with no team resolves to nothing (no silent "public" fallback for tenant-scoped work).
+        // that logic. Schema and team id are resolved together (one row) so they can never diverge; a
+        // caller with no Active Team resolves to nothing (no silent "public" fallback for
+        // tenant-scoped work).
         currentUserGateway.getCurrentUserId()?.let { userId ->
             resolveRouting(request, userId)?.let { routing ->
                 // Respect a tenant already pinned upstream (the test-profile X-Team-Id shim).
@@ -46,22 +47,31 @@ class SessionTenantContextFilter(
     }
 
     /**
-     * The tenant routing is immutable per session in v1 (one team per user, fixed for the session),
-     * so resolve it from the DB once and memoize schema + team id *together* on the session; later
-     * requests read the cached pair, avoiding a `team_members JOIN teams` round-trip on every
-     * authenticated call. Both are cached as a unit so a cached schema can never be paired with a
-     * freshly-queried team id — the single-row guarantee holds across the cache too. On a miss
-     * (first request, or a session surviving a restart) fall back to the DB. Multi-team support
-     * (post-v1) will invalidate these attributes on team-switch.
+     * The Active Team is carried on the session, so read the memo first: schema + team id are memoized
+     * *together* and later requests read the cached pair, avoiding a `team_members JOIN teams`
+     * round-trip on every authenticated call. Both are cached as a unit so a cached schema can never be
+     * paired with a freshly-queried team id.
+     *
+     * Since #143 that memo is a **correctness** concern, not a cache (ADR-0021 §2): it is what says
+     * which Team the request is scoped to, so every switch must overwrite it — [ActiveTeamService]
+     * owns that, by re-pinning through [TenantRoutingGatewayAdapter] on the way through. A missed
+     * overwrite here is a cross-tenant read, not a slow request.
+     *
+     * On a miss — a session predating the pin, or a caller who was teamless when they signed in and
+     * has since joined — fall back to the same landing resolution sign-in uses: the remembered Active
+     * Team while it is still a valid membership, else a sole membership, else nothing. It never picks
+     * between several Teams; a caller with several and none remembered simply has no tenant here and
+     * is asked to choose.
      *
      * The memo's attribute names and formats live in [TenantRoutingSession], shared with
-     * [TenantRoutingGatewayAdapter], which pins the same memo at sign-in. This filter reads the
-     * session off the request it is handed rather than through that adapter's port: it runs at
-     * `HIGHEST_PRECEDENCE + 3`, long before Spring binds the request-scoped proxy the adapter needs.
+     * [TenantRoutingGatewayAdapter], which pins the same memo at sign-in and on every switch. This
+     * filter reads the session off the request it is handed rather than through that adapter's port:
+     * it runs at `HIGHEST_PRECEDENCE + 3`, long before Spring binds the request-scoped proxy the
+     * adapter needs.
      */
     private fun resolveRouting(request: HttpServletRequest, userId: UserId): TenantRouting? {
         val session = request.getSession(false)
         TenantRoutingSession.read(session)?.let { return it }
-        return teamMemberRepository.findTenantRouting(userId)?.also { TenantRoutingSession.write(session, it) }
+        return activeTeamService.resolveLanding(userId)?.also { TenantRoutingSession.write(session, it) }
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingGatewayAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingGatewayAdapter.kt
@@ -22,7 +22,5 @@ class TenantRoutingGatewayAdapter(
 
     override fun pinRouting(routing: TenantRouting) = TenantRoutingSession.write(request.session, routing)
 
-    // getSession(false): nothing to clear when there is no session, and creating one to empty it
-    // would be absurd.
     override fun clearRouting() = TenantRoutingSession.clear(request.getSession(false))
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingGatewayAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingGatewayAdapter.kt
@@ -21,4 +21,8 @@ class TenantRoutingGatewayAdapter(
 ) : TenantRoutingGateway {
 
     override fun pinRouting(routing: TenantRouting) = TenantRoutingSession.write(request.session, routing)
+
+    // getSession(false): nothing to clear when there is no session, and creating one to empty it
+    // would be absurd.
+    override fun clearRouting() = TenantRoutingSession.clear(request.getSession(false))
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingSession.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingSession.kt
@@ -37,7 +37,7 @@ internal object TenantRoutingSession {
         session?.setAttribute(TENANT_TEAM_ID, routing.teamId.value.toString())
     }
 
-    /** Removes both attributes together, so a half-cleared pair can never be read back as a hit. */
+    /** Both together, so a half-cleared pair can never be read back as a hit. */
     fun clear(session: HttpSession?) {
         session?.removeAttribute(TENANT_SCHEMA)
         session?.removeAttribute(TENANT_TEAM_ID)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingSession.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/TenantRoutingSession.kt
@@ -36,4 +36,10 @@ internal object TenantRoutingSession {
         session?.setAttribute(TENANT_SCHEMA, routing.schemaName.value)
         session?.setAttribute(TENANT_TEAM_ID, routing.teamId.value.toString())
     }
+
+    /** Removes both attributes together, so a half-cleared pair can never be read back as a hit. */
+    fun clear(session: HttpSession?) {
+        session?.removeAttribute(TENANT_SCHEMA)
+        session?.removeAttribute(TENANT_TEAM_ID)
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -34,14 +34,8 @@ class JdbcTeamRepositoryAdapter(
             slug.value,
         ) ?: false
 
-    // Ordered by name, not by id: this list is read by humans in the Team switcher. It is a
-    // presentation order and nothing else — resolving which Team is *active* never falls back to it
-    // (ADR-0023 §1). The `ORDER BY tm.team_id LIMIT 1` this replaced did exactly that, picking a Team
-    // by UUID and silently hiding the user's others.
-    //
-    // `t.id` breaks ties because team names are deliberately NOT unique (ADR-0019 §2 — the slug is
-    // the unique address, the name is free text), so two Teams called "Heren 3" would otherwise swap
-    // places between requests.
+    // A presentation order for the switcher, nothing more. `t.id` breaks ties because team names are
+    // deliberately not unique (ADR-0019 §2), so two Teams called "Heren 3" would otherwise reshuffle.
     override fun findTeamsOf(userId: UUID): List<TeamSummary> =
         jdbcTemplate.query(
             "SELECT t.id, t.name, t.slug FROM public.teams t " +

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -36,7 +36,7 @@ class JdbcTeamRepositoryAdapter(
 
     // Ordered by name, not by id: this list is read by humans in the Team switcher. It is a
     // presentation order and nothing else — resolving which Team is *active* never falls back to it
-    // (ADR-0021 §1). The `ORDER BY tm.team_id LIMIT 1` this replaced did exactly that, picking a Team
+    // (ADR-0023 §1). The `ORDER BY tm.team_id LIMIT 1` this replaced did exactly that, picking a Team
     // by UUID and silently hiding the user's others.
     //
     // `t.id` breaks ties because team names are deliberately NOT unique (ADR-0019 §2 — the slug is

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -38,11 +38,15 @@ class JdbcTeamRepositoryAdapter(
     // presentation order and nothing else — resolving which Team is *active* never falls back to it
     // (ADR-0021 §1). The `ORDER BY tm.team_id LIMIT 1` this replaced did exactly that, picking a Team
     // by UUID and silently hiding the user's others.
+    //
+    // `t.id` breaks ties because team names are deliberately NOT unique (ADR-0019 §2 — the slug is
+    // the unique address, the name is free text), so two Teams called "Heren 3" would otherwise swap
+    // places between requests.
     override fun findTeamsOf(userId: UUID): List<TeamSummary> =
         jdbcTemplate.query(
             "SELECT t.id, t.name, t.slug FROM public.teams t " +
                 "JOIN public.team_members tm ON tm.team_id = t.id " +
-                "WHERE tm.user_id = ? AND tm.active = true ORDER BY t.name",
+                "WHERE tm.user_id = ? AND tm.active = true ORDER BY t.name, t.id",
             teamSummaryRow,
             userId,
         )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapter.kt
@@ -7,6 +7,7 @@ import com.github.zzave.teambalance.api.domain.model.TeamName
 import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -33,18 +34,31 @@ class JdbcTeamRepositoryAdapter(
             slug.value,
         ) ?: false
 
-    override fun findByUserId(userId: UUID): TeamSummary? =
+    // Ordered by name, not by id: this list is read by humans in the Team switcher. It is a
+    // presentation order and nothing else — resolving which Team is *active* never falls back to it
+    // (ADR-0021 §1). The `ORDER BY tm.team_id LIMIT 1` this replaced did exactly that, picking a Team
+    // by UUID and silently hiding the user's others.
+    override fun findTeamsOf(userId: UUID): List<TeamSummary> =
         jdbcTemplate.query(
             "SELECT t.id, t.name, t.slug FROM public.teams t " +
                 "JOIN public.team_members tm ON tm.team_id = t.id " +
-                "WHERE tm.user_id = ? AND tm.active = true ORDER BY tm.team_id LIMIT 1",
-            { rs, _ ->
-                TeamSummary(
-                    id = TeamId(rs.getObject("id", UUID::class.java)),
-                    name = TeamName(rs.getString("name")),
-                    slug = Slug(rs.getString("slug")),
-                )
-            },
+                "WHERE tm.user_id = ? AND tm.active = true ORDER BY t.name",
+            teamSummaryRow,
             userId,
+        )
+
+    override fun findBySlug(slug: Slug): TeamSummary? =
+        jdbcTemplate.query(
+            "SELECT t.id, t.name, t.slug FROM public.teams t WHERE t.slug = ?",
+            teamSummaryRow,
+            slug.value,
         ).firstOrNull()
+
+    private val teamSummaryRow = RowMapper { rs, _ ->
+        TeamSummary(
+            id = TeamId(rs.getObject("id", UUID::class.java)),
+            name = TeamName(rs.getString("name")),
+            slug = Slug(rs.getString("slug")),
+        )
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -110,16 +110,19 @@ class JpaTeamMemberRepositoryAdapter(
     @Transactional
     override fun addMember(teamId: TeamId, userId: UserId) {
         if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId.value, userId.value) != null) return
+        // A previously-removed member has a row with active = false, and (team_id, user_id) is
+        // UNIQUE — so an insert cannot re-join them. Flipping the existing row is what "join this
+        // team" means for them; without it the accept answered 200 while leaving them out of the
+        // team, and (since #143) failed to switch them into it as well.
+        if (jpaRepository.reactivateAsUser(teamId.value, userId.value) > 0) return
         try {
             jpaRepository.save(
                 TeamMemberJpaEntity(teamId = teamId.value, userId = userId.value, role = Role.USER.name),
             )
         } catch (e: DataIntegrityViolationException) {
-            // Concurrent accept or inactive-member row conflict — already a member, no-op
-            logger.info(
-                "Failed to add member to team because of a conflic. " +
-                        "This signals that the user is already a member, no biggy", e
-            )
+            // Lost a race with a concurrent accept — the other one made them a member, which is the
+            // outcome this call wanted anyway.
+            logger.info("Concurrent accept for team {} / user {} — already a member", teamId, userId, e)
         }
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -57,12 +57,16 @@ class JpaTeamMemberRepositoryAdapter(
             ?.role
             ?.let { role -> Role.entries.firstOrNull { it.name == role } }
 
-    override fun findTeamId(userId: UserId): TeamId? =
-        jpaRepository.findTeamIdByUserId(userId.value)?.let(::TeamId)
+    override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? =
+        jpaRepository.findTeamRouting(teamId.value, userId.value)?.toDomain()
 
-    override fun findTenantRouting(userId: UserId): TenantRouting? =
-        jpaRepository.findTeamRoutingByUserId(userId.value)
-            ?.let { TenantRouting(teamId = TeamId(it.teamId), schemaName = SchemaName(it.schemaName)) }
+    // Null on 0 rows AND on 2: "several teams" is not a routing, it is a question for the user. The
+    // query caps at 2 rows precisely so this can tell those apart without reading the whole list.
+    override fun findSoleTenantRouting(userId: UserId): TenantRouting? =
+        jpaRepository.findTeamRoutings(userId.value).singleOrNull()?.toDomain()
+
+    private fun TeamRoutingProjection.toDomain() =
+        TenantRouting(teamId = TeamId(teamId), schemaName = SchemaName(schemaName))
 
     @Transactional
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -60,8 +60,7 @@ class JpaTeamMemberRepositoryAdapter(
     override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? =
         jpaRepository.findTeamRouting(teamId.value, userId.value)?.toDomain()
 
-    // Null on 0 rows AND on 2: "several teams" is not a routing, it is a question for the user. The
-    // query caps at 2 rows precisely so this can tell those apart without reading the whole list.
+    // Null on 0 rows AND on 2: "several teams" is not a routing, it is a question for the user.
     override fun findSoleTenantRouting(userId: UserId): TenantRouting? =
         jpaRepository.findTeamRoutings(userId.value).singleOrNull()?.toDomain()
 
@@ -110,10 +109,7 @@ class JpaTeamMemberRepositoryAdapter(
     @Transactional
     override fun addMember(teamId: TeamId, userId: UserId) {
         if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId.value, userId.value) != null) return
-        // A previously-removed member has a row with active = false, and (team_id, user_id) is
-        // UNIQUE — so an insert cannot re-join them. Flipping the existing row is what "join this
-        // team" means for them; without it the accept answered 200 while leaving them out of the
-        // team, and (since #143) failed to switch them into it as well.
+        // (team_id, user_id) is UNIQUE, so an insert cannot re-join a member whose row is inactive.
         if (jpaRepository.reactivateAsUser(teamId.value, userId.value) > 0) return
         try {
             jpaRepository.save(

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaUserRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaUserRepositoryAdapter.kt
@@ -1,12 +1,14 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 class JpaUserRepositoryAdapter(
@@ -21,4 +23,15 @@ class JpaUserRepositoryAdapter(
 
     override fun save(user: User): User =
         jpaRepository.save(user.externalize()).internalize()
+
+    // Read and written as a bare column rather than through UserJpaEntity: the Active Team memory is
+    // routing state, not part of the User aggregate the rest of the app maps, and keeping it off the
+    // entity stops a stale in-memory User from overwriting a switch made on another device.
+    override fun findLastActiveTeamId(userId: UserId): TeamId? =
+        jpaRepository.findLastActiveTeamId(userId.value)?.let(::TeamId)
+
+    @Transactional
+    override fun rememberActiveTeam(userId: UserId, teamId: TeamId) {
+        jpaRepository.updateLastActiveTeamId(userId.value, teamId.value)
+    }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaUserRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaUserRepositoryAdapter.kt
@@ -24,9 +24,8 @@ class JpaUserRepositoryAdapter(
     override fun save(user: User): User =
         jpaRepository.save(user.externalize()).internalize()
 
-    // Read and written as a bare column rather than through UserJpaEntity: the Active Team memory is
-    // routing state, not part of the User aggregate the rest of the app maps, and keeping it off the
-    // entity stops a stale in-memory User from overwriting a switch made on another device.
+    // A bare column rather than a UserJpaEntity field: keeping it off the entity stops a stale
+    // in-memory User from overwriting a switch made on another device.
     override fun findLastActiveTeamId(userId: UserId): TeamId? =
         jpaRepository.findLastActiveTeamId(userId.value)?.let(::TeamId)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -61,6 +61,18 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun deactivate(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): Int
 
+    // Re-joining after removal. The role is reset to USER rather than restored: `addMember` joins as
+    // a USER by contract, and a removed admin walking back in through a shared invite link must not
+    // arrive holding their old admin rights. Returns the rows affected, so the caller can tell a real
+    // re-join from "there was no such row".
+    @Modifying
+    @Query(
+        "UPDATE public.team_members SET active = true, role = 'USER' " +
+            "WHERE team_id = :teamId AND user_id = :userId AND active = false",
+        nativeQuery = true,
+    )
+    fun reactivateAsUser(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): Int
+
     @Query(
         "SELECT COUNT(*) FROM public.team_members " +
             "WHERE team_id = :teamId AND role = 'ADMIN' AND active = true",

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -61,10 +61,8 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun deactivate(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): Int
 
-    // Re-joining after removal. The role is reset to USER rather than restored: `addMember` joins as
-    // a USER by contract, and a removed admin walking back in through a shared invite link must not
-    // arrive holding their old admin rights. Returns the rows affected, so the caller can tell a real
-    // re-join from "there was no such row".
+    // Re-joining after removal. The role resets to USER: a removed admin walking back in through a
+    // shared invite link must not arrive holding their old rights.
     @Modifying
     @Query(
         "UPDATE public.team_members SET active = true, role = 'USER' " +
@@ -119,11 +117,8 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun findMemberSummariesByTeamId(@Param("teamId") teamId: UUID): List<MemberSummaryProjection>
 
-    // Resolves the tenant routing (team id + schema) for ONE named team of a user, so the request's
-    // write schema and its authorized team id come from the same row and cannot diverge. The team id
-    // is a parameter, not a discovery: the `tm.user_id = :userId AND tm.active` predicate IS the
-    // membership check, so a team the caller may not have returns no row — the same answer an unknown
-    // team id gets (ADR-0023 §1).
+    // The write schema and the authorized team id come from the same row, so they cannot diverge.
+    // The `user_id AND active` predicate IS the membership check.
     @Query(
         value = """
             SELECT tm.team_id     AS teamId,
@@ -138,10 +133,8 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun findTeamRouting(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): TeamRoutingProjection?
 
-    // The routing of a user's ONLY active membership. `LIMIT 2` is the point: two rows come back when
-    // there is no sole team, and the adapter answers null rather than picking one. This is what the
-    // deleted `ORDER BY tm.team_id LIMIT 1` used to do wrong — it ordered by UUID, so with two
-    // memberships it chose arbitrarily, and TenantRoutingSession then made that choice sticky.
+    // LIMIT 2 is the point: a second row means there is no sole team, and the adapter answers null
+    // rather than picking one.
     @Query(
         value = """
             SELECT tm.team_id     AS teamId,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -107,9 +107,29 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun findMemberSummariesByTeamId(@Param("teamId") teamId: UUID): List<MemberSummaryProjection>
 
-    // Resolves the tenant routing (team id + schema) for a user in ONE query, so the request's write
-    // schema and its authorized team id come from the same row and cannot diverge. v1 assumes one team
-    // per user; the deterministic ORDER BY makes the single picked row stable if that is ever violated.
+    // Resolves the tenant routing (team id + schema) for ONE named team of a user, so the request's
+    // write schema and its authorized team id come from the same row and cannot diverge. The team id
+    // is a parameter, not a discovery: the `tm.user_id = :userId AND tm.active` predicate IS the
+    // membership check, so a team the caller may not have returns no row — the same answer an unknown
+    // team id gets (ADR-0021 §1).
+    @Query(
+        value = """
+            SELECT tm.team_id     AS teamId,
+                   t.schema_name  AS schemaName
+            FROM   public.team_members tm
+            JOIN   public.teams t ON t.id = tm.team_id
+            WHERE  tm.user_id = :userId
+            AND    tm.team_id = :teamId
+            AND    tm.active = true
+        """,
+        nativeQuery = true,
+    )
+    fun findTeamRouting(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): TeamRoutingProjection?
+
+    // The routing of a user's ONLY active membership. `LIMIT 2` is the point: two rows come back when
+    // there is no sole team, and the adapter answers null rather than picking one. This is what the
+    // deleted `ORDER BY tm.team_id LIMIT 1` used to do wrong — it ordered by UUID, so with two
+    // memberships it chose arbitrarily, and TenantRoutingSession then made that choice sticky.
     @Query(
         value = """
             SELECT tm.team_id     AS teamId,
@@ -118,26 +138,11 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
             JOIN   public.teams t ON t.id = tm.team_id
             WHERE  tm.user_id = :userId
             AND    tm.active = true
-            ORDER  BY tm.team_id
-            LIMIT  1
+            LIMIT  2
         """,
         nativeQuery = true,
     )
-    fun findTeamRoutingByUserId(@Param("userId") userId: UUID): TeamRoutingProjection?
-
-    // v1 assumes one team per user; the deterministic ORDER BY makes the single picked row stable.
-    @Query(
-        value = """
-            SELECT tm.team_id
-            FROM   public.team_members tm
-            WHERE  tm.user_id = :userId
-            AND    tm.active = true
-            ORDER  BY tm.team_id
-            LIMIT  1
-        """,
-        nativeQuery = true,
-    )
-    fun findTeamIdByUserId(@Param("userId") userId: UUID): UUID?
+    fun findTeamRoutings(@Param("userId") userId: UUID): List<TeamRoutingProjection>
 }
 
 interface MemberSummaryProjection {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -123,7 +123,7 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     // write schema and its authorized team id come from the same row and cannot diverge. The team id
     // is a parameter, not a discovery: the `tm.user_id = :userId AND tm.active` predicate IS the
     // membership check, so a team the caller may not have returns no row — the same answer an unknown
-    // team id gets (ADR-0021 §1).
+    // team id gets (ADR-0023 §1).
     @Query(
         value = """
             SELECT tm.team_id     AS teamId,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataUserRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataUserRepository.kt
@@ -13,4 +13,11 @@ interface SpringDataUserRepository : JpaRepository<UserJpaEntity, UUID> {
     @Modifying
     @Query("UPDATE public.users SET display_name = :displayName WHERE id = :id", nativeQuery = true)
     fun updateDisplayName(@Param("id") id: UUID, @Param("displayName") displayName: String): Int
+
+    @Query("SELECT u.last_active_team_id FROM public.users u WHERE u.id = :id", nativeQuery = true)
+    fun findLastActiveTeamId(@Param("id") id: UUID): UUID?
+
+    @Modifying
+    @Query("UPDATE public.users SET last_active_team_id = :teamId WHERE id = :id", nativeQuery = true)
+    fun updateLastActiveTeamId(@Param("id") id: UUID, @Param("teamId") teamId: UUID): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
@@ -32,9 +32,7 @@ class AuthController(
 
     override suspend fun verifyMagicLink(request: VerifyMagicLink.Request): VerifyMagicLink.Response<*> {
         val user = authService.verifyMagicLink(request.body.token) ?: return VerifyMagicLink.Response401(Unit)
-        // Sign-in resolves and pins the Active Team, and hands it back here. The Active Team of *this*
-        // request cannot be read from the request context instead: SessionTenantContextFilter ran
-        // before the session existed, so the context is empty on the very request that creates it.
+        // Not readable from the request context: the tenant filter ran before this session existed.
         val activeTeamId = authService.startSession(user.id)
         return VerifyMagicLink.Response200(describe(user, activeTeamId))
     }
@@ -50,13 +48,8 @@ class AuthController(
             ?: GetAuthMe.Response401(Unit)
 
     /**
-     * The authenticated-user payload: who is calling, every Team they are a Member of, and which one
-     * this request is scoped to (#143, ADR-0023 §4).
-     *
      * [activeTeamId] is intersected with the memberships rather than reported as given, so the payload
-     * can only ever name a Team the caller actually has — a Team id resolved anywhere else cannot leak
-     * a name and a slug through here. `role` is read for that same intersected Team, which is what
-     * makes it "your Role *here*" rather than a property of the user.
+     * can only ever name a Team the caller actually has. `role` is read for that same Team.
      */
     private fun describe(user: User, activeTeamId: TeamId?): AuthenticatedUser {
         val teams = authService.findTeamsFor(user.id)
@@ -73,9 +66,7 @@ class AuthController(
     }
 }
 
-// The Wirespec edge for a Team's public identity — id, name and the slug its URLs are addressed by.
-// The tenant schema is deliberately absent (ADR-0023 §2). internal so the switch endpoint hands back
-// the same shape /auth/me does.
+// The Wirespec edge for a Team's public identity; the tenant schema is deliberately absent.
 internal fun TeamSummary.produce() = TeamRef(id = id.produce(), name = name.value, slug = slug.value)
 
 // The Wirespec edge for a user's identity — the contract, and the session attribute the auth filter

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
@@ -51,7 +51,7 @@ class AuthController(
 
     /**
      * The authenticated-user payload: who is calling, every Team they are a Member of, and which one
-     * this request is scoped to (#143, ADR-0021 §4).
+     * this request is scoped to (#143, ADR-0023 §4).
      *
      * [activeTeamId] is intersected with the memberships rather than reported as given, so the payload
      * can only ever name a Team the caller actually has — a Team id resolved anywhere else cannot leak
@@ -74,7 +74,7 @@ class AuthController(
 }
 
 // The Wirespec edge for a Team's public identity — id, name and the slug its URLs are addressed by.
-// The tenant schema is deliberately absent (ADR-0021 §2). internal so the switch endpoint hands back
+// The tenant schema is deliberately absent (ADR-0023 §2). internal so the switch endpoint hands back
 // the same shape /auth/me does.
 internal fun TeamSummary.produce() = TeamRef(id = id.produce(), name = name.value, slug = slug.value)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AuthController.kt
@@ -2,7 +2,11 @@ package com.github.zzave.teambalance.api.interfaces
 
 import com.github.zzave.teambalance.api.application.AuthService
 import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
+import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetAuthMe
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.Logout
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RequestMagicLink
@@ -15,6 +19,7 @@ import java.util.UUID
 @RestController
 class AuthController(
     private val authService: AuthService,
+    private val currentTeamGateway: CurrentTeamGateway,
 ) : RequestMagicLink.Handler,
     VerifyMagicLink.Handler,
     Logout.Handler,
@@ -27,17 +32,11 @@ class AuthController(
 
     override suspend fun verifyMagicLink(request: VerifyMagicLink.Request): VerifyMagicLink.Response<*> {
         val user = authService.verifyMagicLink(request.body.token) ?: return VerifyMagicLink.Response401(Unit)
-        authService.startSession(user.id)
-        return VerifyMagicLink.Response200(
-            AuthenticatedUser(
-                id = user.id.produce(),
-                email = user.email.produce(),
-                displayName = user.displayName.value,
-                role = resolveRole(user.id),
-                team = resolveTeam(user.id),
-                isPlatformAdmin = authService.isPlatformAdmin(user.id),
-            ),
-        )
+        // Sign-in resolves and pins the Active Team, and hands it back here. The Active Team of *this*
+        // request cannot be read from the request context instead: SessionTenantContextFilter ran
+        // before the session existed, so the context is empty on the very request that creates it.
+        val activeTeamId = authService.startSession(user.id)
+        return VerifyMagicLink.Response200(describe(user, activeTeamId))
     }
 
     override suspend fun logout(request: Logout.Request): Logout.Response<*> {
@@ -46,28 +45,38 @@ class AuthController(
     }
 
     override suspend fun getAuthMe(request: GetAuthMe.Request): GetAuthMe.Response<*> =
-        authService.currentUser()?.let {
-            GetAuthMe.Response200(
-                AuthenticatedUser(
-                    id = it.id.produce(),
-                    email = it.email.produce(),
-                    displayName = it.displayName.value,
-                    role = resolveRole(it.id),
-                    team = resolveTeam(it.id),
-                    isPlatformAdmin = authService.isPlatformAdmin(it.id),
-                ),
-            )
-        } ?: GetAuthMe.Response401(Unit)
+        authService.currentUser()
+            ?.let { GetAuthMe.Response200(describe(it, currentTeamGateway.findCurrentTeamId())) }
+            ?: GetAuthMe.Response401(Unit)
 
-    private fun resolveRole(userId: UserId): String? = authService.findRoleFor(userId)?.name
-
-    // The has-a-team gate signal (#158): a null team means the caller is teamless and belongs on
-    // /create-team. Resolved through the application service so this inbound layer keeps no port
-    // dependency of its own (ADR-0018). v1: one team per user.
-    private fun resolveTeam(userId: UserId): TeamRef? =
-        authService.findTeamFor(userId)
-            ?.let { TeamRef(id = it.id.produce(), name = it.name.value, slug = it.slug.value) }
+    /**
+     * The authenticated-user payload: who is calling, every Team they are a Member of, and which one
+     * this request is scoped to (#143, ADR-0021 §4).
+     *
+     * [activeTeamId] is intersected with the memberships rather than reported as given, so the payload
+     * can only ever name a Team the caller actually has — a Team id resolved anywhere else cannot leak
+     * a name and a slug through here. `role` is read for that same intersected Team, which is what
+     * makes it "your Role *here*" rather than a property of the user.
+     */
+    private fun describe(user: User, activeTeamId: TeamId?): AuthenticatedUser {
+        val teams = authService.findTeamsFor(user.id)
+        val activeTeam = activeTeamId?.let { id -> teams.firstOrNull { it.id == id } }
+        return AuthenticatedUser(
+            id = user.id.produce(),
+            email = user.email.produce(),
+            displayName = user.displayName.value,
+            role = activeTeam?.let { authService.findRoleIn(it.id, user.id)?.name },
+            teams = teams.map { it.produce() },
+            activeTeam = activeTeam?.produce(),
+            isPlatformAdmin = authService.isPlatformAdmin(user.id),
+        )
+    }
 }
+
+// The Wirespec edge for a Team's public identity — id, name and the slug its URLs are addressed by.
+// The tenant schema is deliberately absent (ADR-0021 §2). internal so the switch endpoint hands back
+// the same shape /auth/me does.
+internal fun TeamSummary.produce() = TeamRef(id = id.produce(), name = name.value, slug = slug.value)
 
 // The Wirespec edge for a user's identity — the contract, and the session attribute the auth filter
 // reads back, both still carry a bare UUID string. internal so every controller that names a user

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -45,7 +45,7 @@ class TeamController(
     }
 
     /**
-     * Switches the caller's Active Team to the Team at this slug (ADR-0021 §2) — the request a
+     * Switches the caller's Active Team to the Team at this slug (ADR-0023 §2) — the request a
      * `/t/:slug/…` link performs on the way in, and the one the switcher performs on a tap. They are
      * deliberately the same request.
      *

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -12,17 +12,13 @@ import com.github.zzave.teambalance.api.interfaces.generated.model.Team
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * The two ways a caller comes to be working in a Team: creating one, and switching to one they
- * already have.
+ * Creating a Team, and switching to one you already have.
  *
- * Neither resolves the current tenant (`requireCurrentTeamId`) — create-team's caller may have no
- * Active Team at all, and switch-team's whole job is to *change* it, so reading the outgoing one
- * would prove nothing. Both resolve only the current *user* and let [ActiveTeamService] decide what
- * they may have.
+ * Neither resolves the current tenant: create-team's caller may have no Active Team, and switching
+ * exists to *change* it. Both resolve only the current user and let [ActiveTeamService] decide.
  *
- * Create-team's error mapping (bad name → 400, invalid code → opaque 403, slug clash → 409) is
- * handled by the thrown domain exceptions via [GlobalExceptionHandler]; only the 201 success branch
- * is produced here.
+ * Create-team's error mapping (400 / opaque 403 / 409) comes from the thrown domain exceptions via
+ * [GlobalExceptionHandler]; only the 201 branch is produced here.
  */
 @RestController
 class TeamController(
@@ -45,13 +41,9 @@ class TeamController(
     }
 
     /**
-     * Switches the caller's Active Team to the Team at this slug (ADR-0023 §2) — the request a
-     * `/t/:slug/…` link performs on the way in, and the one the switcher performs on a tap. They are
-     * deliberately the same request.
-     *
-     * A slug that is unknown, and one that names a Team the caller is not a Member of, both answer
-     * 404 with no body: the two are indistinguishable so the Team address space cannot be probed for
-     * which Teams exist. Nothing about the outgoing Active Team changes on a failed switch.
+     * The one switch (ADR-0023 §2): a `/t/:slug/…` link and a tap in the switcher are the same
+     * request. Unknown slug and not-a-Member both answer a bare 404, indistinguishably, and leave
+     * the outgoing Active Team untouched.
      */
     override suspend fun activateTeam(request: ActivateTeam.Request): ActivateTeam.Response<*> {
         val userId = currentUserGateway.requireCurrentUserId()

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -1,25 +1,36 @@
 package com.github.zzave.teambalance.api.interfaces
 
+import com.github.zzave.teambalance.api.application.ActiveTeamService
 import com.github.zzave.teambalance.api.application.CreatedTeam
 import com.github.zzave.teambalance.api.application.TeamService
 import com.github.zzave.teambalance.api.domain.model.CreationCode
+import com.github.zzave.teambalance.api.domain.model.Slug
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ActivateTeam
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateTeam
 import com.github.zzave.teambalance.api.interfaces.generated.model.Team
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Self-service team creation (#154, ADR-0019). The caller is authenticated but, by definition, has no
- * team yet — so this only resolves the current *user* (never `requireCurrentTeamId`, which would
- * fail-closed with 403 for a teamless user). Error mapping (bad name → 400, invalid code → opaque 403,
- * already-in-team / slug clash → 409) is handled by the thrown domain exceptions via
- * [GlobalExceptionHandler]; only the 201 success branch is produced here.
+ * The two ways a caller comes to be working in a Team: creating one, and switching to one they
+ * already have.
+ *
+ * Neither resolves the current tenant (`requireCurrentTeamId`) — create-team's caller may have no
+ * Active Team at all, and switch-team's whole job is to *change* it, so reading the outgoing one
+ * would prove nothing. Both resolve only the current *user* and let [ActiveTeamService] decide what
+ * they may have.
+ *
+ * Create-team's error mapping (bad name → 400, invalid code → opaque 403, slug clash → 409) is
+ * handled by the thrown domain exceptions via [GlobalExceptionHandler]; only the 201 success branch
+ * is produced here.
  */
 @RestController
 class TeamController(
     private val teamService: TeamService,
+    private val activeTeamService: ActiveTeamService,
     private val currentUserGateway: CurrentUserGateway,
-) : CreateTeam.Handler {
+) : CreateTeam.Handler,
+    ActivateTeam.Handler {
 
     override suspend fun createTeam(request: CreateTeam.Request): CreateTeam.Response<*> {
         val founderId = currentUserGateway.requireCurrentUserId()
@@ -31,6 +42,22 @@ class TeamController(
             creationCode = CreationCode(request.body.creationCode.trim()),
         )
         return CreateTeam.Response201(created.toDto())
+    }
+
+    /**
+     * Switches the caller's Active Team to the Team at this slug (ADR-0021 §2) — the request a
+     * `/t/:slug/…` link performs on the way in, and the one the switcher performs on a tap. They are
+     * deliberately the same request.
+     *
+     * A slug that is unknown, and one that names a Team the caller is not a Member of, both answer
+     * 404 with no body: the two are indistinguishable so the Team address space cannot be probed for
+     * which Teams exist. Nothing about the outgoing Active Team changes on a failed switch.
+     */
+    override suspend fun activateTeam(request: ActivateTeam.Request): ActivateTeam.Response<*> {
+        val userId = currentUserGateway.requireCurrentUserId()
+        val activated = activeTeamService.activateBySlug(userId, Slug(request.path.slug))
+            ?: return ActivateTeam.Response404(Unit)
+        return ActivateTeam.Response200(activated.produce())
     }
 }
 

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -59,14 +59,10 @@ ON CONFLICT DO NOTHING;
 -- the event with no row at all, which is what a real not-responded member looks like.
 DELETE FROM team_test.attendances WHERE uuid = 'e2e00000-0000-0000-0000-000000000005';
 
--- --- Second Team, for the team-switching flow (#143, ADR-0023) -------------------------------
--- A second tenant with its own schema and its own event, so "the data followed the switch" is an
--- observable fact rather than an assumption: each Team's events list names an event the other Team
--- does not have.
---
--- Its admin is a SEPARATE user, deliberately. The shared e2e user must stay a Member of exactly one
--- Team: every other spec signs in as them and expects to land somewhere, and a second membership
--- would (correctly) make that landing a choice instead.
+-- --- Second Team, for the team-switching flow (ADR-0023) -------------------------------------
+-- Its own schema and its own event, so "the data followed the switch" is observable. Its admin is a
+-- SEPARATE user: the shared e2e user must stay in exactly one Team, or every other spec's landing
+-- would (correctly) become a choice.
 
 INSERT INTO public.teams (id, name, slug, schema_name)
 VALUES ('e2e00000-0000-0000-0000-000000000011', 'E2E Second Team', 'e2e-second-team', 'team_test_two')

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -59,7 +59,7 @@ ON CONFLICT DO NOTHING;
 -- the event with no row at all, which is what a real not-responded member looks like.
 DELETE FROM team_test.attendances WHERE uuid = 'e2e00000-0000-0000-0000-000000000005';
 
--- --- Second Team, for the team-switching flow (#143, ADR-0021) -------------------------------
+-- --- Second Team, for the team-switching flow (#143, ADR-0023) -------------------------------
 -- A second tenant with its own schema and its own event, so "the data followed the switch" is an
 -- observable fact rather than an assumption: each Team's events list names an event the other Team
 -- does not have.

--- a/api/src/main/resources/db/e2e/seed.sql
+++ b/api/src/main/resources/db/e2e/seed.sql
@@ -58,3 +58,44 @@ ON CONFLICT DO NOTHING;
 -- skips it, so the "Attend N" count can never reach zero. The seeded user starts not-responded on
 -- the event with no row at all, which is what a real not-responded member looks like.
 DELETE FROM team_test.attendances WHERE uuid = 'e2e00000-0000-0000-0000-000000000005';
+
+-- --- Second Team, for the team-switching flow (#143, ADR-0021) -------------------------------
+-- A second tenant with its own schema and its own event, so "the data followed the switch" is an
+-- observable fact rather than an assumption: each Team's events list names an event the other Team
+-- does not have.
+--
+-- Its admin is a SEPARATE user, deliberately. The shared e2e user must stay a Member of exactly one
+-- Team: every other spec signs in as them and expects to land somewhere, and a second membership
+-- would (correctly) make that landing a choice instead.
+
+INSERT INTO public.teams (id, name, slug, schema_name)
+VALUES ('e2e00000-0000-0000-0000-000000000011', 'E2E Second Team', 'e2e-second-team', 'team_test_two')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.users (id, email, display_name)
+VALUES ('e2e00000-0000-0000-0000-000000000012', 'e2e-second@example.com', 'E2E Second Admin')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.team_members (id, team_id, user_id, role, onboarded_at)
+VALUES (
+    'e2e00000-0000-0000-0000-000000000013',
+    'e2e00000-0000-0000-0000-000000000011',
+    'e2e00000-0000-0000-0000-000000000012',
+    'ADMIN',
+    now()
+)
+ON CONFLICT (id) DO UPDATE SET onboarded_at = EXCLUDED.onboarded_at;
+
+INSERT INTO team_test_two.events (uuid, event_type_id, title, description, start_time, end_time, location, created_by)
+SELECT
+    'e2e00000-0000-0000-0000-000000000014',
+    et.id,
+    'E2E Second Team Match',
+    'Seeded so the second Team''s events list is distinguishable from the first',
+    now() + interval '8 days',
+    now() + interval '8 days 2 hours',
+    'E2E Second Sporthal',
+    'e2e00000-0000-0000-0000-000000000012'
+FROM team_test_two.event_types et
+WHERE et.name = 'Match'
+ON CONFLICT DO NOTHING;

--- a/api/src/main/resources/db/migration/V009__user_last_active_team.sql
+++ b/api/src/main/resources/db/migration/V009__user_last_active_team.sql
@@ -1,4 +1,4 @@
--- The Active Team is remembered per user, not per session (ADR-0021 §3): a session-only memory is
+-- The Active Team is remembered per user, not per session (ADR-0023 §3): a session-only memory is
 -- lost exactly when it is most useful — at a fresh magic-link login on a phone.
 --
 -- Nullable on purpose. NULL means "nothing remembered yet": a brand-new user, or one whose remembered

--- a/api/src/main/resources/db/migration/V009__user_last_active_team.sql
+++ b/api/src/main/resources/db/migration/V009__user_last_active_team.sql
@@ -1,0 +1,12 @@
+-- The Active Team is remembered per user, not per session (ADR-0021 §3): a session-only memory is
+-- lost exactly when it is most useful — at a fresh magic-link login on a phone.
+--
+-- Nullable on purpose. NULL means "nothing remembered yet": a brand-new user, or one whose remembered
+-- Team was left. Resolution never trusts this column on its own — the remembered Team is re-verified
+-- against an active team_members row on every read, so a stale value degrades to "force a choice"
+-- rather than to a cross-tenant read.
+--
+-- ON DELETE SET NULL rather than RESTRICT: a deleted Team must not pin a user's row open. Teams are
+-- not deleted today, so this is a guard on a path that does not exist yet, not a workflow.
+ALTER TABLE users
+    ADD COLUMN last_active_team_id UUID REFERENCES teams(id) ON DELETE SET NULL;

--- a/api/src/main/resources/db/migration/V009__user_last_active_team.sql
+++ b/api/src/main/resources/db/migration/V009__user_last_active_team.sql
@@ -1,12 +1,7 @@
--- The Active Team is remembered per user, not per session (ADR-0023 §3): a session-only memory is
--- lost exactly when it is most useful — at a fresh magic-link login on a phone.
+-- Remembered per user, not per session (ADR-0023 §3): a session-only memory is lost exactly when it
+-- is most useful, at a fresh magic-link login on a phone.
 --
--- Nullable on purpose. NULL means "nothing remembered yet": a brand-new user, or one whose remembered
--- Team was left. Resolution never trusts this column on its own — the remembered Team is re-verified
--- against an active team_members row on every read, so a stale value degrades to "force a choice"
--- rather than to a cross-tenant read.
---
--- ON DELETE SET NULL rather than RESTRICT: a deleted Team must not pin a user's row open. Teams are
--- not deleted today, so this is a guard on a path that does not exist yet, not a workflow.
+-- NULL means "nothing remembered yet". Resolution re-verifies this against an active team_members row
+-- on every read, so a stale value degrades to "force a choice" rather than a cross-tenant read.
 ALTER TABLE users
     ADD COLUMN last_active_team_id UUID REFERENCES teams(id) ON DELETE SET NULL;

--- a/api/src/main/wirespec/auth.ws
+++ b/api/src/main/wirespec/auth.ws
@@ -12,12 +12,14 @@ type TeamRef {
     slug: String
 }
 
+// `teams` is every Team the caller is an active Member of; `activeTeam` is the one this request is scoped to - the Active Team (ADR-0021). The route gate reads BOTH: an empty `teams` means teamless (send them to onboarding), while a non-empty `teams` with a null `activeTeam` means "a Member of several, none chosen yet" - a choice to make, not an error. Never infer either from `role`. And `role` is the caller's Role IN THE ACTIVE TEAM, so it is null exactly when `activeTeam` is: a Member of two Teams has two Roles, and only the active one is theirs for this request, which is why it cannot be a property of the user alone.
 type AuthenticatedUser {
     id: String,
     email: String,
     displayName: String,
     role: String?,
-    team: TeamRef?,
+    teams: TeamRef[],
+    activeTeam: TeamRef?,
     isPlatformAdmin: Boolean
 }
 

--- a/api/src/main/wirespec/auth.ws
+++ b/api/src/main/wirespec/auth.ws
@@ -12,7 +12,7 @@ type TeamRef {
     slug: String
 }
 
-// `teams` is every Team the caller is an active Member of; `activeTeam` is the one this request is scoped to - the Active Team (ADR-0023). The route gate reads BOTH: an empty `teams` means teamless (send them to onboarding), while a non-empty `teams` with a null `activeTeam` means "a Member of several, none chosen yet" - a choice to make, not an error. Never infer either from `role`. And `role` is the caller's Role IN THE ACTIVE TEAM, so it is null exactly when `activeTeam` is: a Member of two Teams has two Roles, and only the active one is theirs for this request, which is why it cannot be a property of the user alone.
+// The route gate reads BOTH: empty `teams` means teamless, while a non-empty `teams` with a null `activeTeam` means "a Member of several, none chosen yet" - a choice, not an error. `role` is the Role IN THE ACTIVE TEAM, so it is null exactly when `activeTeam` is (ADR-0023).
 type AuthenticatedUser {
     id: String,
     email: String,

--- a/api/src/main/wirespec/auth.ws
+++ b/api/src/main/wirespec/auth.ws
@@ -12,7 +12,7 @@ type TeamRef {
     slug: String
 }
 
-// `teams` is every Team the caller is an active Member of; `activeTeam` is the one this request is scoped to - the Active Team (ADR-0021). The route gate reads BOTH: an empty `teams` means teamless (send them to onboarding), while a non-empty `teams` with a null `activeTeam` means "a Member of several, none chosen yet" - a choice to make, not an error. Never infer either from `role`. And `role` is the caller's Role IN THE ACTIVE TEAM, so it is null exactly when `activeTeam` is: a Member of two Teams has two Roles, and only the active one is theirs for this request, which is why it cannot be a property of the user alone.
+// `teams` is every Team the caller is an active Member of; `activeTeam` is the one this request is scoped to - the Active Team (ADR-0023). The route gate reads BOTH: an empty `teams` means teamless (send them to onboarding), while a non-empty `teams` with a null `activeTeam` means "a Member of several, none chosen yet" - a choice to make, not an error. Never infer either from `role`. And `role` is the caller's Role IN THE ACTIVE TEAM, so it is null exactly when `activeTeam` is: a Member of two Teams has two Roles, and only the active one is theirs for this request, which is why it cannot be a property of the user alone.
 type AuthenticatedUser {
     id: String,
     email: String,

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -16,3 +16,10 @@ endpoint CreateTeam POST CreateTeamRequest /api/teams -> {
     403 -> Unit
     409 -> Unit
 }
+
+// Switches the caller's Active Team to the Team at this slug and returns it (ADR-0021 section 2). Addressed by slug, not id, because the slug is the Team's public address and is what a shared /t/:slug/... link carries - opening such a link IS this call. There is one kind of switch: a deliberate one and a link-induced one are the same request, and both are remembered as the caller's last-used Team. 404 covers both "no such slug" and "not yours", deliberately indistinguishable, so the Team address space cannot be probed for which Teams exist.
+endpoint ActivateTeam POST /api/teams/{slug: String}/activate -> {
+    200 -> TeamRef
+    401 -> Unit
+    404 -> Unit
+}

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -17,7 +17,7 @@ endpoint CreateTeam POST CreateTeamRequest /api/teams -> {
     409 -> Unit
 }
 
-// Switches the caller's Active Team to the Team at this slug and returns it (ADR-0021 section 2). Addressed by slug, not id, because the slug is the Team's public address and is what a shared /t/:slug/... link carries - opening such a link IS this call. There is one kind of switch: a deliberate one and a link-induced one are the same request, and both are remembered as the caller's last-used Team. 404 covers both "no such slug" and "not yours", deliberately indistinguishable, so the Team address space cannot be probed for which Teams exist.
+// Switches the caller's Active Team to the Team at this slug and returns it (ADR-0023 section 2). Addressed by slug, not id, because the slug is the Team's public address and is what a shared /t/:slug/... link carries - opening such a link IS this call. There is one kind of switch: a deliberate one and a link-induced one are the same request, and both are remembered as the caller's last-used Team. 404 covers both "no such slug" and "not yours", deliberately indistinguishable, so the Team address space cannot be probed for which Teams exist.
 endpoint ActivateTeam POST /api/teams/{slug: String}/activate -> {
     200 -> TeamRef
     401 -> Unit

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -17,7 +17,7 @@ endpoint CreateTeam POST CreateTeamRequest /api/teams -> {
     409 -> Unit
 }
 
-// Switches the caller's Active Team to the Team at this slug and returns it (ADR-0023 section 2). Addressed by slug, not id, because the slug is the Team's public address and is what a shared /t/:slug/... link carries - opening such a link IS this call. There is one kind of switch: a deliberate one and a link-induced one are the same request, and both are remembered as the caller's last-used Team. 404 covers both "no such slug" and "not yours", deliberately indistinguishable, so the Team address space cannot be probed for which Teams exist.
+// Addressed by slug because that is what a shared /t/:slug/... link carries - opening such a link IS this call (ADR-0023 section 2). 404 covers both "no such slug" and "not yours", deliberately indistinguishable.
 endpoint ActivateTeam POST /api/teams/{slug: String}/activate -> {
     200 -> TeamRef
     401 -> Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
@@ -2,8 +2,10 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.SchemaName
 import com.github.zzave.teambalance.api.domain.model.Slug
 import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.TenantRouting
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import io.kotest.core.spec.style.FunSpec
@@ -71,7 +73,7 @@ class ActiveTeamServiceTest : FunSpec() {
                 directory.join(member, setpoint)
                 directory.join(member, tovo)
                 service.activate(member, tovo)
-                gateway.pins.clear()
+                gateway.writes.clear()
 
                 directory.leave(member, tovo)
 
@@ -129,7 +131,7 @@ class ActiveTeamServiceTest : FunSpec() {
                 val theirs = directory.addTeam("Someone Else", "someone-else")
                 directory.join(member, mine)
                 service.activate(member, mine)
-                gateway.pins.clear()
+                gateway.writes.clear()
 
                 service.activate(member, theirs).shouldBeNull()
 
@@ -203,6 +205,35 @@ class ActiveTeamServiceTest : FunSpec() {
 
                 service.pinLanding(member).shouldBeNull()
                 gateway.pins.shouldBeEmpty()
+            }
+
+            // Signing in on a session that already carries someone else's routing — a shared phone,
+            // a second magic link in the same browser. The pin is conditional; the clear is not, or
+            // the new caller inherits the previous caller's tenant.
+            test("clears any routing already on the session, even when it pins nothing after") {
+                val (directory, gateway, service) = fixture()
+                directory.join(member, directory.addTeam("Alpha", "alpha"))
+                directory.join(member, directory.addTeam("Bravo", "bravo"))
+                gateway.pinRouting(
+                    TenantRouting(teamId = TeamId(UUID.randomUUID()), schemaName = SchemaName("team_someone_else")),
+                )
+
+                service.pinLanding(member).shouldBeNull()
+
+                gateway.pinned.shouldBeNull()
+            }
+
+            test("clears before it pins, so a sole membership still lands correctly") {
+                val (directory, gateway, service) = fixture()
+                val alpha = directory.addTeam("Alpha", "alpha")
+                directory.join(member, alpha)
+                gateway.pinRouting(
+                    TenantRouting(teamId = TeamId(UUID.randomUUID()), schemaName = SchemaName("team_someone_else")),
+                )
+
+                service.pinLanding(member) shouldBe alpha
+
+                gateway.pinned.shouldNotBeNull().teamId shouldBe alpha
             }
         }
     }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
@@ -42,8 +42,6 @@ class ActiveTeamServiceTest : FunSpec() {
                 service.resolveLanding(member).shouldBeNull()
             }
 
-            // The bug this seam fixes: two memberships used to be resolved by `ORDER BY team_id LIMIT 1`,
-            // which picks by UUID. Answering *nothing* is what forces the choice to be explicit.
             test("two memberships and nothing remembered resolve to nothing, never an arbitrary pick") {
                 val (directory, _, service) = fixture()
                 directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
@@ -63,9 +61,7 @@ class ActiveTeamServiceTest : FunSpec() {
                 service.resolveLanding(member)?.teamId shouldBe tovo
             }
 
-            // Sessions slide for four weeks and survive restarts (ADR-0014/0015), so a remembered Team
-            // can outlive the membership behind it. Trusting it would route a removed Member back into
-            // a tenant they were removed from.
+            // Sessions slide for four weeks (ADR-0015), long enough to outlive the membership.
             test("a remembered Team whose membership was revoked is not trusted") {
                 val (directory, gateway, service) = fixture()
                 val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
@@ -77,8 +73,7 @@ class ActiveTeamServiceTest : FunSpec() {
 
                 directory.leave(member, tovo)
 
-                // Not "fall back to Setpoint": with the remembered Team gone they are down to one
-                // membership, and a sole membership IS a defensible landing.
+                // Not a fallback: with the remembered Team gone, a sole membership is defensible.
                 service.resolveLanding(member)?.teamId shouldBe setpoint
             }
 
@@ -106,8 +101,6 @@ class ActiveTeamServiceTest : FunSpec() {
                 service.activate(member, tovo).shouldNotBeNull().teamId shouldBe tovo
 
                 directory.rememberedTeamOf(member) shouldBe tovo
-                // The pin carries the NEW team's schema — this is the session-memo invalidation, and a
-                // pin of the outgoing tenant here would be a cross-tenant read on the next request.
                 gateway.lastPinned.shouldNotBeNull().schemaName shouldBe directory.schemaOf(tovo)
             }
 
@@ -135,8 +128,6 @@ class ActiveTeamServiceTest : FunSpec() {
 
                 service.activate(member, theirs).shouldBeNull()
 
-                // Nothing pinned and nothing remembered: a refused switch must not disturb the Active
-                // Team the caller already had, and must not route them at all.
                 gateway.pins.shouldBeEmpty()
                 directory.rememberedTeamOf(member) shouldBe mine
             }
@@ -159,8 +150,6 @@ class ActiveTeamServiceTest : FunSpec() {
                 gateway.lastPinned.shouldNotBeNull().teamId shouldBe tovo
             }
 
-            // "not yours" and "no such Team" must read identically, or the slug space becomes a probe
-            // for which Teams exist on the platform.
             test("a real slug the caller may not have, and an unknown slug, are both just null") {
                 val (directory, _, service) = fixture()
                 directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
@@ -207,9 +196,8 @@ class ActiveTeamServiceTest : FunSpec() {
                 gateway.pins.shouldBeEmpty()
             }
 
-            // Signing in on a session that already carries someone else's routing — a shared phone,
-            // a second magic link in the same browser. The pin is conditional; the clear is not, or
-            // the new caller inherits the previous caller's tenant.
+            // A shared phone, or a second magic link in the same browser: the pin is conditional,
+            // the clear is not, or the new caller inherits the previous caller's tenant.
             test("clears any routing already on the session, even when it pins nothing after") {
                 val (directory, gateway, service) = fixture()
                 directory.join(member, directory.addTeam("Alpha", "alpha"))

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
@@ -1,0 +1,209 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.model.DisplayName
+import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.Slug
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.User
+import com.github.zzave.teambalance.api.domain.model.UserId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+class ActiveTeamServiceTest : FunSpec() {
+    init {
+        val member = UserId.random()
+        val memberUser = User(id = member, email = Email("member@example.com"), displayName = DisplayName("Member"))
+
+        fun fixture(): Triple<TeamDirectory, RecordingTenantRoutingGateway, ActiveTeamService> {
+            val directory = TeamDirectory()
+            val gateway = RecordingTenantRoutingGateway()
+            return Triple(directory, gateway, directory.activeTeamService(gateway, memberUser))
+        }
+
+        context("resolving where a caller lands with no Team named") {
+            test("a sole membership is the landing Team, without anything remembered") {
+                val (directory, _, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                directory.join(member, setpoint)
+
+                service.resolveLanding(member)?.teamId shouldBe setpoint
+            }
+
+            test("a teamless caller lands nowhere — no silent default tenant") {
+                val (_, _, service) = fixture()
+
+                service.resolveLanding(member).shouldBeNull()
+            }
+
+            // The bug this seam fixes: two memberships used to be resolved by `ORDER BY team_id LIMIT 1`,
+            // which picks by UUID. Answering *nothing* is what forces the choice to be explicit.
+            test("two memberships and nothing remembered resolve to nothing, never an arbitrary pick") {
+                val (directory, _, service) = fixture()
+                directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
+                directory.join(member, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+
+                service.resolveLanding(member).shouldBeNull()
+            }
+
+            test("the remembered Team wins over the other memberships") {
+                val (directory, gateway, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+                directory.join(member, setpoint)
+                directory.join(member, tovo)
+                directory.activeTeamService(gateway, memberUser).activate(member, tovo)
+
+                service.resolveLanding(member)?.teamId shouldBe tovo
+            }
+
+            // Sessions slide for four weeks and survive restarts (ADR-0014/0015), so a remembered Team
+            // can outlive the membership behind it. Trusting it would route a removed Member back into
+            // a tenant they were removed from.
+            test("a remembered Team whose membership was revoked is not trusted") {
+                val (directory, gateway, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+                directory.join(member, setpoint)
+                directory.join(member, tovo)
+                service.activate(member, tovo)
+                gateway.pins.clear()
+
+                directory.leave(member, tovo)
+
+                // Not "fall back to Setpoint": with the remembered Team gone they are down to one
+                // membership, and a sole membership IS a defensible landing.
+                service.resolveLanding(member)?.teamId shouldBe setpoint
+            }
+
+            test("a revoked remembered Team with several left standing forces a choice again") {
+                val (directory, _, service) = fixture()
+                val a = directory.addTeam("Alpha", "alpha")
+                val b = directory.addTeam("Bravo", "bravo")
+                val c = directory.addTeam("Charlie", "charlie")
+                listOf(a, b, c).forEach { directory.join(member, it) }
+                service.activate(member, c)
+                directory.leave(member, c)
+
+                service.resolveLanding(member).shouldBeNull()
+            }
+        }
+
+        context("switching") {
+            test("activating a Team the caller is a Member of remembers it and re-pins the routing") {
+                val (directory, gateway, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+                directory.join(member, setpoint)
+                directory.join(member, tovo)
+
+                service.activate(member, tovo).shouldNotBeNull().teamId shouldBe tovo
+
+                directory.rememberedTeamOf(member) shouldBe tovo
+                // The pin carries the NEW team's schema — this is the session-memo invalidation, and a
+                // pin of the outgoing tenant here would be a cross-tenant read on the next request.
+                gateway.lastPinned.shouldNotBeNull().schemaName shouldBe directory.schemaOf(tovo)
+            }
+
+            test("every switch re-pins, so the memo can never be left holding the previous tenant") {
+                val (directory, gateway, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+                directory.join(member, setpoint)
+                directory.join(member, tovo)
+
+                service.activate(member, setpoint)
+                service.activate(member, tovo)
+                service.activate(member, setpoint)
+
+                gateway.pins.map { it.teamId } shouldContainExactly listOf(setpoint, tovo, setpoint)
+            }
+
+            test("activating a Team the caller is NOT a Member of changes nothing") {
+                val (directory, gateway, service) = fixture()
+                val mine = directory.addTeam("Setpoint VT", "setpoint-vt")
+                val theirs = directory.addTeam("Someone Else", "someone-else")
+                directory.join(member, mine)
+                service.activate(member, mine)
+                gateway.pins.clear()
+
+                service.activate(member, theirs).shouldBeNull()
+
+                // Nothing pinned and nothing remembered: a refused switch must not disturb the Active
+                // Team the caller already had, and must not route them at all.
+                gateway.pins.shouldBeEmpty()
+                directory.rememberedTeamOf(member) shouldBe mine
+            }
+
+            test("a Team that does not exist at all is refused the same way") {
+                val (directory, _, service) = fixture()
+                directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
+
+                service.activate(member, TeamId(UUID.randomUUID())).shouldBeNull()
+            }
+        }
+
+        context("switching by slug — what a shared /t/:slug link performs") {
+            test("a slug the caller is entitled to switches and hands back the Team") {
+                val (directory, gateway, service) = fixture()
+                val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+                directory.join(member, tovo)
+
+                service.activateBySlug(member, Slug("tovo-heren-5")).shouldNotBeNull().id shouldBe tovo
+                gateway.lastPinned.shouldNotBeNull().teamId shouldBe tovo
+            }
+
+            // "not yours" and "no such Team" must read identically, or the slug space becomes a probe
+            // for which Teams exist on the platform.
+            test("a real slug the caller may not have, and an unknown slug, are both just null") {
+                val (directory, _, service) = fixture()
+                directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
+                directory.addTeam("Someone Else", "someone-else")
+
+                service.activateBySlug(member, Slug("someone-else")).shouldBeNull()
+                service.activateBySlug(member, Slug("no-such-team")).shouldBeNull()
+            }
+        }
+
+        context("listing the caller's Teams") {
+            test("lists every active membership by name") {
+                val (directory, _, service) = fixture()
+                directory.join(member, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+                directory.join(member, directory.addTeam("Setpoint VT", "setpoint-vt"))
+
+                service.teamsOf(member).map { it.name.value } shouldContainExactly
+                    listOf("Setpoint VT", "Tovo Heren 5")
+            }
+
+            test("a teamless caller has no Teams") {
+                val (_, _, service) = fixture()
+
+                service.teamsOf(member).shouldBeEmpty()
+            }
+        }
+
+        context("pinning at sign-in") {
+            test("pins the landing Team and reports it") {
+                val (directory, gateway, service) = fixture()
+                val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+                directory.join(member, setpoint)
+
+                service.pinLanding(member) shouldBe setpoint
+                gateway.lastPinned.shouldNotBeNull().teamId shouldBe setpoint
+            }
+
+            test("pins nothing for a caller with several Teams and none remembered") {
+                val (directory, gateway, service) = fixture()
+                directory.join(member, directory.addTeam("Alpha", "alpha"))
+                directory.join(member, directory.addTeam("Bravo", "bravo"))
+
+                service.pinLanding(member).shouldBeNull()
+                gateway.pins.shouldBeEmpty()
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthServiceTest.kt
@@ -46,54 +46,11 @@ private class FakeAuthSessionGateway(private var sessionUserId: UserId? = null) 
     }
 }
 
-private class FakeTenantRoutingGateway : TenantRoutingGateway {
-    var pinnedRouting: TenantRouting? = null
-
-    override fun pinRouting(routing: TenantRouting) {
-        pinnedRouting = routing
-    }
-}
-
-private class FakeUserRepository(private val users: Map<UserId, User>) : UserRepository {
-    override fun findById(id: UserId): User? = users[id]
-    override fun findByEmail(email: Email): User? = users.values.firstOrNull { it.email == email }
-    override fun save(user: User): User = user
-}
-
-private class FakeRoutingTeamMemberRepository(private val routing: TenantRouting?) : TeamMemberRepository {
-    override fun findByTeamId(teamId: TeamId) = emptyList<TeamMember>()
-    override fun findDisplayName(userId: UserId): DisplayName? = null
-    override fun findMembersByUserIds(userIds: Set<UserId>) = emptyMap<UserId, TeamMember>()
-    override fun findRole(teamId: TeamId, userId: UserId): Role? = Role.USER
-    override fun findTeamId(userId: UserId): TeamId? = routing?.teamId
-    override fun findTenantRouting(userId: UserId): TenantRouting? = routing
-    override fun addMember(teamId: TeamId, userId: UserId) = Unit
-    override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
-    override fun deactivate(teamId: TeamId, userId: UserId) = Unit
-    override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit
-    override fun applyMemberEdit(
-        teamId: TeamId,
-        userId: UserId,
-        displayName: DisplayName,
-        role: Role,
-        positionId: PositionId?,
-        markOnboardedAt: Instant?,
-    ) = Unit
-    override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
-    override fun countAdmins(teamId: TeamId): Int = 0
-}
-
 private class FakeMagicLinkTokenRepository : MagicLinkTokenRepository {
     override fun save(token: MagicLinkToken): MagicLinkToken = token
     override fun findByTokenHash(tokenHash: TokenHash): MagicLinkToken? = null
     override fun consumeAndResolveUser(consumedToken: MagicLinkToken, displayName: DisplayName): User =
         error("not used in these tests")
-}
-
-private class FakeTeamRepository : TeamRepository {
-    override fun findAllSchemaNames() = emptyList<SchemaName>()
-    override fun existsBySlug(slug: Slug) = false
-    override fun findByUserId(userId: UUID): TeamSummary? = null
 }
 
 private class FakeEmailGateway : EmailGateway {
@@ -120,55 +77,100 @@ class AuthServiceTest : FunSpec() {
             email = Email("session@test.com"),
             displayName = DisplayName("Session"),
         )
-        val routing = TenantRouting(teamId = TeamId(UUID.randomUUID()), schemaName = SchemaName("team_alpha"))
-
         fun serviceWith(
             gateway: AuthSessionGateway,
-            tenantRouting: TenantRouting?,
-            routingGateway: TenantRoutingGateway = FakeTenantRoutingGateway(),
+            directory: TeamDirectory = TeamDirectory(),
+            routingGateway: TenantRoutingGateway = RecordingTenantRoutingGateway(),
         ) = AuthService(
             magicLinkTokenRepository = FakeMagicLinkTokenRepository(),
-            userRepository = FakeUserRepository(mapOf(userId to user)),
-            teamRepository = FakeTeamRepository(),
-            teamMemberRepository = FakeRoutingTeamMemberRepository(tenantRouting),
+            userRepository = directory.userRepository(user),
+            teamMemberRepository = directory.teamMemberRepository(),
+            activeTeamService = directory.activeTeamService(routingGateway, user),
             emailGateway = FakeEmailGateway(),
             platformAdminGateway = FakePlatformAdminGateway(),
             authSessionGateway = gateway,
-            tenantRoutingGateway = routingGateway,
             clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
         )
 
-        test("startSession pins the signed-in user's tenant routing") {
+        test("startSession pins the Active Team the signed-in user lands in, and reports it") {
             val gateway = FakeAuthSessionGateway()
-            val routingGateway = FakeTenantRoutingGateway()
+            val routingGateway = RecordingTenantRoutingGateway()
+            val directory = TeamDirectory()
+            val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+            directory.join(userId, setpoint)
 
-            serviceWith(gateway, routing, routingGateway).startSession(userId)
+            serviceWith(gateway, directory, routingGateway).startSession(userId) shouldBe setpoint
 
             gateway.startedFor shouldBe userId
-            routingGateway.pinnedRouting shouldBe routing
+            routingGateway.lastPinned?.schemaName shouldBe directory.schemaOf(setpoint)
         }
 
         test("startSession leaves the tenant unpinned for a teamless user") {
             val gateway = FakeAuthSessionGateway()
-            val routingGateway = FakeTenantRoutingGateway()
+            val routingGateway = RecordingTenantRoutingGateway()
 
-            serviceWith(gateway, null, routingGateway).startSession(userId)
+            serviceWith(gateway, routingGateway = routingGateway).startSession(userId) shouldBe null
 
             gateway.startedFor shouldBe userId
-            routingGateway.pinnedRouting shouldBe null
+            routingGateway.lastPinned shouldBe null
+        }
+
+        // A Member of several Teams with none remembered is signed in but *unrouted*: the session
+        // exists, no tenant is pinned, and the frontend asks them which Team they mean.
+        test("startSession pins nothing when several Teams are open and none is remembered") {
+            val gateway = FakeAuthSessionGateway()
+            val routingGateway = RecordingTenantRoutingGateway()
+            val directory = TeamDirectory()
+            directory.join(userId, directory.addTeam("Setpoint VT", "setpoint-vt"))
+            directory.join(userId, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+
+            serviceWith(gateway, directory, routingGateway).startSession(userId) shouldBe null
+
+            gateway.startedFor shouldBe userId
+            routingGateway.pins shouldBe emptyList()
+        }
+
+        test("findTeamsFor lists every Team the caller is a Member of") {
+            val directory = TeamDirectory()
+            directory.join(userId, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+            directory.join(userId, directory.addTeam("Setpoint VT", "setpoint-vt"))
+
+            serviceWith(FakeAuthSessionGateway(userId), directory).findTeamsFor(userId)
+                .map { it.name.value } shouldBe listOf("Setpoint VT", "Tovo Heren 5")
+        }
+
+        // The Role reported to the caller is the Role in the Team they are *in*, not a property of the
+        // user: the same person is an Admin in one Team and a plain User in another.
+        test("findRoleIn answers per Team, not per user") {
+            val directory = TeamDirectory()
+            val setpoint = directory.addTeam("Setpoint VT", "setpoint-vt")
+            val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+            directory.join(userId, setpoint, Role.ADMIN)
+            directory.join(userId, tovo, Role.USER)
+            val service = serviceWith(FakeAuthSessionGateway(userId), directory)
+
+            service.findRoleIn(setpoint, userId) shouldBe Role.ADMIN
+            service.findRoleIn(tovo, userId) shouldBe Role.USER
+        }
+
+        test("findRoleIn is null for a Team the caller is not a Member of") {
+            val directory = TeamDirectory()
+            val theirs = directory.addTeam("Someone Else", "someone-else")
+
+            serviceWith(FakeAuthSessionGateway(userId), directory).findRoleIn(theirs, userId) shouldBe null
         }
 
         test("currentUser resolves the user the session belongs to") {
-            serviceWith(FakeAuthSessionGateway(userId), routing).currentUser() shouldBe user
+            serviceWith(FakeAuthSessionGateway(userId)).currentUser() shouldBe user
         }
 
         test("currentUser is null without a session") {
-            serviceWith(FakeAuthSessionGateway(null), routing).currentUser() shouldBe null
+            serviceWith(FakeAuthSessionGateway(null)).currentUser() shouldBe null
         }
 
         test("endSession drops the session, leaving no current user") {
             val gateway = FakeAuthSessionGateway(userId)
-            val service = serviceWith(gateway, routing)
+            val service = serviceWith(gateway)
 
             service.endSession()
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -20,8 +20,8 @@ private class FakeTeamMemberRepository(private val roles: Map<Pair<TeamId, UserI
     override fun findDisplayName(userId: UserId): DisplayName? = null
     override fun findMembersByUserIds(userIds: Set<UserId>) = emptyMap<UserId, TeamMember>()
     override fun findRole(teamId: TeamId, userId: UserId): Role? = roles[teamId to userId]
-    override fun findTeamId(userId: UserId): TeamId? = null
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
+    override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
+    override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
     override fun addMember(teamId: TeamId, userId: UserId) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun deactivate(teamId: TeamId, userId: UserId) = Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -61,8 +61,8 @@ private class EventFakeMemberRepo(private val admins: Set<UserId>) : TeamMemberR
     override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
     override fun findDisplayName(userId: UserId): DisplayName? = null
     override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
-    override fun findTeamId(userId: UserId): TeamId? = null
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
+    override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
+    override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
     override fun addMember(teamId: TeamId, userId: UserId) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun deactivate(teamId: TeamId, userId: UserId) = Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -143,7 +143,7 @@ class InvitationServiceTest : FunSpec() {
             f.directory.join(nonAdmin, other)
             f.service.acceptInvitation(token = "anything", userId = nonAdmin)
             f.invitations.expire()
-            f.routingGateway.pins.clear()
+            f.routingGateway.writes.clear()
 
             f.service.acceptInvitation(token = "anything", userId = nonAdmin) shouldBe null
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -123,7 +123,7 @@ class InvitationServiceTest : FunSpec() {
             f.members.findRole(f.teamId, nonAdmin) shouldBe Role.USER
         }
 
-        // ADR-0021 §4: accepting is no longer fire-and-forget. A joiner who is already a Member
+        // ADR-0023 §4: accepting is no longer fire-and-forget. A joiner who is already a Member
         // somewhere would otherwise join and keep looking at their other Team.
         test("acceptInvitation makes the joined Team the joiner's Active Team") {
             val f = newFixture()

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -30,7 +30,7 @@ private class FakeInvitationRepo(private var live: Invitation?) : InvitationRepo
     var expiredTeam: TeamId? = null
     val rotated = mutableListOf<Invitation>()
 
-    /** Kills the stored link the way a rotate or a lapsed TTL does — every later lookup misses. */
+    /** The way a rotate or a lapsed TTL does: every later lookup misses. */
     fun expire() { live = null }
 
     override fun save(invitation: Invitation): Invitation { saved += invitation; return invitation }
@@ -123,8 +123,6 @@ class InvitationServiceTest : FunSpec() {
             f.members.findRole(f.teamId, nonAdmin) shouldBe Role.USER
         }
 
-        // ADR-0023 §4: accepting is no longer fire-and-forget. A joiner who is already a Member
-        // somewhere would otherwise join and keep looking at their other Team.
         test("acceptInvitation makes the joined Team the joiner's Active Team") {
             val f = newFixture()
             val other = f.directory.addTeam("Tovo Heren 5", "tovo-heren-5")
@@ -136,7 +134,6 @@ class InvitationServiceTest : FunSpec() {
             f.routingGateway.lastPinned?.schemaName shouldBe f.directory.schemaOf(f.teamId)
         }
 
-        // A dead token must not disturb the Active Team of whoever presented it.
         test("an expired token joins nothing and switches nothing") {
             val f = newFixture()
             val other = f.directory.addTeam("Tovo Heren 5", "tovo-heren-5")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.NotTeamAdminException
 import com.github.zzave.teambalance.api.domain.model.DisplayName
+import com.github.zzave.teambalance.api.domain.model.Email
 import com.github.zzave.teambalance.api.domain.model.Invitation
 import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.model.Role
@@ -9,6 +10,7 @@ import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TenantRouting
 import com.github.zzave.teambalance.api.domain.model.TeamMember
 import com.github.zzave.teambalance.api.domain.model.TokenHash
+import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
@@ -23,12 +25,16 @@ import java.util.UUID
 
 // Records saves and always resolves a live invitation for the accept path (token hashing is not the
 // subject here — authorization is).
-private class FakeInvitationRepo(private val live: Invitation) : InvitationRepository {
+private class FakeInvitationRepo(private var live: Invitation?) : InvitationRepository {
     val saved = mutableListOf<Invitation>()
     var expiredTeam: TeamId? = null
     val rotated = mutableListOf<Invitation>()
+
+    /** Kills the stored link the way a rotate or a lapsed TTL does — every later lookup misses. */
+    fun expire() { live = null }
+
     override fun save(invitation: Invitation): Invitation { saved += invitation; return invitation }
-    override fun findByTokenHash(tokenHash: TokenHash): Invitation = live
+    override fun findByTokenHash(tokenHash: TokenHash): Invitation? = live
     override fun expireActive(teamId: TeamId, now: Instant) { expiredTeam = teamId }
     override fun rotate(teamId: TeamId, replacement: Invitation, now: Instant): Invitation {
         rotated += replacement
@@ -36,94 +42,112 @@ private class FakeInvitationRepo(private val live: Invitation) : InvitationRepos
     }
 }
 
-// USER for everyone except the seeded admins; records joins so the open accept path can be asserted.
-private class InviteFakeMemberRepo(private val admins: Set<UserId>) : TeamMemberRepository {
-    val joined = mutableListOf<Pair<TeamId, UserId>>()
-    override fun findRole(teamId: TeamId, userId: UserId): Role = if (userId in admins) Role.ADMIN else Role.USER
-    override fun addMember(teamId: TeamId, userId: UserId) { joined += teamId to userId }
-    override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
-    override fun findDisplayName(userId: UserId): DisplayName? = null
-    override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
-    override fun findTeamId(userId: UserId): TeamId? = null
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
-    override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
-    override fun deactivate(teamId: TeamId, userId: UserId) = Unit
-    override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit
-    override fun applyMemberEdit(
-        teamId: TeamId,
-        userId: UserId,
-        displayName: DisplayName,
-        role: Role,
-        positionId: PositionId?,
-        markOnboardedAt: Instant?,
-    ) = Unit
-    override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
-    override fun countAdmins(teamId: TeamId): Int = admins.size
-}
-
 class InvitationServiceTest : FunSpec() {
     init {
         val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-        val teamId = TeamId(UUID.randomUUID())
         val adminId = UserId.random()
         val nonAdmin = UserId.random()
+        val joiner = User(id = nonAdmin, email = Email("joiner@example.com"), displayName = DisplayName("Joiner"))
 
-        val liveInvitation = Invitation(
-            id = UUID.randomUUID(),
-            teamId = teamId,
-            tokenHash = TokenHash("hash"),
-            createdBy = adminId,
-            expiresAt = Instant.EPOCH.plus(Duration.ofDays(1)),
-            createdAt = Instant.EPOCH,
-        )
+        class Fixture(val directory: TeamDirectory, val teamId: TeamId) {
+            val invitations = FakeInvitationRepo(
+                Invitation(
+                    id = UUID.randomUUID(),
+                    teamId = teamId,
+                    tokenHash = TokenHash("hash"),
+                    createdBy = adminId,
+                    expiresAt = Instant.EPOCH.plus(Duration.ofDays(1)),
+                    createdAt = Instant.EPOCH,
+                ),
+            )
+            val routingGateway = RecordingTenantRoutingGateway()
+            val members = directory.teamMemberRepository()
+            val service = InvitationService(
+                invitationRepository = invitations,
+                teamMemberRepository = members,
+                authorizationService = AuthorizationService(members),
+                activeTeamService = directory.activeTeamService(routingGateway, joiner),
+                clock = clock,
+                tokenSalt = "salt",
+            )
+        }
 
-        fun newService(): Triple<InvitationService, FakeInvitationRepo, InviteFakeMemberRepo> {
-            val invitations = FakeInvitationRepo(liveInvitation)
-            val members = InviteFakeMemberRepo(admins = setOf(adminId))
-            val service = InvitationService(invitations, members, AuthorizationService(members), clock, "salt")
-            return Triple(service, invitations, members)
+        fun newFixture(): Fixture {
+            val directory = TeamDirectory()
+            val teamId = directory.addTeam("Setpoint VT", "setpoint-vt")
+            directory.join(adminId, teamId, Role.ADMIN)
+            return Fixture(directory, teamId)
         }
 
         test("generateInviteLink by a non-admin is forbidden") {
-            val (service, _, _) = newService()
-            shouldThrow<NotTeamAdminException> { service.generateInviteLink(callerId = nonAdmin, teamId = teamId) }
+            val f = newFixture()
+            shouldThrow<NotTeamAdminException> { f.service.generateInviteLink(callerId = nonAdmin, teamId = f.teamId) }
         }
 
         test("expireActiveInvitations by a non-admin is forbidden") {
-            val (service, _, _) = newService()
-            shouldThrow<NotTeamAdminException> { service.expireActiveInvitations(callerId = nonAdmin, teamId = teamId) }
+            val f = newFixture()
+            shouldThrow<NotTeamAdminException> {
+                f.service.expireActiveInvitations(callerId = nonAdmin, teamId = f.teamId)
+            }
         }
 
         test("rotateInviteLink by a non-admin is forbidden") {
-            val (service, _, _) = newService()
-            shouldThrow<NotTeamAdminException> { service.rotateInviteLink(callerId = nonAdmin, teamId = teamId) }
+            val f = newFixture()
+            shouldThrow<NotTeamAdminException> { f.service.rotateInviteLink(callerId = nonAdmin, teamId = f.teamId) }
         }
 
         // The expire and the mint must reach the port as ONE call: that single call is what the adapter
         // makes atomic, so a failure to mint can't leave the team with no usable link. Two separate
         // calls would be two transactions and would reintroduce that gap.
         test("rotateInviteLink hands the expire and the mint over as a single port call") {
-            val (service, invitations, _) = newService()
-            val result = service.rotateInviteLink(callerId = adminId, teamId = teamId)
+            val f = newFixture()
+            val result = f.service.rotateInviteLink(callerId = adminId, teamId = f.teamId)
 
-            invitations.rotated.single().createdBy shouldBe adminId
-            invitations.saved.isEmpty() shouldBe true
-            invitations.expiredTeam shouldBe null
+            f.invitations.rotated.single().createdBy shouldBe adminId
+            f.invitations.saved.isEmpty() shouldBe true
+            f.invitations.expiredTeam shouldBe null
             result.token.value.isNotBlank() shouldBe true
         }
 
         test("generateInviteLink by an admin mints a link attributed to the caller") {
-            val (service, invitations, _) = newService()
-            val result = service.generateInviteLink(callerId = adminId, teamId = teamId)
+            val f = newFixture()
+            val result = f.service.generateInviteLink(callerId = adminId, teamId = f.teamId)
             result.token.value.isNotBlank() shouldBe true
-            invitations.saved.single().createdBy shouldBe adminId
+            f.invitations.saved.single().createdBy shouldBe adminId
         }
 
         test("acceptInvitation requires no admin role — any authenticated user may join") {
-            val (service, _, members) = newService()
-            val joinedTeam = service.acceptInvitation(token = "anything", userId = nonAdmin)
-            joinedTeam shouldBe teamId
-            members.joined shouldBe listOf(teamId to nonAdmin)
+            val f = newFixture()
+            val joinedTeam = f.service.acceptInvitation(token = "anything", userId = nonAdmin)
+            joinedTeam shouldBe f.teamId
+            f.members.findRole(f.teamId, nonAdmin) shouldBe Role.USER
+        }
+
+        // ADR-0021 §4: accepting is no longer fire-and-forget. A joiner who is already a Member
+        // somewhere would otherwise join and keep looking at their other Team.
+        test("acceptInvitation makes the joined Team the joiner's Active Team") {
+            val f = newFixture()
+            val other = f.directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+            f.directory.join(nonAdmin, other)
+
+            f.service.acceptInvitation(token = "anything", userId = nonAdmin)
+
+            f.directory.rememberedTeamOf(nonAdmin) shouldBe f.teamId
+            f.routingGateway.lastPinned?.schemaName shouldBe f.directory.schemaOf(f.teamId)
+        }
+
+        // A dead token must not disturb the Active Team of whoever presented it.
+        test("an expired token joins nothing and switches nothing") {
+            val f = newFixture()
+            val other = f.directory.addTeam("Tovo Heren 5", "tovo-heren-5")
+            f.directory.join(nonAdmin, other)
+            f.service.acceptInvitation(token = "anything", userId = nonAdmin)
+            f.invitations.expire()
+            f.routingGateway.pins.clear()
+
+            f.service.acceptInvitation(token = "anything", userId = nonAdmin) shouldBe null
+
+            f.routingGateway.pins shouldBe emptyList()
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
@@ -33,6 +33,8 @@ private class FakeMemberUserRepo(users: List<User>) : UserRepository {
         store[user.id] = user
         return user
     }
+    override fun findLastActiveTeamId(userId: UserId): TeamId? = null
+    override fun rememberActiveTeam(userId: UserId, teamId: TeamId) = Unit
 }
 
 // Reads display names from [userRepo] so a save() is reflected by a later findByTeamId — mirroring the
@@ -74,8 +76,8 @@ private class FakeMembershipRepo(
     override fun findMembersByUserIds(userIds: Set<UserId>) = emptyMap<UserId, TeamMember>()
     override fun findRole(teamId: TeamId, userId: UserId): Role? =
         store[teamId to userId]?.takeIf { it.active }?.role
-    override fun findTeamId(userId: UserId): TeamId? = null
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
+    override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
+    override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
     override fun addMember(teamId: TeamId, userId: UserId) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) {
         store[teamId to userId]?.role = role

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
@@ -48,8 +48,8 @@ private class FakeAdminRepo(private val admins: Set<UserId>) : TeamMemberReposit
     override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
     override fun findDisplayName(userId: UserId): DisplayName? = null
     override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
-    override fun findTeamId(userId: UserId): TeamId? = null
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
+    override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
+    override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
     override fun addMember(teamId: TeamId, userId: UserId) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun deactivate(teamId: TeamId, userId: UserId) = Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -122,7 +122,7 @@ internal class TeamDirectory {
 }
 
 /**
- * Records every pin in order. Order matters: the pin IS the session-memo invalidation (ADR-0021 §2),
+ * Records every pin in order. Order matters: the pin IS the session-memo invalidation (ADR-0023 §2),
  * so "was the last pin the Team we switched to?" is the assertion that a switch cannot be read back
  * as the previous tenant.
  */

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -127,11 +127,21 @@ internal class TeamDirectory {
  * as the previous tenant.
  */
 internal class RecordingTenantRoutingGateway : TenantRoutingGateway {
-    val pins = mutableListOf<TenantRouting>()
+    /** Every pin and clear in order — `null` is a clear. */
+    val writes = mutableListOf<TenantRouting?>()
+
+    val pins: List<TenantRouting> get() = writes.filterNotNull()
     val lastPinned: TenantRouting? get() = pins.lastOrNull()
 
+    /** What the session would actually be carrying now: the last write, pin or clear. */
+    val pinned: TenantRouting? get() = writes.lastOrNull()
+
     override fun pinRouting(routing: TenantRouting) {
-        pins += routing
+        writes += routing
+    }
+
+    override fun clearRouting() {
+        writes += null
     }
 }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -21,14 +21,11 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * An in-memory stand-in for the `public` schema — Teams, who is an active Member of which, and each
- * user's remembered Active Team — behind the three ports that read it.
+ * An in-memory stand-in for the `public` schema behind the three ports that read it.
  *
- * Shared by the tests that exercise the Active Team seam because the interesting cases are *shapes of
- * the directory* (two memberships, a remembered Team whose membership was revoked, a deactivated row)
- * rather than shapes of a single port's answers. Building those from one holder keeps the three ports
- * consistent with each other the way the database keeps them consistent — a fake that let
- * `findTeamsOf` and `findTenantRouting` disagree could not reproduce the bug this seam fixes.
+ * One holder rather than three independent fakes, because the interesting cases are shapes of the
+ * *directory* (two memberships, a revoked one, a deactivated row) and the ports have to stay
+ * consistent with each other the way the database keeps them consistent.
  */
 internal class TeamDirectory {
     private data class TeamRow(val summary: TeamSummary, val schemaName: SchemaName)
@@ -52,7 +49,7 @@ internal class TeamDirectory {
         memberships[userId to teamId] = role
     }
 
-    /** Ends the membership the way `active = false` does: the row is gone for every read. */
+    /** Ends the membership the way `active = false` does: gone for every read. */
     fun leave(userId: UserId, teamId: TeamId) {
         memberships.remove(userId to teamId)
     }
@@ -121,19 +118,15 @@ internal class TeamDirectory {
     }
 }
 
-/**
- * Records every pin in order. Order matters: the pin IS the session-memo invalidation (ADR-0023 §2),
- * so "was the last pin the Team we switched to?" is the assertion that a switch cannot be read back
- * as the previous tenant.
- */
+/** Order matters: the pin is the session-memo invalidation (ADR-0023 §2). */
 internal class RecordingTenantRoutingGateway : TenantRoutingGateway {
-    /** Every pin and clear in order — `null` is a clear. */
+    /** In order; `null` is a clear. */
     val writes = mutableListOf<TenantRouting?>()
 
     val pins: List<TenantRouting> get() = writes.filterNotNull()
     val lastPinned: TenantRouting? get() = pins.lastOrNull()
 
-    /** What the session would actually be carrying now: the last write, pin or clear. */
+    /** What the session would be carrying now. */
     val pinned: TenantRouting? get() = writes.lastOrNull()
 
     override fun pinRouting(routing: TenantRouting) {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -1,0 +1,146 @@
+package com.github.zzave.teambalance.api.application
+
+import com.github.zzave.teambalance.api.domain.model.DisplayName
+import com.github.zzave.teambalance.api.domain.model.Email
+import com.github.zzave.teambalance.api.domain.model.PositionId
+import com.github.zzave.teambalance.api.domain.model.Role
+import com.github.zzave.teambalance.api.domain.model.SchemaName
+import com.github.zzave.teambalance.api.domain.model.Slug
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.TeamMember
+import com.github.zzave.teambalance.api.domain.model.TeamName
+import com.github.zzave.teambalance.api.domain.model.TeamSummary
+import com.github.zzave.teambalance.api.domain.model.TenantRouting
+import com.github.zzave.teambalance.api.domain.model.User
+import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
+import com.github.zzave.teambalance.api.domain.port.UserRepository
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * An in-memory stand-in for the `public` schema — Teams, who is an active Member of which, and each
+ * user's remembered Active Team — behind the three ports that read it.
+ *
+ * Shared by the tests that exercise the Active Team seam because the interesting cases are *shapes of
+ * the directory* (two memberships, a remembered Team whose membership was revoked, a deactivated row)
+ * rather than shapes of a single port's answers. Building those from one holder keeps the three ports
+ * consistent with each other the way the database keeps them consistent — a fake that let
+ * `findTeamsOf` and `findTenantRouting` disagree could not reproduce the bug this seam fixes.
+ */
+internal class TeamDirectory {
+    private data class TeamRow(val summary: TeamSummary, val schemaName: SchemaName)
+
+    private val teams = mutableMapOf<TeamId, TeamRow>()
+
+    /** (userId, teamId) -> role, present only while the membership is active. */
+    private val memberships = mutableMapOf<Pair<UserId, TeamId>, Role>()
+    private val remembered = mutableMapOf<UserId, TeamId>()
+
+    fun addTeam(name: String, slug: String): TeamId {
+        val id = TeamId(UUID.randomUUID())
+        teams[id] = TeamRow(
+            summary = TeamSummary(id = id, name = TeamName(name), slug = Slug(slug)),
+            schemaName = SchemaName("team_${slug.replace("-", "_")}"),
+        )
+        return id
+    }
+
+    fun join(userId: UserId, teamId: TeamId, role: Role = Role.USER) {
+        memberships[userId to teamId] = role
+    }
+
+    /** Ends the membership the way `active = false` does: the row is gone for every read. */
+    fun leave(userId: UserId, teamId: TeamId) {
+        memberships.remove(userId to teamId)
+    }
+
+    fun rememberedTeamOf(userId: UserId): TeamId? = remembered[userId]
+
+    fun schemaOf(teamId: TeamId): SchemaName = teams.getValue(teamId).schemaName
+
+    fun summaryOf(teamId: TeamId): TeamSummary = teams.getValue(teamId).summary
+
+    private fun routing(teamId: TeamId) =
+        teams[teamId]?.let { TenantRouting(teamId = teamId, schemaName = it.schemaName) }
+
+    fun teamRepository(): TeamRepository = object : TeamRepository {
+        override fun findAllSchemaNames(): List<SchemaName> = teams.values.map { it.schemaName }
+        override fun existsBySlug(slug: Slug): Boolean = teams.values.any { it.summary.slug == slug }
+        override fun findTeamsOf(userId: UUID): List<TeamSummary> =
+            memberships.keys
+                .filter { it.first.value == userId }
+                .mapNotNull { teams[it.second]?.summary }
+                .sortedBy { it.name.value }
+        override fun findBySlug(slug: Slug): TeamSummary? =
+            teams.values.firstOrNull { it.summary.slug == slug }?.summary
+    }
+
+    fun userRepository(vararg users: User): UserRepository = object : UserRepository {
+        private val byId = users.associateBy { it.id }
+        override fun findById(id: UserId): User? = byId[id]
+        override fun findByEmail(email: Email): User? = byId.values.firstOrNull { it.email == email }
+        override fun save(user: User): User = user
+        override fun findLastActiveTeamId(userId: UserId): TeamId? = remembered[userId]
+        override fun rememberActiveTeam(userId: UserId, teamId: TeamId) {
+            remembered[userId] = teamId
+        }
+    }
+
+    @Suppress("TooManyFunctions")
+    fun teamMemberRepository(): TeamMemberRepository = object : TeamMemberRepository {
+        override fun findRole(teamId: TeamId, userId: UserId): Role? = memberships[userId to teamId]
+
+        override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? =
+            routing(teamId)?.takeIf { memberships.containsKey(userId to teamId) }
+
+        override fun findSoleTenantRouting(userId: UserId): TenantRouting? =
+            memberships.keys.filter { it.first == userId }.singleOrNull()?.let { routing(it.second) }
+
+        override fun addMember(teamId: TeamId, userId: UserId) = join(userId, teamId)
+
+        override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
+        override fun findDisplayName(userId: UserId): DisplayName? = null
+        override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
+        override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = join(userId, teamId, role)
+        override fun deactivate(teamId: TeamId, userId: UserId) = leave(userId, teamId)
+        override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit
+        override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
+        override fun applyMemberEdit(
+            teamId: TeamId,
+            userId: UserId,
+            displayName: DisplayName,
+            role: Role,
+            positionId: PositionId?,
+            markOnboardedAt: Instant?,
+        ) = Unit
+        override fun countAdmins(teamId: TeamId): Int =
+            memberships.count { it.key.second == teamId && it.value == Role.ADMIN }
+    }
+}
+
+/**
+ * Records every pin in order. Order matters: the pin IS the session-memo invalidation (ADR-0021 §2),
+ * so "was the last pin the Team we switched to?" is the assertion that a switch cannot be read back
+ * as the previous tenant.
+ */
+internal class RecordingTenantRoutingGateway : TenantRoutingGateway {
+    val pins = mutableListOf<TenantRouting>()
+    val lastPinned: TenantRouting? get() = pins.lastOrNull()
+
+    override fun pinRouting(routing: TenantRouting) {
+        pins += routing
+    }
+}
+
+internal fun TeamDirectory.activeTeamService(
+    routingGateway: TenantRoutingGateway,
+    vararg users: User,
+) = ActiveTeamService(
+    teamMemberRepository = teamMemberRepository(),
+    teamRepository = teamRepository(),
+    userRepository = userRepository(*users),
+    tenantRoutingGateway = routingGateway,
+)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -63,7 +63,6 @@ private class RecordingRegistrar(
         now: Instant,
     ): TeamId {
         calls += "register:$slug"
-        // What the real registrar commits in one transaction: the team row plus the founding admin.
         return directory.addTeam(name.value, slug.value).also { directory.join(founder, it, Role.ADMIN) }
     }
 }
@@ -87,10 +86,8 @@ class TeamServiceTest : FunSpec() {
         val founder = UserId.random()
         val founderUser = User(id = founder, email = Email("founder@example.com"), displayName = DisplayName("Founder"))
 
-        // The registrar is faked, so the directory has to be told what a successful register() would
-        // have written: the Team row and the founder's ADMIN membership. Handing that to
-        // RecordingRegistrar keeps "the founder is a Member as of register()" true here too — which is
-        // exactly the precondition the Active Team switch that follows it depends on.
+        // The faked registrar still writes what a real one commits — the Team row and the founder's
+        // ADMIN membership — because the Active Team switch that follows depends on it.
         fun fixture(
             calls: MutableList<String> = mutableListOf(),
             existingSlugs: Set<Slug> = emptySet(),
@@ -136,8 +133,6 @@ class TeamServiceTest : FunSpec() {
             calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
         }
 
-        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0023 §4): it existed only to match a
-        // routing layer that could hold one Team per user, and that constraint is gone.
         test("a founder who already plays in a team may create another") {
             val calls = mutableListOf<String>()
             val (directory, _, service) = fixture(calls)
@@ -149,8 +144,6 @@ class TeamServiceTest : FunSpec() {
             calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
         }
 
-        // Without this the founder would create a Team and stay routed to the one they were already
-        // in — the new Team would exist and be invisible to the person who made it.
         test("the new team becomes the founder's Active Team") {
             val (directory, gateway, service) = fixture()
             directory.join(founder, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -1,13 +1,11 @@
 package com.github.zzave.teambalance.api.application
 
-import com.github.zzave.teambalance.api.domain.exception.AlreadyInTeamException
 import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
 import com.github.zzave.teambalance.api.domain.exception.InvalidSlugException
 import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
 import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
 import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
-import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.SchemaName
 import com.github.zzave.teambalance.api.domain.model.CreationCode
@@ -15,55 +13,22 @@ import com.github.zzave.teambalance.api.domain.model.Slug
 import com.github.zzave.teambalance.api.domain.model.TeamCreationCode
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TeamName
-import com.github.zzave.teambalance.api.domain.model.TenantRouting
-import com.github.zzave.teambalance.api.domain.model.TeamMember
-import com.github.zzave.teambalance.api.domain.model.TeamSummary
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.domain.port.TeamNotificationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRegistrationGateway
-import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import com.github.zzave.teambalance.api.domain.port.TenantProvisioningGateway
-import com.github.zzave.teambalance.api.domain.port.UserRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.UUID
-
-private class FakeMemberRepo(private val existingTeam: TeamId?) : TeamMemberRepository {
-    override fun findTeamId(userId: UserId): TeamId? = existingTeam
-    override fun findTenantRouting(userId: UserId): TenantRouting? = null
-    override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
-    override fun findDisplayName(userId: UserId): DisplayName? = null
-    override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
-    override fun findRole(teamId: TeamId, userId: UserId): Role? = null
-    override fun addMember(teamId: TeamId, userId: UserId) = Unit
-    override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
-    override fun deactivate(teamId: TeamId, userId: UserId) = Unit
-    override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit
-    override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
-    override fun applyMemberEdit(
-        teamId: TeamId,
-        userId: UserId,
-        displayName: DisplayName,
-        role: Role,
-        positionId: PositionId?,
-        markOnboardedAt: Instant?,
-    ) = Unit
-    override fun countAdmins(teamId: TeamId): Int = 0
-}
-
-private class FakeTeamRepo(private val existingSlugs: Set<Slug> = emptySet()) : TeamRepository {
-    override fun findAllSchemaNames(): List<SchemaName> = emptyList()
-    override fun existsBySlug(slug: Slug): Boolean = slug in existingSlugs
-    override fun findByUserId(userId: UUID): TeamSummary? = null
-}
 
 private class FakeCodeRepo(private val redeemable: Boolean) : TeamCreationCodeRepository {
     override fun isRedeemable(code: CreationCode, now: Instant): Boolean = redeemable
@@ -86,7 +51,8 @@ private class RecordingProvisioner(private val calls: MutableList<String>, priva
 
 private class RecordingRegistrar(
     private val calls: MutableList<String>,
-    private val teamId: TeamId,
+    private val directory: TeamDirectory,
+    private val founder: UserId,
 ) : TeamRegistrationGateway {
     override fun register(
         creationCode: CreationCode,
@@ -97,14 +63,9 @@ private class RecordingRegistrar(
         now: Instant,
     ): TeamId {
         calls += "register:$slug"
-        return teamId
+        // What the real registrar commits in one transaction: the team row plus the founding admin.
+        return directory.addTeam(name.value, slug.value).also { directory.join(founder, it, Role.ADMIN) }
     }
-}
-
-private class FakeUserRepo(private val user: User?) : UserRepository {
-    override fun findById(id: UserId): User? = user
-    override fun findByEmail(email: Email): User? = null
-    override fun save(user: User): User = user
 }
 
 private class RecordingNotifier(private val throwing: Boolean = false) : TeamNotificationGateway {
@@ -124,46 +85,80 @@ class TeamServiceTest : FunSpec() {
     init {
         val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
         val founder = UserId.random()
-        val newTeamId = TeamId(UUID.randomUUID())
         val founderUser = User(id = founder, email = Email("founder@example.com"), displayName = DisplayName("Founder"))
 
-        fun service(
+        // The registrar is faked, so the directory has to be told what a successful register() would
+        // have written: the Team row and the founder's ADMIN membership. Handing that to
+        // RecordingRegistrar keeps "the founder is a Member as of register()" true here too — which is
+        // exactly the precondition the Active Team switch that follows it depends on.
+        fun fixture(
             calls: MutableList<String> = mutableListOf(),
-            existingTeam: TeamId? = null,
             existingSlugs: Set<Slug> = emptySet(),
             redeemable: Boolean = true,
             provisionFails: Boolean = false,
             user: User? = founderUser,
             notifier: TeamNotificationGateway = RecordingNotifier(),
-        ) = TeamService(
-            teamMemberRepository = FakeMemberRepo(existingTeam),
-            teamRepository = FakeTeamRepo(existingSlugs),
-            creationCodeRepository = FakeCodeRepo(redeemable),
-            tenantProvisioningGateway = RecordingProvisioner(calls, provisionFails),
-            teamRegistrationGateway = RecordingRegistrar(calls, newTeamId),
-            userRepository = FakeUserRepo(user),
-            teamNotificationGateway = notifier,
-            clock = clock,
-        )
+        ): Triple<TeamDirectory, RecordingTenantRoutingGateway, TeamService> {
+            val directory = TeamDirectory()
+            existingSlugs.forEach { directory.addTeam(it.value, it.value) }
+            val gateway = RecordingTenantRoutingGateway()
+            val service = TeamService(
+                teamRepository = directory.teamRepository(),
+                creationCodeRepository = FakeCodeRepo(redeemable),
+                tenantProvisioningGateway = RecordingProvisioner(calls, provisionFails),
+                teamRegistrationGateway = RecordingRegistrar(calls, directory, founder),
+                userRepository = directory.userRepository(*listOfNotNull(user).toTypedArray()),
+                teamNotificationGateway = notifier,
+                activeTeamService = directory.activeTeamService(gateway, *listOfNotNull(user).toTypedArray()),
+                clock = clock,
+            )
+            return Triple(directory, gateway, service)
+        }
+
+        fun service(
+            calls: MutableList<String> = mutableListOf(),
+            existingSlugs: Set<Slug> = emptySet(),
+            redeemable: Boolean = true,
+            provisionFails: Boolean = false,
+            user: User? = founderUser,
+            notifier: TeamNotificationGateway = RecordingNotifier(),
+        ) = fixture(calls, existingSlugs, redeemable, provisionFails, user, notifier).third
 
         test("creates the team: provisions the schema, registers, and returns id/name/slug") {
             val calls = mutableListOf<String>()
-            val created = service(calls).createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
+            val (directory, _, service) = fixture(calls)
+            val created = service.createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
 
-            created.id shouldBe newTeamId
+            directory.summaryOf(created.id).slug shouldBe Slug("setpoint-vt")
             created.name shouldBe TeamName("Setpoint VT")
             created.slug shouldBe Slug("setpoint-vt")
             // Provision-first: the schema is created before the atomic register commits.
             calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
         }
 
-        test("rejects a founder who already belongs to a team, without provisioning") {
+        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4): it existed only to match a
+        // routing layer that could hold one Team per user, and that constraint is gone.
+        test("a founder who already plays in a team may create another") {
             val calls = mutableListOf<String>()
-            shouldThrow<AlreadyInTeamException> {
-                service(calls, existingTeam = TeamId(UUID.randomUUID()))
-                    .createTeam(founder, "New Team", "new-team", CreationCode("GOODCODE"))
-            }
-            calls shouldBe emptyList()
+            val (directory, _, service) = fixture(calls)
+            directory.join(founder, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+
+            val created = service.createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
+
+            created.name shouldBe TeamName("Setpoint VT")
+            calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
+        }
+
+        // Without this the founder would create a Team and stay routed to the one they were already
+        // in — the new Team would exist and be invisible to the person who made it.
+        test("the new team becomes the founder's Active Team") {
+            val (directory, gateway, service) = fixture()
+            directory.join(founder, directory.addTeam("Tovo Heren 5", "tovo-heren-5"))
+
+            val created = service.createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
+
+            directory.rememberedTeamOf(founder) shouldBe created.id
+            gateway.lastPinned.shouldNotBeNull().schemaName shouldBe directory.schemaOf(created.id)
         }
 
         test("rejects a blank name with 400 before any provisioning") {
@@ -214,9 +209,9 @@ class TeamServiceTest : FunSpec() {
         }
 
         test("a failing notifier never fails a committed creation (fire-and-forget)") {
-            val created = service(notifier = RecordingNotifier(throwing = true))
-                .createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
-            created.id shouldBe newTeamId
+            val (directory, _, service) = fixture(notifier = RecordingNotifier(throwing = true))
+            val created = service.createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
+            directory.summaryOf(created.id).name shouldBe TeamName("Setpoint VT")
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -136,7 +136,7 @@ class TeamServiceTest : FunSpec() {
             calls shouldContainExactly listOf("provision:team_setpoint_vt", "register:setpoint-vt")
         }
 
-        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4): it existed only to match a
+        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0023 §4): it existed only to match a
         // routing layer that could hold one Team per user, and that constraint is gone.
         test("a founder who already plays in a team may create another") {
             val calls = mutableListOf<String>()

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGatewayAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGatewayAdapterTest.kt
@@ -4,6 +4,7 @@ import com.github.zzave.teambalance.api.domain.exception.NotPlatformAdminExcepti
 import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
 import com.github.zzave.teambalance.api.domain.model.PlatformAdminAllowlist
+import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.User
 import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.UserRepository
@@ -17,6 +18,8 @@ private class FakeUsers(private val byId: Map<UUID, User>) : UserRepository {
     override fun findById(id: UserId): User? = byId[id.value]
     override fun findByEmail(email: Email): User? = byId.values.firstOrNull { it.email == email }
     override fun save(user: User): User = user
+    override fun findLastActiveTeamId(userId: UserId): TeamId? = null
+    override fun rememberActiveTeam(userId: UserId, teamId: TeamId) = Unit
 }
 
 class PlatformAdminGatewayAdapterTest : FunSpec() {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -1,21 +1,26 @@
 package com.github.zzave.teambalance.api.infrastructure.multitenancy
 
 import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.application.ActiveTeamService
+import com.github.zzave.teambalance.api.domain.model.TeamId
+import com.github.zzave.teambalance.api.domain.model.UserId
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
-import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
 import com.github.zzave.teambalance.api.infrastructure.identity.UserContext
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockHttpSession
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
 import java.util.UUID
 
 class SessionTenantContextFilterTest : TeamBalanceIT() {
 
     @Autowired
-    lateinit var teamMemberRepository: TeamMemberRepository
+    lateinit var activeTeamService: ActiveTeamService
 
     @Autowired
     lateinit var currentUserGateway: CurrentUserGateway
@@ -77,6 +82,52 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
             second.teamId shouldBe teamId
         }
 
+        // The memo is a CORRECTNESS concern since #143, not a cache (ADR-0021 §2): it is what says
+        // which Team the request is scoped to. This is the direct test that a switch overwrites it —
+        // a switch that did not would leave the very next request reading the previous tenant.
+        test("switching the Active Team overwrites the session memo, so the next request follows") {
+            tenantSchemaAdapter.provisionPlatformSchema()
+            val userId = UUID.randomUUID()
+            val first = UUID.randomUUID()
+            val second = UUID.randomUUID()
+            seedMember(userId, first, schemaFor(first))
+            seedTeam(second, schemaFor(second))
+            seedMembership(userId, second)
+
+            val session = MockHttpSession()
+
+            // Land in `first` explicitly, then memoize it by taking one request through the filter.
+            activate(userId, first, session)
+            UserContext.set(userId)
+            runFilter(session).schema shouldBe schemaFor(first)
+
+            activate(userId, second, session)
+
+            UserContext.set(userId)
+            val afterSwitch = runFilter(session)
+            afterSwitch.schema shouldBe schemaFor(second)
+            afterSwitch.teamId shouldBe second
+        }
+
+        // The other half of the same guarantee: a refused switch must not disturb the memo either, or
+        // a probe for someone else's Team would knock the caller out of their own.
+        test("a refused switch leaves the memo — and the Active Team — exactly as it was") {
+            tenantSchemaAdapter.provisionPlatformSchema()
+            val userId = UUID.randomUUID()
+            val mine = UUID.randomUUID()
+            val theirs = UUID.randomUUID()
+            seedMember(userId, mine, schemaFor(mine))
+            seedTeam(theirs, schemaFor(theirs))
+
+            val session = MockHttpSession()
+            activate(userId, mine, session)
+
+            activateExpectingRefusal(userId, theirs, session)
+
+            UserContext.set(userId)
+            runFilter(session).schema shouldBe schemaFor(mine)
+        }
+
         test("session user with no team_members row falls through with no silent fallback") {
             tenantSchemaAdapter.provisionPlatformSchema()
             val userId = UUID.randomUUID()
@@ -96,25 +147,60 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
         }
     }
 
+    private fun schemaFor(teamId: UUID) = "team_${teamId.toString().replace("-", "")}"
+
     private fun seedMember(userId: UUID, teamId: UUID, schemaName: String) {
         jdbcTemplate.update(
             "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
             userId, "member-$userId@test.com", "Test Member",
         )
+        seedTeam(teamId, schemaName)
+        seedMembership(userId, teamId)
+    }
+
+    private fun seedTeam(teamId: UUID, schemaName: String) {
         jdbcTemplate.update(
             "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
             teamId, "Test Team", "test-team-$teamId", schemaName,
         )
+    }
+
+    private fun seedMembership(userId: UUID, teamId: UUID) {
         jdbcTemplate.update(
             "INSERT INTO public.team_members (team_id, user_id, role) VALUES (?, ?, 'USER')",
             teamId, userId,
         )
     }
 
+    /**
+     * Performs a switch the way a request would: the routing gateway pins onto the session behind the
+     * request-scoped [HttpServletRequest] proxy, so the switch has to run inside a bound request — the
+     * same constraint the real controller runs under.
+     */
+    private fun activate(userId: UUID, teamId: UUID, session: MockHttpSession) =
+        inBoundRequest(session) {
+            activeTeamService.activate(UserId(userId), TeamId(teamId)).shouldNotBeNull()
+        }
+
+    private fun activateExpectingRefusal(userId: UUID, teamId: UUID, session: MockHttpSession) =
+        inBoundRequest(session) {
+            activeTeamService.activate(UserId(userId), TeamId(teamId)) shouldBe null
+        }
+
+    private fun <T> inBoundRequest(session: MockHttpSession, block: () -> T): T {
+        val request = MockHttpServletRequest().apply { setSession(session) }
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+        try {
+            return block()
+        } finally {
+            RequestContextHolder.resetRequestAttributes()
+        }
+    }
+
     private data class Resolved(val schema: String?, val teamId: UUID?, val wasSet: Boolean)
 
     private fun runFilter(session: MockHttpSession? = null): Resolved {
-        val filter = SessionTenantContextFilter(teamMemberRepository, currentUserGateway)
+        val filter = SessionTenantContextFilter(activeTeamService, currentUserGateway)
         val request = MockHttpServletRequest().apply { session?.let { setSession(it) } }
         var resolved = Resolved(null, null, false)
         filter.doFilter(request, MockHttpServletResponse()) { _, _ ->

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -82,7 +82,7 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
             second.teamId shouldBe teamId
         }
 
-        // The memo is a CORRECTNESS concern since #143, not a cache (ADR-0021 §2): it is what says
+        // The memo is a CORRECTNESS concern since #143, not a cache (ADR-0023 §2): it is what says
         // which Team the request is scoped to. This is the direct test that a switch overwrites it —
         // a switch that did not would leave the very next request reading the previous tenant.
         test("switching the Active Team overwrites the session memo, so the next request follows") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
@@ -1,0 +1,111 @@
+package com.github.zzave.teambalance.api.infrastructure.persistence
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.domain.model.Slug
+import com.github.zzave.teambalance.api.domain.port.TeamRepository
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.UUID
+
+/**
+ * The platform-level reads behind the Team switcher and the authorized switch (#143, ADR-0021).
+ * Both replaced an `ORDER BY tm.team_id LIMIT 1` that answered "the user's team" by picking one in
+ * UUID order — so what matters here is that a user with several Teams gets *all* of them, and that
+ * a slug resolves without saying anything about who may have it.
+ */
+class JdbcTeamRepositoryAdapterTest : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var teamRepository: TeamRepository
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    init {
+        test("findTeamsOf returns every active membership, not one of them") {
+            val userId = seedUser()
+            val first = seedTeam("Zulu Squad")
+            val second = seedTeam("Alpha Squad")
+            seedMembership(userId, first)
+            seedMembership(userId, second)
+
+            teamRepository.findTeamsOf(userId).map { it.name.value } shouldBe listOf("Alpha Squad", "Zulu Squad")
+        }
+
+        test("findTeamsOf drops a deactivated membership") {
+            val userId = seedUser()
+            val stays = seedTeam("Stays")
+            val left = seedTeam("Left")
+            seedMembership(userId, stays)
+            seedMembership(userId, left, active = false)
+
+            teamRepository.findTeamsOf(userId).map { it.name.value } shouldBe listOf("Stays")
+        }
+
+        test("findTeamsOf is empty for a teamless user") {
+            teamRepository.findTeamsOf(seedUser()).shouldBeEmpty()
+        }
+
+        // Team names are deliberately not unique (the slug is the unique address), so the order has
+        // to be TOTAL or the switcher list reshuffles between requests. Which of the two comes first
+        // is not the point and is not asserted — that it is the same one every time is.
+        test("findTeamsOf orders stably when two teams share a name") {
+            val userId = seedUser()
+            seedMembership(userId, seedTeam("Heren 3"))
+            seedMembership(userId, seedTeam("Heren 3"))
+
+            val first = teamRepository.findTeamsOf(userId).map { it.id.value }
+            first shouldHaveSize 2
+            repeat(3) { teamRepository.findTeamsOf(userId).map { it.id.value } shouldBe first }
+        }
+
+        // The slug is a Team's public address, so resolving one says nothing about membership —
+        // authorization is a separate step, and keeping them separate is what lets "not yours" and
+        // "no such team" answer identically at the edge.
+        test("findBySlug resolves a team regardless of who is asking") {
+            val teamId = seedTeam("Someone Else's Team", slug = "someone-elses-team")
+
+            teamRepository.findBySlug(Slug("someone-elses-team")).shouldNotBeNull().id.value shouldBe teamId
+        }
+
+        test("findBySlug is null for an unknown slug") {
+            teamRepository.findBySlug(Slug("no-such-team-${UUID.randomUUID()}")).shouldBeNull()
+        }
+    }
+
+    private fun seedUser(): UUID {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        val userId = UUID.randomUUID()
+        jdbcTemplate.update(
+            "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
+            userId, "teams-$userId@test.com", "Test Member",
+        )
+        return userId
+    }
+
+    private fun seedTeam(name: String, slug: String? = null): UUID {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        val teamId = UUID.randomUUID()
+        jdbcTemplate.update(
+            "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
+            teamId, name, slug ?: "team-$teamId", "team_${teamId.toString().replace("-", "")}",
+        )
+        return teamId
+    }
+
+    private fun seedMembership(userId: UUID, teamId: UUID, active: Boolean = true) {
+        jdbcTemplate.update(
+            "INSERT INTO public.team_members (team_id, user_id, role, active) VALUES (?, ?, 'USER', ?)",
+            teamId, userId, active,
+        )
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
@@ -14,10 +14,8 @@ import org.springframework.jdbc.core.JdbcTemplate
 import java.util.UUID
 
 /**
- * The platform-level reads behind the Team switcher and the authorized switch (#143, ADR-0023).
- * Both replaced an `ORDER BY tm.team_id LIMIT 1` that answered "the user's team" by picking one in
- * UUID order — so what matters here is that a user with several Teams gets *all* of them, and that
- * a slug resolves without saying anything about who may have it.
+ * The platform-level reads behind the Team switcher and the authorized switch (ADR-0023): a user
+ * with several Teams gets *all* of them, and a slug resolves without saying who may have it.
  */
 class JdbcTeamRepositoryAdapterTest : TeamBalanceIT() {
 
@@ -55,9 +53,8 @@ class JdbcTeamRepositoryAdapterTest : TeamBalanceIT() {
             teamRepository.findTeamsOf(seedUser()).shouldBeEmpty()
         }
 
-        // Team names are deliberately not unique (the slug is the unique address), so the order has
-        // to be TOTAL or the switcher list reshuffles between requests. Which of the two comes first
-        // is not the point and is not asserted — that it is the same one every time is.
+        // Team names are deliberately not unique, so the order must be TOTAL. Which one comes first
+        // is not asserted; that it is the same one every time is.
         test("findTeamsOf orders stably when two teams share a name") {
             val userId = seedUser()
             seedMembership(userId, seedTeam("Heren 3"))
@@ -68,9 +65,6 @@ class JdbcTeamRepositoryAdapterTest : TeamBalanceIT() {
             repeat(3) { teamRepository.findTeamsOf(userId).map { it.id.value } shouldBe first }
         }
 
-        // The slug is a Team's public address, so resolving one says nothing about membership —
-        // authorization is a separate step, and keeping them separate is what lets "not yours" and
-        // "no such team" answer identically at the edge.
         test("findBySlug resolves a team regardless of who is asking") {
             val teamId = seedTeam("Someone Else's Team", slug = "someone-elses-team")
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRepositoryAdapterTest.kt
@@ -14,7 +14,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import java.util.UUID
 
 /**
- * The platform-level reads behind the Team switcher and the authorized switch (#143, ADR-0021).
+ * The platform-level reads behind the Team switcher and the authorized switch (#143, ADR-0023).
  * Both replaced an `ORDER BY tm.team_id LIMIT 1` that answered "the user's team" by picking one in
  * UUID order — so what matters here is that a user with several Teams gets *all* of them, and that
  * a slug resolves without saying anything about who may have it.

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -66,7 +66,7 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
             teamMemberRepository.findByTeamId(teamId).first { it.userId == userId }.onboarded shouldBe true
         }
 
-        // The tenant-resolution seam (ADR-0021 §1). Only a real database can prove these: the team id
+        // The tenant-resolution seam (ADR-0023 §1). Only a real database can prove these: the team id
         // is a parameter and the membership predicate IS the authorization, so the SQL is the check.
         test("findTenantRouting resolves schema and team id together for a member of that team") {
             val (teamId, userId) = seedMember(role = "USER", active = true)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -66,8 +66,7 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
             teamMemberRepository.findByTeamId(teamId).first { it.userId == userId }.onboarded shouldBe true
         }
 
-        // The tenant-resolution seam (ADR-0023 §1). Only a real database can prove these: the team id
-        // is a parameter and the membership predicate IS the authorization, so the SQL is the check.
+        // The membership predicate IS the authorization, so only a real database proves these.
         test("findTenantRouting resolves schema and team id together for a member of that team") {
             val (teamId, userId) = seedMember(role = "USER", active = true)
             val routing = teamMemberRepository.findTenantRouting(teamId, userId)
@@ -92,7 +91,6 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
             teamMemberRepository.findSoleTenantRouting(userId)?.teamId shouldBe teamId
         }
 
-        // The deleted `ORDER BY team_id LIMIT 1` answered here with an arbitrary UUID-ordered pick.
         test("findSoleTenantRouting is null once the user belongs to two teams") {
             val (_, userId) = seedMember(role = "USER", active = true)
             val (second, _) = seedMember(role = "USER", active = true)
@@ -106,8 +104,7 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
         }
 
         // (team_id, user_id) is UNIQUE and a removed member keeps a deactivated row, so an INSERT
-        // cannot re-join them. Before this was handled, accepting a fresh invite answered 200 while
-        // silently leaving them out of the team — and, since #143, failing to switch them into it.
+        // cannot re-join them.
         test("addMember re-joins a previously removed member by reactivating their row") {
             val (teamId, userId) = seedMember(role = "USER", active = true)
             teamMemberRepository.deactivate(teamId, userId)
@@ -119,8 +116,6 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
             teamMemberRepository.findTenantRouting(teamId, userId)?.teamId shouldBe teamId
         }
 
-        // A removed admin walking back in through a shared invite link must not arrive holding their
-        // old admin rights: addMember joins as a USER, and re-joining is joining.
         test("a removed admin re-joins as a plain USER, not as an admin") {
             val (teamId, userId) = seedMember(role = "ADMIN", active = true)
             teamMemberRepository.deactivate(teamId, userId)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -65,12 +65,53 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
             teamMemberRepository.markOnboarded(teamId, userId, Instant.parse("2026-07-22T10:00:00Z"))
             teamMemberRepository.findByTeamId(teamId).first { it.userId == userId }.onboarded shouldBe true
         }
+
+        // The tenant-resolution seam (ADR-0021 §1). Only a real database can prove these: the team id
+        // is a parameter and the membership predicate IS the authorization, so the SQL is the check.
+        test("findTenantRouting resolves schema and team id together for a member of that team") {
+            val (teamId, userId) = seedMember(role = "USER", active = true)
+            val routing = teamMemberRepository.findTenantRouting(teamId, userId)
+            routing?.teamId shouldBe teamId
+            routing?.schemaName?.value shouldBe schemaNameOf(teamId)
+        }
+
+        test("findTenantRouting is null for a team the user is not a member of") {
+            val (teamId, _) = seedMember(role = "USER", active = true)
+            val (_, stranger) = seedMember(role = "USER", active = true)
+            teamMemberRepository.findTenantRouting(teamId, stranger) shouldBe null
+        }
+
+        test("findTenantRouting is null once the membership is deactivated") {
+            val (teamId, userId) = seedMember(role = "USER", active = true)
+            teamMemberRepository.deactivate(teamId, userId)
+            teamMemberRepository.findTenantRouting(teamId, userId) shouldBe null
+        }
+
+        test("findSoleTenantRouting resolves the only team a user belongs to") {
+            val (teamId, userId) = seedMember(role = "USER", active = true)
+            teamMemberRepository.findSoleTenantRouting(userId)?.teamId shouldBe teamId
+        }
+
+        // The deleted `ORDER BY team_id LIMIT 1` answered here with an arbitrary UUID-ordered pick.
+        test("findSoleTenantRouting is null once the user belongs to two teams") {
+            val (_, userId) = seedMember(role = "USER", active = true)
+            val (second, _) = seedMember(role = "USER", active = true)
+            teamMemberRepository.addMember(second, userId)
+
+            teamMemberRepository.findSoleTenantRouting(userId) shouldBe null
+        }
+
+        test("findSoleTenantRouting is null for a user with no team at all") {
+            teamMemberRepository.findSoleTenantRouting(UserId(seedUser())) shouldBe null
+        }
     }
+
+    private fun schemaNameOf(teamId: TeamId) = "team_${teamId.value.toString().replace("-", "")}"
 
     private fun seedMember(role: String, active: Boolean): Pair<TeamId, UserId> {
         tenantSchemaAdapter.provisionPlatformSchema()
         val teamId = TeamId(UUID.randomUUID())
-        val schemaName = "team_${teamId.toString().replace("-", "")}"
+        val schemaName = schemaNameOf(teamId)
         jdbcTemplate.update(
             "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
             teamId.value, "Test Team", "test-team-$teamId", schemaName,
@@ -79,12 +120,18 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
         return teamId to userId
     }
 
-    private fun seedMemberOnTeam(teamId: TeamId, role: String, active: Boolean): UserId {
-        val userId = UserId.random()
+    private fun seedUser(): UUID {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        val userId = UUID.randomUUID()
         jdbcTemplate.update(
             "INSERT INTO public.users (id, email, display_name) VALUES (?, ?, ?)",
-            userId.value, "member-$userId@test.com", "Test Member",
+            userId, "member-$userId@test.com", "Test Member",
         )
+        return userId
+    }
+
+    private fun seedMemberOnTeam(teamId: TeamId, role: String, active: Boolean): UserId {
+        val userId = UserId(seedUser())
         jdbcTemplate.update(
             "INSERT INTO public.team_members (team_id, user_id, role, active) VALUES (?, ?, ?, ?)",
             teamId.value, userId.value, role, active,

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapterTest.kt
@@ -104,6 +104,39 @@ class JpaTeamMemberRepositoryAdapterTest : TeamBalanceIT() {
         test("findSoleTenantRouting is null for a user with no team at all") {
             teamMemberRepository.findSoleTenantRouting(UserId(seedUser())) shouldBe null
         }
+
+        // (team_id, user_id) is UNIQUE and a removed member keeps a deactivated row, so an INSERT
+        // cannot re-join them. Before this was handled, accepting a fresh invite answered 200 while
+        // silently leaving them out of the team — and, since #143, failing to switch them into it.
+        test("addMember re-joins a previously removed member by reactivating their row") {
+            val (teamId, userId) = seedMember(role = "USER", active = true)
+            teamMemberRepository.deactivate(teamId, userId)
+            teamMemberRepository.findRole(teamId, userId) shouldBe null
+
+            teamMemberRepository.addMember(teamId, userId)
+
+            teamMemberRepository.findRole(teamId, userId) shouldBe Role.USER
+            teamMemberRepository.findTenantRouting(teamId, userId)?.teamId shouldBe teamId
+        }
+
+        // A removed admin walking back in through a shared invite link must not arrive holding their
+        // old admin rights: addMember joins as a USER, and re-joining is joining.
+        test("a removed admin re-joins as a plain USER, not as an admin") {
+            val (teamId, userId) = seedMember(role = "ADMIN", active = true)
+            teamMemberRepository.deactivate(teamId, userId)
+
+            teamMemberRepository.addMember(teamId, userId)
+
+            teamMemberRepository.findRole(teamId, userId) shouldBe Role.USER
+        }
+
+        test("addMember leaves an existing active member untouched, role and all") {
+            val (teamId, userId) = seedMember(role = "ADMIN", active = true)
+
+            teamMemberRepository.addMember(teamId, userId)
+
+            teamMemberRepository.findRole(teamId, userId) shouldBe Role.ADMIN
+        }
     }
 
     private fun schemaNameOf(teamId: TeamId) = "team_${teamId.value.toString().replace("-", "")}"

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
@@ -17,13 +17,13 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * The switch endpoint through the real HTTP boundary (#143, ADR-0021 §2): `POST /api/teams/{slug}/activate`,
+ * The switch endpoint through the real HTTP boundary (#143, ADR-0023 §2): `POST /api/teams/{slug}/activate`,
  * driven over a **real signed-in session** (magic-link verify, then the session cookie) rather than
  * the X-User-Id test shim. Two things can only be proven that way:
  *
  *  - **The session memo really is invalidated.** The Active Team is carried as a session attribute
  *    pair that every later request reads back without touching the database, so "the switch
- *    overwrote it" is a claim about a *subsequent request on the same session*. ADR-0021 calls a
+ *    overwrote it" is a claim about a *subsequent request on the same session*. ADR-0023 calls a
  *    missed invalidation here a cross-tenant read; this is the test that would catch one.
  *  - **"Not yours" is indistinguishable from "no such Team".** Both must answer byte-identically,
  *    or the slug space becomes a probe for which Teams exist on the platform.
@@ -106,7 +106,7 @@ class ActivateTeamControllerIT : TeamBalanceIT() {
 
             // A second sign-in for the same person — a new session, a new device. With two Teams open
             // and nothing remembered they would have to choose; the remembered Team is what makes the
-            // landing deterministic (ADR-0021 §3).
+            // landing deterministic (ADR-0023 §3).
             val fresh = signIn(email)
 
             activeTeamOnMe(fresh) shouldBe bravoSlug

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
@@ -17,16 +17,10 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * The switch endpoint through the real HTTP boundary (#143, ADR-0023 §2): `POST /api/teams/{slug}/activate`,
- * driven over a **real signed-in session** (magic-link verify, then the session cookie) rather than
- * the X-User-Id test shim. Two things can only be proven that way:
- *
- *  - **The session memo really is invalidated.** The Active Team is carried as a session attribute
- *    pair that every later request reads back without touching the database, so "the switch
- *    overwrote it" is a claim about a *subsequent request on the same session*. ADR-0023 calls a
- *    missed invalidation here a cross-tenant read; this is the test that would catch one.
- *  - **"Not yours" is indistinguishable from "no such Team".** Both must answer byte-identically,
- *    or the slug space becomes a probe for which Teams exist on the platform.
+ * `POST /api/teams/{slug}/activate` over a **real signed-in session** (magic-link verify, then the
+ * session cookie) rather than the X-User-Id shim, because the two properties worth proving are both
+ * about a *subsequent request on the same session*: that the switch overwrote the session memo, and
+ * that "not yours" and "no such Team" answer byte-identically.
  */
 @AutoConfigureMockMvc
 class ActivateTeamControllerIT : TeamBalanceIT() {
@@ -66,8 +60,8 @@ class ActivateTeamControllerIT : TeamBalanceIT() {
 
             activate(secondSlug, session).andExpect(MockMvcResultMatchers.status().isOk)
 
-            // The load-bearing assertion: without the re-pin this still reads firstSlug, and every
-            // tenant-scoped read on this session lands in the previous Team's schema.
+            // Without the re-pin this still reads firstSlug, and every tenant-scoped read on this
+            // session lands in the previous Team's schema.
             activeTeamOnMe(session) shouldBe secondSlug
         }
 
@@ -85,8 +79,6 @@ class ActivateTeamControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isNotFound)
                 .andReturn().response.contentAsString
 
-            // Byte-identical, and carrying no discriminator either — the caller cannot tell which of
-            // the two happened, which is the whole point.
             notMine shouldBe notThere
             notMine.contains("code") shouldBe false
 
@@ -104,21 +96,18 @@ class ActivateTeamControllerIT : TeamBalanceIT() {
             seedMembership(first.userId, bravo)
             activate(bravoSlug, first).andExpect(MockMvcResultMatchers.status().isOk)
 
-            // A second sign-in for the same person — a new session, a new device. With two Teams open
-            // and nothing remembered they would have to choose; the remembered Team is what makes the
-            // landing deterministic (ADR-0023 §3).
+            // A new session, a new device: with two Teams open, the remembered one is what makes
+            // the landing deterministic rather than a choice (ADR-0023 §3).
             val fresh = signIn(email)
 
             activeTeamOnMe(fresh) shouldBe bravoSlug
             lastActiveTeamOf(first.userId) shouldBe bravo
-            // The other Team is still theirs — remembering one is not choosing between them.
-            teamSlugsOnMe(fresh) shouldBe listOf(alphaSlug, bravoSlug).sorted()
         }
     }
 
     // --- helpers ---------------------------------------------------------------------------------
 
-    /** A signed-in caller: the user the magic link resolved to, plus the session cookie to carry. */
+    /** The user the magic link resolved to, plus the session cookie to carry. */
     private data class SignedIn(val userId: UUID, val cookies: List<Cookie>)
 
     private fun signIn(email: String = "switcher-${UUID.randomUUID()}@test.com"): SignedIn {
@@ -167,7 +156,7 @@ class ActivateTeamControllerIT : TeamBalanceIT() {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn().response.contentAsString
 
-    /** The Active Team as the caller's own `/auth/me` reports it — i.e. what the next request resolves. */
+    /** The Active Team as `/auth/me` reports it — what the next request resolves. */
     private fun activeTeamOnMe(session: SignedIn): String? =
         Regex("\"activeTeam\":\\{[^}]*\"slug\":\"([^\"]+)\"").find(me(session))?.groupValues?.get(1)
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActivateTeamControllerIT.kt
@@ -1,0 +1,204 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.http.Cookie
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.security.MessageDigest
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The switch endpoint through the real HTTP boundary (#143, ADR-0021 §2): `POST /api/teams/{slug}/activate`,
+ * driven over a **real signed-in session** (magic-link verify, then the session cookie) rather than
+ * the X-User-Id test shim. Two things can only be proven that way:
+ *
+ *  - **The session memo really is invalidated.** The Active Team is carried as a session attribute
+ *    pair that every later request reads back without touching the database, so "the switch
+ *    overwrote it" is a claim about a *subsequent request on the same session*. ADR-0021 calls a
+ *    missed invalidation here a cross-tenant read; this is the test that would catch one.
+ *  - **"Not yours" is indistinguishable from "no such Team".** Both must answer byte-identically,
+ *    or the slug space becomes a probe for which Teams exist on the platform.
+ */
+@AutoConfigureMockMvc
+class ActivateTeamControllerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    init {
+        test("activating a Team the caller is a Member of returns it and remembers it as last-used") {
+            val session = signIn()
+            val (teamId, slug) = seedTeam()
+            seedMembership(session.userId, teamId)
+
+            activate(slug, session)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.slug").value(slug))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(teamId.toString()))
+
+            lastActiveTeamOf(session.userId) shouldBe teamId
+        }
+
+        test("the switch is what the next request on that session reads back as its tenant") {
+            val session = signIn()
+            val (firstTeam, firstSlug) = seedTeam()
+            val (secondTeam, secondSlug) = seedTeam()
+            seedMembership(session.userId, firstTeam)
+            seedMembership(session.userId, secondTeam)
+
+            activate(firstSlug, session).andExpect(MockMvcResultMatchers.status().isOk)
+            activeTeamOnMe(session) shouldBe firstSlug
+
+            activate(secondSlug, session).andExpect(MockMvcResultMatchers.status().isOk)
+
+            // The load-bearing assertion: without the re-pin this still reads firstSlug, and every
+            // tenant-scoped read on this session lands in the previous Team's schema.
+            activeTeamOnMe(session) shouldBe secondSlug
+        }
+
+        test("a Team the caller is not a Member of and an unknown slug are the same bare 404") {
+            val session = signIn()
+            val (mine, mySlug) = seedTeam()
+            val (_, theirSlug) = seedTeam()
+            seedMembership(session.userId, mine)
+            activate(mySlug, session).andExpect(MockMvcResultMatchers.status().isOk)
+
+            val notMine = activate(theirSlug, session)
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andReturn().response.contentAsString
+            val notThere = activate("no-such-team-${UUID.randomUUID()}", session)
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andReturn().response.contentAsString
+
+            // Byte-identical, and carrying no discriminator either — the caller cannot tell which of
+            // the two happened, which is the whole point.
+            notMine shouldBe notThere
+            notMine.contains("code") shouldBe false
+
+            // And a refused switch leaves the caller where they were, on the session and on the user.
+            activeTeamOnMe(session) shouldBe mySlug
+            lastActiveTeamOf(session.userId) shouldBe mine
+        }
+
+        test("the Active Team is remembered across a fresh sign-in, on a brand-new session") {
+            val email = "switcher-${UUID.randomUUID()}@test.com"
+            val first = signIn(email)
+            val (alpha, alphaSlug) = seedTeam()
+            val (bravo, bravoSlug) = seedTeam()
+            seedMembership(first.userId, alpha)
+            seedMembership(first.userId, bravo)
+            activate(bravoSlug, first).andExpect(MockMvcResultMatchers.status().isOk)
+
+            // A second sign-in for the same person — a new session, a new device. With two Teams open
+            // and nothing remembered they would have to choose; the remembered Team is what makes the
+            // landing deterministic (ADR-0021 §3).
+            val fresh = signIn(email)
+
+            activeTeamOnMe(fresh) shouldBe bravoSlug
+            lastActiveTeamOf(first.userId) shouldBe bravo
+            // The other Team is still theirs — remembering one is not choosing between them.
+            teamSlugsOnMe(fresh) shouldBe listOf(alphaSlug, bravoSlug).sorted()
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    /** A signed-in caller: the user the magic link resolved to, plus the session cookie to carry. */
+    private data class SignedIn(val userId: UUID, val cookies: List<Cookie>)
+
+    private fun signIn(email: String = "switcher-${UUID.randomUUID()}@test.com"): SignedIn {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        val rawToken = "activate-${UUID.randomUUID()}"
+        jdbcTemplate.update(
+            """
+            INSERT INTO public.magic_link_tokens (id, token_hash, email, expires_at, used_at, created_at)
+            VALUES (?, ?, ?, ?, NULL, now())
+            """,
+            UUID.randomUUID(),
+            sha256(rawToken),
+            email,
+            Timestamp.from(Instant.now().plusSeconds(900)),
+        )
+        val response = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/auth/magic-link/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"token":"$rawToken"}"""),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn().response
+
+        val userId = UUID.fromString(
+            Regex("\"id\":\"([^\"]+)\"").find(response.contentAsString)!!.groupValues[1],
+        )
+        return SignedIn(userId, response.cookies.toList())
+    }
+
+    private fun activate(slug: String, session: SignedIn) =
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/teams/$slug/activate").cookie(*session.cookies.toTypedArray()),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    private fun me(session: SignedIn): String =
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/auth/me").cookie(*session.cookies.toTypedArray()))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn().response.contentAsString
+
+    /** The Active Team as the caller's own `/auth/me` reports it — i.e. what the next request resolves. */
+    private fun activeTeamOnMe(session: SignedIn): String? =
+        Regex("\"activeTeam\":\\{[^}]*\"slug\":\"([^\"]+)\"").find(me(session))?.groupValues?.get(1)
+
+    private fun teamSlugsOnMe(session: SignedIn): List<String> {
+        val teams = Regex("\"teams\":\\[(.*?)]").find(me(session))?.groupValues?.get(1) ?: return emptyList()
+        return Regex("\"slug\":\"([^\"]+)\"").findAll(teams).map { it.groupValues[1] }.sorted().toList()
+    }
+
+    private fun lastActiveTeamOf(userId: UUID): UUID? = jdbcTemplate.queryForObject(
+        "SELECT last_active_team_id FROM public.users WHERE id = ?",
+        UUID::class.java,
+        userId,
+    )
+
+    private fun seedTeam(): Pair<UUID, String> {
+        val teamId = UUID.randomUUID()
+        val slug = "switch-${teamId.toString().take(8)}"
+        jdbcTemplate.update(
+            "INSERT INTO public.teams (id, name, slug, schema_name) VALUES (?, ?, ?, ?)",
+            teamId, "Switch Team", slug, "team_${teamId.toString().replace("-", "")}",
+        )
+        return teamId to slug
+    }
+
+    private fun seedMembership(userId: UUID, teamId: UUID) {
+        jdbcTemplate.update(
+            "INSERT INTO public.team_members (team_id, user_id, role) VALUES (?, ?, 'USER')",
+            teamId, userId,
+        )
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256").digest(value.toByteArray()).joinToString("") { "%02x".format(it) }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
@@ -197,7 +197,7 @@ class CreateTeamControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
-        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4). Both Teams exist afterwards and
+        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0023 §4). Both Teams exist afterwards and
         // both memberships are real — the routing layer no longer has an opinion about how many a
         // person may have.
         test("a founder already in a team may create a second one") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
@@ -155,11 +155,14 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             row["slug"] shouldBe "create-it-happy"
 
             // The read edge, the other direction: the same row mapped back through the port that
-            // powers /auth/me's has-a-team signal. Nothing asserted this mapping before.
-            val summary = teamRepository.findByUserId(UUID.fromString(founder)).shouldNotBeNull()
+            // powers /auth/me's has-any-team signal. Nothing asserted this mapping before.
+            val summary = teamRepository.findTeamsOf(UUID.fromString(founder)).single()
             summary.id shouldBe TeamId(UUID.fromString(teamId!!))
             summary.name shouldBe TeamName("Create IT Happy")
             summary.slug shouldBe Slug("create-it-happy")
+
+            // And addressable by its public slug, which is what /t/:slug/... resolves through.
+            teamRepository.findBySlug(Slug("create-it-happy")).shouldNotBeNull().id shouldBe summary.id
         }
 
         test("a consumed code cannot be reused — second use returns opaque 403") {
@@ -194,7 +197,10 @@ class CreateTeamControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
-        test("a founder already in a team gets 409 and the code stays unconsumed") {
+        // ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4). Both Teams exist afterwards and
+        // both memberships are real — the routing layer no longer has an opinion about how many a
+        // person may have.
+        test("a founder already in a team may create a second one") {
             val founder = UUID.randomUUID().toString()
             seedUser(founder, "already-${founder.take(8)}@test.com")
             seedCode("CT-FIRST-${founder.take(8)}")
@@ -204,16 +210,18 @@ class CreateTeamControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isCreated)
 
             createTeam(founder, "Create IT Second", "create-it-second", "CT-SECOND-${founder.take(8)}")
-                .andExpect(MockMvcResultMatchers.status().isConflict)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("ALREADY_IN_TEAM"))
+                .andExpect(MockMvcResultMatchers.status().isCreated)
 
-            // The one-team guard trips before the code is touched, so the second code is still redeemable.
-            val consumedAt = jdbcTemplate.queryForObject(
-                "SELECT consumed_at FROM public.team_creation_codes WHERE code = ?",
-                java.sql.Timestamp::class.java,
-                "CT-SECOND-${founder.take(8)}",
-            )
-            consumedAt shouldBe null
+            teamRepository.findTeamsOf(UUID.fromString(founder)).map { it.slug.value } shouldBe
+                listOf("create-it-first", "create-it-second")
+
+            // The Team they just made is where they land — the second create-team switched them.
+            jdbcTemplate.queryForObject(
+                "SELECT t.slug FROM public.users u JOIN public.teams t ON t.id = u.last_active_team_id " +
+                    "WHERE u.id = ?::uuid",
+                String::class.java,
+                founder,
+            ) shouldBe "create-it-second"
         }
 
         // The only end-to-end exercise of TeamRepository.existsBySlug: every other test of the

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -241,9 +241,14 @@ class EventControllerTest : TeamBalanceIT() {
 
             // Member ids unique to this test: integration tests share DB state and seed with
             // ON CONFLICT DO NOTHING, so reusing the shared ids would keep roles set by other tests.
-            val setterAId = "b0000000-0000-0000-0000-0000000000a1"
-            val setterBId = "b0000000-0000-0000-0000-0000000000a2"
-            val liberoId = "b0000000-0000-0000-0000-0000000000a3"
+            // Since #143 the uniqueness must hold ACROSS specs too, not just within this one: tenant
+            // routing resolves a sole membership and answers *nothing* for a user who turns out to
+            // belong to two Teams, so a user id shared with another spec's Team no longer resolves at
+            // all. It used to, by picking one of the two Teams in UUID order — the silent misrouting
+            // ADR-0021 removes. (These collided with EventControllerTenantIsolationTest's ALPHA_USER.)
+            val setterAId = "b0000000-0000-0000-0000-0000000000d1"
+            val setterBId = "b0000000-0000-0000-0000-0000000000d2"
+            val liberoId = "b0000000-0000-0000-0000-0000000000d3"
 
             jdbcTemplate.execute(
                 """

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventControllerTest.kt
@@ -245,7 +245,7 @@ class EventControllerTest : TeamBalanceIT() {
             // routing resolves a sole membership and answers *nothing* for a user who turns out to
             // belong to two Teams, so a user id shared with another spec's Team no longer resolves at
             // all. It used to, by picking one of the two Teams in UUID order — the silent misrouting
-            // ADR-0021 removes. (These collided with EventControllerTenantIsolationTest's ALPHA_USER.)
+            // ADR-0023 removes. (These collided with EventControllerTenantIsolationTest's ALPHA_USER.)
             val setterAId = "b0000000-0000-0000-0000-0000000000d1"
             val setterBId = "b0000000-0000-0000-0000-0000000000d2"
             val liberoId = "b0000000-0000-0000-0000-0000000000d3"

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.util.UUID
 
 // Spec-dedicated, and it has to stay that way: this user must belong to exactly ONE Team. Tenant
-// routing resolves a sole membership and answers nothing for a user in two Teams (ADR-0021 §1), so
+// routing resolves a sole membership and answers nothing for a user in two Teams (ADR-0023 §1), so
 // sharing this id with another spec's Team leaves every request here with no tenant. It used to
 // "work" by picking a Team in UUID order — which is the misrouting #143 fixes. (Was b…f1, shared
 // with ConcurrentSessionTenantIT.)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventTransactionBoundaryIT.kt
@@ -15,7 +15,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.util.UUID
 
-private const val ADMIN_USER_ID = "b0000000-0000-0000-0000-0000000000f1"
+// Spec-dedicated, and it has to stay that way: this user must belong to exactly ONE Team. Tenant
+// routing resolves a sole membership and answers nothing for a user in two Teams (ADR-0021 §1), so
+// sharing this id with another spec's Team leaves every request here with no tenant. It used to
+// "work" by picking a Team in UUID order — which is the misrouting #143 fixes. (Was b…f1, shared
+// with ConcurrentSessionTenantIT.)
+private const val ADMIN_USER_ID = "b0000000-0000-0000-0000-0000000000e1"
 
 // teams.schema_name is UNIQUE, so every IT that routes to the `public` tenant shares this one team.
 private const val TEAM_ID = "a0000000-0000-0000-0000-000000000001"

--- a/app/e2e-real/auth-guard.spec.ts
+++ b/app/e2e-real/auth-guard.spec.ts
@@ -30,8 +30,7 @@ test.describe('logout', () => {
     await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
 
     // The header no longer carries nav — the tab bar is the primary nav and Log out lives on the
-    // Profile page. Route there via the Profile tab, then tear the session down. Profile is
-    // team-scoped since #143, so its URL carries the Team slug (ADR-0023 §2).
+    // Profile page, whose URL is team-scoped (ADR-0023 §2).
     await page.getByRole('link', { name: 'Profile' }).click()
     await expect(page).toHaveURL(/\/t\/[^/]+\/profile\/?$/)
     await page.getByRole('button', { name: 'Log out' }).click()

--- a/app/e2e-real/auth-guard.spec.ts
+++ b/app/e2e-real/auth-guard.spec.ts
@@ -30,9 +30,10 @@ test.describe('logout', () => {
     await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
 
     // The header no longer carries nav — the tab bar is the primary nav and Log out lives on the
-    // Profile page. Route there via the Profile tab, then tear the session down.
+    // Profile page. Route there via the Profile tab, then tear the session down. Profile is
+    // team-scoped since #143, so its URL carries the Team slug (ADR-0021 §2).
     await page.getByRole('link', { name: 'Profile' }).click()
-    await expect(page).toHaveURL('/profile')
+    await expect(page).toHaveURL(/\/t\/[^/]+\/profile\/?$/)
     await page.getByRole('button', { name: 'Log out' }).click()
     await expect(page).toHaveURL('/login')
     await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()

--- a/app/e2e-real/auth-guard.spec.ts
+++ b/app/e2e-real/auth-guard.spec.ts
@@ -31,7 +31,7 @@ test.describe('logout', () => {
 
     // The header no longer carries nav — the tab bar is the primary nav and Log out lives on the
     // Profile page. Route there via the Profile tab, then tear the session down. Profile is
-    // team-scoped since #143, so its URL carries the Team slug (ADR-0021 §2).
+    // team-scoped since #143, so its URL carries the Team slug (ADR-0023 §2).
     await page.getByRole('link', { name: 'Profile' }).click()
     await expect(page).toHaveURL(/\/t\/[^/]+\/profile\/?$/)
     await page.getByRole('button', { name: 'Log out' }).click()

--- a/app/e2e-real/create-team.spec.ts
+++ b/app/e2e-real/create-team.spec.ts
@@ -39,9 +39,9 @@ test('create-team: a teamless founder enters code + name + slug and lands in the
   expect(tokenResponse.ok()).toBeTruthy()
   const { token } = await tokenResponse.json()
 
-  // 2. Click the emailed link → session established. The has-a-team gate routes the teamless founder
-  //    to /onboarding (proving they are NOT bounced to /login by the old teamless-user behaviour),
-  //    from where they click through to /create-team — the rare, code-gated path.
+  // 2. Click the emailed link → session established. The has-any-team gate routes the teamless
+  //    founder to /onboarding (proving they are NOT bounced to /login by the old teamless-user
+  //    behaviour), from where they click through to /create-team — the rare, code-gated path.
   await page.goto(`/auth/verify?token=${token}`)
   await expect(page.getByRole('heading', { name: /Welcome to TeamBalance/ })).toBeVisible({ timeout: 10_000 })
   await page.getByRole('button', { name: 'Create a team' }).click()
@@ -53,8 +53,9 @@ test('create-team: a teamless founder enters code + name + slug and lands in the
   await page.getByLabel('Creation code').fill(CREATION_CODE)
 
   // 4. Create → provisions the tenant schema + Flyway migrate in-request (allow for cold start),
-  //    makes the founder ADMIN, and lands on the team roster inside the brand-new team.
+  //    makes the founder ADMIN, makes the new team their Active Team, and lands on its roster. The
+  //    URL carries the new team's slug (ADR-0021 §2), which is also the proof the Active Team moved.
   await page.getByRole('button', { name: 'Create team' }).click()
-  await expect(page).toHaveURL(/\/team\/?$/, { timeout: 20_000 })
+  await expect(page).toHaveURL(new RegExp(`/t/${EXPECTED_SLUG}/team/?$`), { timeout: 20_000 })
   await expect(page.getByRole('heading', { name: 'Team' })).toBeVisible()
 })

--- a/app/e2e-real/create-team.spec.ts
+++ b/app/e2e-real/create-team.spec.ts
@@ -53,8 +53,8 @@ test('create-team: a teamless founder enters code + name + slug and lands in the
   await page.getByLabel('Creation code').fill(CREATION_CODE)
 
   // 4. Create → provisions the tenant schema + Flyway migrate in-request (allow for cold start),
-  //    makes the founder ADMIN, makes the new team their Active Team, and lands on its roster. The
-  //    URL carries the new team's slug (ADR-0023 §2), which is also the proof the Active Team moved.
+  //    makes the founder ADMIN, and lands on the new team's roster. The slug in the URL is also the
+  //    proof the Active Team moved.
   await page.getByRole('button', { name: 'Create team' }).click()
   await expect(page).toHaveURL(new RegExp(`/t/${EXPECTED_SLUG}/team/?$`), { timeout: 20_000 })
   await expect(page.getByRole('heading', { name: 'Team' })).toBeVisible()

--- a/app/e2e-real/create-team.spec.ts
+++ b/app/e2e-real/create-team.spec.ts
@@ -54,7 +54,7 @@ test('create-team: a teamless founder enters code + name + slug and lands in the
 
   // 4. Create → provisions the tenant schema + Flyway migrate in-request (allow for cold start),
   //    makes the founder ADMIN, makes the new team their Active Team, and lands on its roster. The
-  //    URL carries the new team's slug (ADR-0021 §2), which is also the proof the Active Team moved.
+  //    URL carries the new team's slug (ADR-0023 §2), which is also the proof the Active Team moved.
   await page.getByRole('button', { name: 'Create team' }).click()
   await expect(page).toHaveURL(new RegExp(`/t/${EXPECTED_SLUG}/team/?$`), { timeout: 20_000 })
   await expect(page.getByRole('heading', { name: 'Team' })).toBeVisible()

--- a/app/e2e-real/switch-team.spec.ts
+++ b/app/e2e-real/switch-team.spec.ts
@@ -1,23 +1,12 @@
 import { test, expect, request as playwrightRequest, type Page } from '@playwright/test'
 import { STORAGE_STATE, postAsSharedAdmin } from './helpers'
 
-// Real e2e: multi-Team membership and switching between Teams (#143, ADR-0023).
+// Real e2e: multi-Team membership and switching (ADR-0023). Justified under the PR gate as a new
+// cross-tenant seam — every other spec runs as a caller with exactly one Team, where tenant
+// resolution has only one possible answer.
 //
-// Justified under the PR gate as a genuinely new seam: this is a **cross-tenant** flow, and neither
-// the login nor the attendance flow exercises it. Every other spec runs as a caller with exactly one
-// Team, where tenant resolution has only one possible answer. What is proven here can only be proven
-// end to end:
-//
-//   - a second `team_members` row for one user is reachable, and both Teams stay visible to them
-//     (the state the deleted `ORDER BY team_id LIMIT 1` used to hide one half of);
-//   - accepting an invite makes the joined Team Active, so the joiner lands where they accepted;
-//   - switching re-routes the tenant — each Team's events list shows its own event and NOT the
-//     other's, across two real tenant schemas;
-//   - the choice survives a full page load, i.e. it reached `users.last_active_team_id` and the
-//     session memo agrees with it rather than still holding the Team they left.
-//
-// Idempotent across warm-DB re-runs: a per-run-unique joiner email is always freshly teamless (the
-// magic-link verify creates the user), and fresh invites are minted for both Teams every run.
+// Idempotent across warm-DB re-runs: the joiner email is per-run unique (so always freshly teamless)
+// and fresh invites are minted for both Teams every run.
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
 const BASE_URL = 'http://localhost:5173'
@@ -31,10 +20,7 @@ const SECOND = { name: 'E2E Second Team', slug: 'e2e-second-team', event: 'E2E S
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
-/**
- * Completes the one-time onboarding for [slug]'s Team and waits for its events home. Onboarding is
- * per-Team (`team_members.onboarded_at`), so this runs once per Team the joiner enters.
- */
+/** Onboarding is per-Team (`team_members.onboarded_at`), so this runs once per Team entered. */
 async function onboardInto(page: Page, slug: string, position?: string) {
   await expect(page).toHaveURL(new RegExp(`/t/${slug}/get-started`), { timeout: 15_000 })
   await expect(page.getByRole('heading', { name: 'Welcome to TeamBalance' })).toBeVisible()
@@ -61,9 +47,8 @@ async function signIn(email: string) {
 }
 
 test('a member of two teams switches, and the tenant data follows', async ({ page }) => {
-  // 1. As each Team's own admin: make sure the Team has a Position (onboarding requires one when the
-  //    Team has any, and this spec must not depend on another spec having created it) and mint a
-  //    fresh invite link.
+  // 1. As each Team's own admin: ensure a Position exists (onboarding requires one when the Team has
+  //    any, and this spec must not depend on another spec creating it) and mint a fresh invite.
   const firstAdmin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
   expect([201, 409]).toContain((await postAsSharedAdmin(firstAdmin, '/api/positions', { data: { label: 'Setter' } })).status())
   const firstInvite = await postAsSharedAdmin(firstAdmin, '/api/invitations')
@@ -96,12 +81,10 @@ test('a member of two teams switches, and the tenant data follows', async ({ pag
   await expect(page).toHaveURL(new RegExp(`/t/${FIRST.slug}/?$`), { timeout: 15_000 })
   await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })
 
-  // 3. Accept the SECOND Team's invite while already signed in and already in a Team. Two
-  //    team_members rows for one user — and the joined Team becomes Active, so they land in it.
+  // 3. Accept the SECOND Team's invite while already in a Team: two team_members rows for one user,
+  //    and the joined Team becomes Active.
   await page.goto(`/invite/${secondInviteToken}`)
-  // Onboarding is per-Team — joining a second Team means onboarding into it — so the second Team's
-  // own get-started runs here. That is itself worth seeing: it only happens because the gate moved
-  // from the root route down to /t/$slug, where the Active Team is settled.
+  // Onboarding is per-Team, so the second Team's own get-started runs here.
   await onboardInto(page, SECOND.slug)
 
   // The tenant followed: the second Team's event is here, the first Team's is not.
@@ -116,8 +99,7 @@ test('a member of two teams switches, and the tenant data follows', async ({ pag
   await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })
   await expect(page.getByText(SECOND.event)).toHaveCount(0)
 
-  // 5. The choice is remembered across a full page load: `/` re-resolves the Active Team from the
-  //    server, and it is the Team they switched to — not the one they were in before.
+  // 5. Remembered across a full page load: `/` re-resolves the Active Team from the server.
   await page.goto('/')
   await expect(page).toHaveURL(new RegExp(`/t/${FIRST.slug}/?$`), { timeout: 15_000 })
   await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })

--- a/app/e2e-real/switch-team.spec.ts
+++ b/app/e2e-real/switch-team.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, request as playwrightRequest, type Page } from '@playwright/test'
+import { STORAGE_STATE, postAsSharedAdmin } from './helpers'
+
+// Real e2e: multi-Team membership and switching between Teams (#143, ADR-0021).
+//
+// Justified under the PR gate as a genuinely new seam: this is a **cross-tenant** flow, and neither
+// the login nor the attendance flow exercises it. Every other spec runs as a caller with exactly one
+// Team, where tenant resolution has only one possible answer. What is proven here can only be proven
+// end to end:
+//
+//   - a second `team_members` row for one user is reachable, and both Teams stay visible to them
+//     (the state the deleted `ORDER BY team_id LIMIT 1` used to hide one half of);
+//   - accepting an invite makes the joined Team Active, so the joiner lands where they accepted;
+//   - switching re-routes the tenant — each Team's events list shows its own event and NOT the
+//     other's, across two real tenant schemas;
+//   - the choice survives a full page load, i.e. it reached `users.last_active_team_id` and the
+//     session memo agrees with it rather than still holding the Team they left.
+//
+// Idempotent across warm-DB re-runs: a per-run-unique joiner email is always freshly teamless (the
+// magic-link verify creates the user), and fresh invites are minted for both Teams every run.
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+const BASE_URL = 'http://localhost:5173'
+const RUN = Date.now()
+const JOINER_EMAIL = `switcher-${RUN}@example.com`
+const JOINER_NAME = `Switcher ${RUN}`
+const SECOND_ADMIN_EMAIL = 'e2e-second@example.com'
+
+const FIRST = { name: 'E2E Test Team', slug: 'e2e-test-team', event: 'E2E Training' }
+const SECOND = { name: 'E2E Second Team', slug: 'e2e-second-team', event: 'E2E Second Team Match' }
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+/**
+ * Completes the one-time onboarding for [slug]'s Team and waits for its events home. Onboarding is
+ * per-Team (`team_members.onboarded_at`), so this runs once per Team the joiner enters.
+ */
+async function onboardInto(page: Page, slug: string, position?: string) {
+  await expect(page).toHaveURL(new RegExp(`/t/${slug}/get-started`), { timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: 'Welcome to TeamBalance' })).toBeVisible()
+  await page.getByLabel('Display name').fill(JOINER_NAME)
+  if (position) {
+    await page.getByRole('combobox', { name: 'Position' }).click()
+    await page.getByRole('option', { name: position }).click()
+  }
+  await page.getByRole('button', { name: 'Save' }).click()
+  await expect(page).toHaveURL(new RegExp(`/t/${slug}/?$`), { timeout: 15_000 })
+}
+
+/** Signs an email in over the API and returns a request context carrying that session. */
+async function signIn(email: string) {
+  const context = await playwrightRequest.newContext({ baseURL: BASE_URL })
+  expect((await context.post('/api/auth/magic-link/request', { data: { email } })).status()).toBe(202)
+  const tokenResponse = await context.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+  expect((await context.post('/api/auth/magic-link/verify', { data: { token } })).ok()).toBeTruthy()
+  return context
+}
+
+test('a member of two teams switches, and the tenant data follows', async ({ page }) => {
+  // 1. As each Team's own admin: make sure the Team has a Position (onboarding requires one when the
+  //    Team has any, and this spec must not depend on another spec having created it) and mint a
+  //    fresh invite link.
+  const firstAdmin = await playwrightRequest.newContext({ baseURL: BASE_URL, storageState: STORAGE_STATE })
+  expect([201, 409]).toContain((await postAsSharedAdmin(firstAdmin, '/api/positions', { data: { label: 'Setter' } })).status())
+  const firstInvite = await postAsSharedAdmin(firstAdmin, '/api/invitations')
+  expect(firstInvite.status()).toBe(201)
+  const { token: firstInviteToken } = await firstInvite.json()
+  await firstAdmin.dispose()
+
+  const secondAdmin = await signIn(SECOND_ADMIN_EMAIL)
+  const secondInvite = await secondAdmin.post('/api/invitations')
+  expect(secondInvite.status()).toBe(201)
+  const { token: secondInviteToken } = await secondInvite.json()
+  await secondAdmin.dispose()
+
+  // 2. A brand-new user joins the FIRST Team through the ordinary invite → magic-link flow.
+  await page.goto(`/invite/${firstInviteToken}`)
+  await page.getByLabel('Email').fill(JOINER_EMAIL)
+  await page.getByRole('button', { name: 'Send magic link' }).click()
+  await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+  const tokenResponse = await page.request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email: JOINER_EMAIL },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+  await page.goto(`/auth/verify?token=${token}`)
+
+  await onboardInto(page, FIRST.slug, 'Setter')
+
+  // They land inside the first Team: the slug is in the URL, and the events are that Team's.
+  await expect(page).toHaveURL(new RegExp(`/t/${FIRST.slug}/?$`), { timeout: 15_000 })
+  await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })
+
+  // 3. Accept the SECOND Team's invite while already signed in and already in a Team. Two
+  //    team_members rows for one user — and the joined Team becomes Active, so they land in it.
+  await page.goto(`/invite/${secondInviteToken}`)
+  // Onboarding is per-Team — joining a second Team means onboarding into it — so the second Team's
+  // own get-started runs here. That is itself worth seeing: it only happens because the gate moved
+  // from the root route down to /t/$slug, where the Active Team is settled.
+  await onboardInto(page, SECOND.slug)
+
+  // The tenant followed: the second Team's event is here, the first Team's is not.
+  await expect(page.getByText(SECOND.event).first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByText(FIRST.event)).toHaveCount(0)
+
+  // 4. Switch back through the switcher, which names the Team it is in (ADR-0021 §3).
+  await page.getByRole('button', { name: new RegExp(`Current team: ${SECOND.name}`) }).click()
+  await page.getByRole('option', { name: new RegExp(FIRST.name) }).click()
+
+  await expect(page).toHaveURL(new RegExp(`/t/${FIRST.slug}/?$`), { timeout: 15_000 })
+  await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByText(SECOND.event)).toHaveCount(0)
+
+  // 5. The choice is remembered across a full page load: `/` re-resolves the Active Team from the
+  //    server, and it is the Team they switched to — not the one they were in before.
+  await page.goto('/')
+  await expect(page).toHaveURL(new RegExp(`/t/${FIRST.slug}/?$`), { timeout: 15_000 })
+  await expect(page.getByText(FIRST.event).first()).toBeVisible({ timeout: 15_000 })
+})

--- a/app/e2e-real/switch-team.spec.ts
+++ b/app/e2e-real/switch-team.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, request as playwrightRequest, type Page } from '@playwright/test'
 import { STORAGE_STATE, postAsSharedAdmin } from './helpers'
 
-// Real e2e: multi-Team membership and switching between Teams (#143, ADR-0021).
+// Real e2e: multi-Team membership and switching between Teams (#143, ADR-0023).
 //
 // Justified under the PR gate as a genuinely new seam: this is a **cross-tenant** flow, and neither
 // the login nor the attendance flow exercises it. Every other spec runs as a caller with exactly one
@@ -108,7 +108,7 @@ test('a member of two teams switches, and the tenant data follows', async ({ pag
   await expect(page.getByText(SECOND.event).first()).toBeVisible({ timeout: 15_000 })
   await expect(page.getByText(FIRST.event)).toHaveCount(0)
 
-  // 4. Switch back through the switcher, which names the Team it is in (ADR-0021 §3).
+  // 4. Switch back through the switcher, which names the Team it is in (ADR-0023 §3).
   await page.getByRole('button', { name: new RegExp(`Current team: ${SECOND.name}`) }).click()
   await page.getByRole('option', { name: new RegExp(FIRST.name) }).click()
 

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -16,8 +16,7 @@ const USER: AuthenticatedUser = {
   email: 'jan@example.com',
   displayName: 'Jan',
   role: 'USER',
-  // A confirmed Member with an Active Team, so the has-any-team gate passes and this test stays
-  // focused on the auth-confirmation seam (401 vs 200), not on team routing.
+  // A confirmed Member with an Active Team, so this stays focused on the auth-confirmation seam.
   teams: [TEAM],
   activeTeam: TEAM,
   isPlatformAdmin: false,

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -9,14 +9,17 @@ import type { AuthenticatedUser } from '@shared/api/auth'
 // fetch protected data) until the session is confirmed. An unconfirmed session — a 401 probe OR
 // any /me error — fails closed to the login screen.
 
+const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
+
 const USER: AuthenticatedUser = {
   id: 'user-1',
   email: 'jan@example.com',
   displayName: 'Jan',
   role: 'USER',
-  // A confirmed member of a team, so the has-a-team gate passes and this test stays focused on the
-  // auth-confirmation seam (401 vs 200), not team routing.
-  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
+  // A confirmed Member with an Active Team, so the has-any-team gate passes and this test stays
+  // focused on the auth-confirmation seam (401 vs 200), not on team routing.
+  teams: [TEAM],
+  activeTeam: TEAM,
   isPlatformAdmin: false,
 }
 

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -19,21 +19,27 @@ import { queryClient } from '@shared/api/query-client'
 let session: AuthenticatedUser | null = null
 let accepted = false
 
-// Pre-join: a teamless newbie (no role, no team). Accepting the invite makes them a member — see the
-// accept handler, which flips the session to [MEMBER] so the has-a-team gate passes on the landing.
+const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
+
+// Pre-join: a teamless newbie (no Role, no Teams). Accepting the invite makes them a Member — see
+// the accept handler, which flips the session to [MEMBER] so the has-any-team gate passes on the
+// landing. The joined Team comes back as the ACTIVE one, which is the server's job since ADR-0021
+// §4: accepting is no longer fire-and-forget, so the joiner lands where they just accepted.
 const USER: AuthenticatedUser = {
   id: 'user-1',
   email: 'newbie@example.com',
   displayName: 'newbie',
   role: undefined,
-  team: undefined,
+  teams: [],
+  activeTeam: undefined,
   isPlatformAdmin: false,
 }
 
 const MEMBER: AuthenticatedUser = {
   ...USER,
   role: 'USER',
-  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
+  teams: [TEAM],
+  activeTeam: TEAM,
 }
 
 const server = setupServer(
@@ -46,16 +52,17 @@ const server = setupServer(
     return HttpResponse.json(USER)
   }),
   http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
-  // The root onboarding gate reads /members/me; an onboarded member skips /get-started and lands on
-  // events, keeping this test focused on the invite/accept seam.
+  // The team route's onboarding gate reads /members/me; an onboarded member skips get-started and
+  // lands on events, keeping this test focused on the invite/accept seam.
   http.get('/api/members/me', () =>
     HttpResponse.json({ userId: 'user-1', displayName: 'newbie', role: 'USER', onboarded: true }),
   ),
   http.post('/api/invitations/:token/accept', ({ params }) => {
     if (params.token !== 'valid-invite-token') return new HttpResponse(null, { status: 404 })
     accepted = true
-    // Joining a team makes the caller a member — /auth/me now reports the team, so the has-a-team gate
-    // lets them land on events (the flow invalidates ['auth','me'] right after accept).
+    // Joining a Team makes the caller a Member of it AND makes it their Active Team, so /auth/me
+    // reports both and the has-any-team gate lets them land on that Team's events (the flow
+    // invalidates ['auth','me'] right after accept).
     session = MEMBER
     return HttpResponse.json({ teamId: 'team-1' })
   }),
@@ -87,7 +94,8 @@ describe('invite acceptance', () => {
     session = USER
     const router = renderAppAt('/invite/valid-invite-token')
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/'))
+    // `/` dispatches into the Active Team, which after accept is the Team they just joined.
+    await waitFor(() => expect(router.state.location.pathname).toBe('/t/setpoint-vt'))
     expect(await screen.findByRole('heading', { name: 'Events' })).toBeInTheDocument()
     expect(accepted).toBe(true)
   })
@@ -113,7 +121,7 @@ describe('invite acceptance', () => {
     // (localStorage survives), so the pending invite token saved on submit is still there.
     const verifyRouter = renderAppAt('/auth/verify?token=valid-token')
 
-    await waitFor(() => expect(verifyRouter.state.location.pathname).toBe('/'))
+    await waitFor(() => expect(verifyRouter.state.location.pathname).toBe('/t/setpoint-vt'))
     expect(await screen.findAllByRole('heading', { name: 'Events' })).not.toHaveLength(0)
     expect(accepted).toBe(true)
     expect(localStorage.getItem('tb-pending-invite-token')).toBeNull()

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -21,10 +21,8 @@ let accepted = false
 
 const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
 
-// Pre-join: a teamless newbie (no Role, no Teams). Accepting the invite makes them a Member — see
-// the accept handler, which flips the session to [MEMBER] so the has-any-team gate passes on the
-// landing. The joined Team comes back as the ACTIVE one, which is the server's job since ADR-0023
-// §4: accepting is no longer fire-and-forget, so the joiner lands where they just accepted.
+// Pre-join: a teamless newbie. The accept handler flips the session to [MEMBER], with the joined
+// Team ACTIVE — the server's job since ADR-0023 §4, so the joiner lands where they accepted.
 const USER: AuthenticatedUser = {
   id: 'user-1',
   email: 'newbie@example.com',
@@ -60,9 +58,7 @@ const server = setupServer(
   http.post('/api/invitations/:token/accept', ({ params }) => {
     if (params.token !== 'valid-invite-token') return new HttpResponse(null, { status: 404 })
     accepted = true
-    // Joining a Team makes the caller a Member of it AND makes it their Active Team, so /auth/me
-    // reports both and the has-any-team gate lets them land on that Team's events (the flow
-    // invalidates ['auth','me'] right after accept).
+    // /auth/me then reports both, so the gate lets them land on that Team's events.
     session = MEMBER
     return HttpResponse.json({ teamId: 'team-1' })
   }),

--- a/app/src/app/providers/invite-flow.test.tsx
+++ b/app/src/app/providers/invite-flow.test.tsx
@@ -23,7 +23,7 @@ const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
 
 // Pre-join: a teamless newbie (no Role, no Teams). Accepting the invite makes them a Member — see
 // the accept handler, which flips the session to [MEMBER] so the has-any-team gate passes on the
-// landing. The joined Team comes back as the ACTIVE one, which is the server's job since ADR-0021
+// landing. The joined Team comes back as the ACTIVE one, which is the server's job since ADR-0023
 // §4: accepting is no longer fire-and-forget, so the joiner lands where they just accepted.
 const USER: AuthenticatedUser = {
   id: 'user-1',

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -22,8 +22,7 @@ const USER: AuthenticatedUser = {
   email: 'jan@example.com',
   displayName: 'Jan',
   role: 'USER',
-  // A Member with an Active Team, so the has-any-team gate passes and `/` dispatches into that Team
-  // rather than to onboarding or the picker.
+  // A Member with an Active Team, so the gate passes and `/` dispatches into that Team.
   teams: [TEAM],
   activeTeam: TEAM,
   isPlatformAdmin: false,
@@ -67,8 +66,7 @@ describe('magic-link verification', () => {
   it('establishes the session and lands on events, without the guard bouncing back to login', async () => {
     const router = renderAppAt('/auth/verify?token=valid-token')
 
-    // `/` is a dispatcher now: it resolves the Active Team and redirects into `/t/:slug` (ADR-0023
-    // §2), so landing "on events" means landing on that Team's events.
+    // `/` is a dispatcher: it resolves the Active Team and redirects into `/t/:slug`.
     await waitFor(() => expect(router.state.location.pathname).toBe('/t/setpoint-vt'), { timeout: 5000 })
     expect(await screen.findByRole('heading', { name: 'Events' }, { timeout: 5000 })).toBeInTheDocument()
     expect(screen.queryByText(/link expired/i)).not.toBeInTheDocument()

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -67,7 +67,7 @@ describe('magic-link verification', () => {
   it('establishes the session and lands on events, without the guard bouncing back to login', async () => {
     const router = renderAppAt('/auth/verify?token=valid-token')
 
-    // `/` is a dispatcher now: it resolves the Active Team and redirects into `/t/:slug` (ADR-0021
+    // `/` is a dispatcher now: it resolves the Active Team and redirects into `/t/:slug` (ADR-0023
     // §2), so landing "on events" means landing on that Team's events.
     await waitFor(() => expect(router.state.location.pathname).toBe('/t/setpoint-vt'), { timeout: 5000 })
     expect(await screen.findByRole('heading', { name: 'Events' }, { timeout: 5000 })).toBeInTheDocument()

--- a/app/src/app/providers/verify-flow.test.tsx
+++ b/app/src/app/providers/verify-flow.test.tsx
@@ -15,13 +15,17 @@ import type { AuthenticatedUser } from '@shared/api/auth'
 // verify rather than racing it with a slower background fetch.
 let session: AuthenticatedUser | null = null
 
+const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
+
 const USER: AuthenticatedUser = {
   id: 'user-1',
   email: 'jan@example.com',
   displayName: 'Jan',
   role: 'USER',
-  // A member of a team, so the has-a-team gate passes and the flow lands on events (not /create-team).
-  team: { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' },
+  // A Member with an Active Team, so the has-any-team gate passes and `/` dispatches into that Team
+  // rather than to onboarding or the picker.
+  teams: [TEAM],
+  activeTeam: TEAM,
   isPlatformAdmin: false,
 }
 
@@ -34,8 +38,8 @@ const server = setupServer(
     return HttpResponse.json(USER)
   }),
   http.get('/api/auth/me', () => (session ? HttpResponse.json(session) : new HttpResponse(null, { status: 401 }))),
-  // The root onboarding gate reads /members/me; an onboarded member skips /get-started and lands on
-  // events, keeping this test focused on the verify/auth-routing seam.
+  // The team route's onboarding gate reads /members/me; an onboarded member skips get-started and
+  // lands on events, keeping this test focused on the verify/auth-routing seam.
   http.get('/api/members/me', () =>
     HttpResponse.json({ userId: 'user-1', displayName: 'Jan', role: 'USER', onboarded: true }),
   ),
@@ -63,7 +67,9 @@ describe('magic-link verification', () => {
   it('establishes the session and lands on events, without the guard bouncing back to login', async () => {
     const router = renderAppAt('/auth/verify?token=valid-token')
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/'), { timeout: 5000 })
+    // `/` is a dispatcher now: it resolves the Active Team and redirects into `/t/:slug` (ADR-0021
+    // §2), so landing "on events" means landing on that Team's events.
+    await waitFor(() => expect(router.state.location.pathname).toBe('/t/setpoint-vt'), { timeout: 5000 })
     expect(await screen.findByRole('heading', { name: 'Events' }, { timeout: 5000 })).toBeInTheDocument()
     expect(screen.queryByText(/link expired/i)).not.toBeInTheDocument()
   })

--- a/app/src/entities/event/ui/EventCard.tsx
+++ b/app/src/entities/event/ui/EventCard.tsx
@@ -7,6 +7,7 @@ import { EventDateChit } from './EventDateChit'
 import { EventTypeBadge } from './EventTypeBadge'
 import { ReferenceChips } from './ReferenceChips'
 import { RelativeTimeLabel } from './RelativeTimeLabel'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
 interface EventCardProps {
   event: Event
@@ -24,6 +25,7 @@ interface EventCardProps {
  * edge-to-edge under the chit and the whole thing reads as one card rather than two panes.
  */
 export function EventCard({ event, index = 0, now = new Date() }: EventCardProps) {
+  const routes = useTeamRoutes()
   const date = new Date(event.startTime)
   const { attendanceSummary: s } = event
   const invited = s.attending + s.maybe + s.absent + s.notResponded
@@ -48,8 +50,7 @@ export function EventCard({ event, index = 0, now = new Date() }: EventCardProps
           </div>
 
           <Link
-            to="/events/$eventId"
-            params={{ eventId: event.id }}
+            to={routes.event(event.id)}
             className="font-display mt-1 block text-[17px] font-medium leading-tight after:absolute after:inset-0"
           >
             {event.title}

--- a/app/src/entities/event/ui/SeriesPeek.tsx
+++ b/app/src/entities/event/ui/SeriesPeek.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { ChevronDown, Repeat } from 'lucide-react'
 import type { SeriesPeek as SeriesPeekModel, SeriesPeekEntry } from '../lib/series-peek'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
 interface SeriesPeekProps {
   peek: SeriesPeekModel
@@ -12,6 +13,7 @@ function formatOccurrence(iso: string): string {
 }
 
 function Occurrence({ entry }: { entry: SeriesPeekEntry }) {
+  const routes = useTeamRoutes()
   const label = formatOccurrence(entry.startTime)
   const content = (
     <div
@@ -30,7 +32,7 @@ function Occurrence({ entry }: { entry: SeriesPeekEntry }) {
     </div>
   )
   // The current occurrence is the page you're on — the rest link to their own detail.
-  return entry.isCurrent ? content : <Link to="/events/$eventId" params={{ eventId: entry.id }}>{content}</Link>
+  return entry.isCurrent ? content : <Link to={routes.event(entry.id)}>{content}</Link>
 }
 
 /**

--- a/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
@@ -86,11 +86,13 @@ export const NameOrSlugInvalid: Story = {
   },
 }
 
-export const AlreadyInTeam: Story = {
-  args: { error: new CreateTeamError('ALREADY_IN_TEAM', "You're already on a team.") },
+// The banner slot, now that ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4) and a founder
+// who already plays somewhere may start another Team: GENERIC is the only error with nowhere better
+// to go than a banner, so this story is what keeps that slot covered.
+export const GenericFailure: Story = {
+  args: { error: new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.') },
   play: async ({ canvas }) => {
-    // A banner (role=alert), not a field error — the container also redirects the user into their team.
-    await expect(canvas.getByRole('alert')).toHaveTextContent("You're already on a team.")
+    await expect(canvas.getByRole('alert')).toHaveTextContent('Something went wrong creating your team.')
   },
 }
 

--- a/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
@@ -86,7 +86,7 @@ export const NameOrSlugInvalid: Story = {
   },
 }
 
-// The banner slot, now that ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0021 §4) and a founder
+// The banner slot, now that ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0023 §4) and a founder
 // who already plays somewhere may start another Team: GENERIC is the only error with nowhere better
 // to go than a banner, so this story is what keeps that slot covered.
 export const GenericFailure: Story = {

--- a/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
@@ -86,9 +86,8 @@ export const NameOrSlugInvalid: Story = {
   },
 }
 
-// The banner slot, now that ADR-0019 §3's 409 ALREADY_IN_TEAM is lifted (ADR-0023 §4) and a founder
-// who already plays somewhere may start another Team: GENERIC is the only error with nowhere better
-// to go than a banner, so this story is what keeps that slot covered.
+// GENERIC is the only error with nowhere better to go than a banner, now that ADR-0023 lifted
+// ALREADY_IN_TEAM — so this story keeps that slot covered.
 export const GenericFailure: Story = {
   args: { error: new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.') },
   play: async ({ canvas }) => {

--- a/app/src/features/create-team/ui/CreateTeamForm.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.tsx
@@ -69,7 +69,7 @@ export function CreateTeamForm({ isPending, error, onSubmit, reassuranceDelayMs 
   const nameError = placed('INVALID_NAME')
   const slugError = placed('INVALID_SLUG', 'SLUG_TAKEN') ?? clientSlugError
   const codeError = placed('INVALID_CREATION_CODE')
-  const bannerError = placed('ALREADY_IN_TEAM', 'GENERIC')
+  const bannerError = placed('GENERIC')
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/app/src/features/edit-event/ui/DeleteEventDialog.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@shared/ui/button'
 import { useDeleteEvent, type Event } from '@shared/api/events'
 import { DeleteEventDialogView } from './DeleteEventDialogView'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
 interface DeleteEventDialogProps {
   eventId: string
@@ -29,6 +30,7 @@ interface DeleteEventDialogProps {
 export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEventDialogProps) {
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
+  const routes = useTeamRoutes()
   const deleteEvent = useDeleteEvent()
 
   const isSeries = siblings.length > 1
@@ -55,7 +57,9 @@ export function DeleteEventDialog({ eventId, title, siblings = [] }: DeleteEvent
           siblings={siblings}
           isPending={deleteEvent.isPending}
           isError={deleteEvent.isError}
-          onDelete={(scope) => deleteEvent.mutate({ id: eventId, scope }, { onSuccess: () => navigate({ to: '/' }) })}
+          onDelete={(scope) =>
+            deleteEvent.mutate({ id: eventId, scope }, { onSuccess: () => navigate({ to: routes.events }) })
+          }
           onCancel={() => setOpen(false)}
         />
       </DialogContent>

--- a/app/src/features/join-team/lib/use-join-team.ts
+++ b/app/src/features/join-team/lib/use-join-team.ts
@@ -7,11 +7,18 @@ const INVALID_OR_EXPIRED =
 const GENERIC = 'Something went wrong, try again.'
 
 /**
- * Thin wiring over useAcceptInvitation for the /onboarding/join route: on success, invalidates
- * /auth/me (same pattern as /invite/$token.tsx) and navigates home — the root gate then carries the
- * now-teamed user on to /get-started. useAcceptInvitation throws a single generic Error for both an
- * invalid and an expired token (the accept endpoint returns 404 for both, deliberately, so there's no
- * oracle); anything else (network failure, unexpected status) is treated as the generic failure.
+ * Thin wiring over useAcceptInvitation for the /onboarding/join route: on success, drops the cache
+ * and navigates to `/` — the dispatcher, which resolves the Active Team the server just set to the
+ * team they joined (ADR-0021 §4) and lands them in it, where the team route's gate carries them on
+ * to get-started.
+ *
+ * The cache is cleared rather than merely invalidating /auth/me (as /invite/\$token.tsx also does):
+ * a joiner may already have been in another Team, and every cached tenant-scoped query belongs to
+ * the one they were in. This is the same obligation `/t/\$slug`'s gate carries on a switch.
+ *
+ * useAcceptInvitation throws a single generic Error for both an invalid and an expired token (the
+ * accept endpoint returns 404 for both, deliberately, so there's no oracle); anything else (network
+ * failure, unexpected status) is treated as the generic failure.
  */
 export function useJoinTeam() {
   const client = useQueryClient()
@@ -20,8 +27,8 @@ export function useJoinTeam() {
 
   const join = (token: string) => {
     acceptInvitation.mutate(token, {
-      onSuccess: async () => {
-        await client.invalidateQueries({ queryKey: ['auth', 'me'] })
+      onSuccess: () => {
+        client.clear()
         navigate({ to: '/' })
       },
     })

--- a/app/src/features/join-team/lib/use-join-team.ts
+++ b/app/src/features/join-team/lib/use-join-team.ts
@@ -12,7 +12,7 @@ const GENERIC = 'Something went wrong, try again.'
  * team they joined (ADR-0021 §4) and lands them in it, where the team route's gate carries them on
  * to get-started.
  *
- * The cache is cleared rather than merely invalidating /auth/me (as /invite/\$token.tsx also does):
+ * The cache is reset rather than merely invalidating /auth/me (as /invite/\$token.tsx also does):
  * a joiner may already have been in another Team, and every cached tenant-scoped query belongs to
  * the one they were in. This is the same obligation `/t/\$slug`'s gate carries on a switch.
  *
@@ -27,8 +27,8 @@ export function useJoinTeam() {
 
   const join = (token: string) => {
     acceptInvitation.mutate(token, {
-      onSuccess: () => {
-        client.clear()
+      onSuccess: async () => {
+        await client.resetQueries()
         navigate({ to: '/' })
       },
     })

--- a/app/src/features/join-team/lib/use-join-team.ts
+++ b/app/src/features/join-team/lib/use-join-team.ts
@@ -9,7 +9,7 @@ const GENERIC = 'Something went wrong, try again.'
 /**
  * Thin wiring over useAcceptInvitation for the /onboarding/join route: on success, drops the cache
  * and navigates to `/` — the dispatcher, which resolves the Active Team the server just set to the
- * team they joined (ADR-0021 §4) and lands them in it, where the team route's gate carries them on
+ * team they joined (ADR-0023 §4) and lands them in it, where the team route's gate carries them on
  * to get-started.
  *
  * The cache is reset rather than merely invalidating /auth/me (as /invite/\$token.tsx also does):

--- a/app/src/features/join-team/lib/use-join-team.ts
+++ b/app/src/features/join-team/lib/use-join-team.ts
@@ -7,18 +7,12 @@ const INVALID_OR_EXPIRED =
 const GENERIC = 'Something went wrong, try again.'
 
 /**
- * Thin wiring over useAcceptInvitation for the /onboarding/join route: on success, drops the cache
- * and navigates to `/` — the dispatcher, which resolves the Active Team the server just set to the
- * team they joined (ADR-0023 §4) and lands them in it, where the team route's gate carries them on
- * to get-started.
+ * Thin wiring over useAcceptInvitation for /onboarding/join. Accepting sets the Active Team server
+ * side (ADR-0023 §4), so `/` lands them in the Team they joined; the cache is reset because a joiner
+ * may have come from another tenant.
  *
- * The cache is reset rather than merely invalidating /auth/me (as /invite/\$token.tsx also does):
- * a joiner may already have been in another Team, and every cached tenant-scoped query belongs to
- * the one they were in. This is the same obligation `/t/\$slug`'s gate carries on a switch.
- *
- * useAcceptInvitation throws a single generic Error for both an invalid and an expired token (the
- * accept endpoint returns 404 for both, deliberately, so there's no oracle); anything else (network
- * failure, unexpected status) is treated as the generic failure.
+ * useAcceptInvitation throws one generic Error for invalid and expired alike — the accept endpoint
+ * returns 404 for both deliberately, so there is no oracle.
  */
 export function useJoinTeam() {
   const client = useQueryClient()

--- a/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
@@ -3,9 +3,8 @@ import { expect, fn, userEvent } from 'storybook/test'
 import type { TeamRef } from '@shared/api/teams'
 import { SelectTeamView } from './SelectTeamView'
 
-// The "which Team?" screen. It exists because tenant resolution refuses to guess between several
-// memberships (ADR-0023 §1): reaching it is a normal state — a first sign-in after joining a second
-// Team, or the remembered Team's membership ending — not an error, and the copy has to read that way.
+// Reaching this screen is a normal state, not an error — a first sign-in after joining a second
+// Team, or the remembered Team's membership ending — and the copy has to read that way.
 const TEAMS: TeamRef[] = [
   { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' },
   { id: 't2', name: 'Tovo Heren 5', slug: 'tovo-heren-5' },
@@ -26,7 +25,6 @@ export const TwoTeams: Story = {
     await expect(canvas.getByRole('heading', { name: 'Which team?' })).toBeInTheDocument()
     await expect(canvas.getByText('Setpoint VT')).toBeInTheDocument()
     await expect(canvas.getByText('Tovo Heren 5')).toBeInTheDocument()
-    // The slug is shown: it is the Team's public address, and what a shared link carries.
     await expect(canvas.getByText('/setpoint-vt')).toBeInTheDocument()
   },
 }
@@ -44,8 +42,7 @@ export const ManyTeams: Story = {
   },
 }
 
-// The prop contract: choosing hands up the slug, which the container turns into a /t/:slug
-// navigation — and that navigation is what performs the authorized switch.
+// The container turns this slug into a /t/:slug navigation, which is what performs the switch.
 export const ChoosingHandsUpTheSlug: Story = {
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByText('Tovo Heren 5'))

--- a/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
@@ -4,7 +4,7 @@ import type { TeamRef } from '@shared/api/teams'
 import { SelectTeamView } from './SelectTeamView'
 
 // The "which Team?" screen. It exists because tenant resolution refuses to guess between several
-// memberships (ADR-0021 §1): reaching it is a normal state — a first sign-in after joining a second
+// memberships (ADR-0023 §1): reaching it is a normal state — a first sign-in after joining a second
 // Team, or the remembered Team's membership ending — not an error, and the copy has to read that way.
 const TEAMS: TeamRef[] = [
   { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' },

--- a/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, userEvent } from 'storybook/test'
+import type { TeamRef } from '@shared/api/teams'
+import { SelectTeamView } from './SelectTeamView'
+
+// The "which Team?" screen. It exists because tenant resolution refuses to guess between several
+// memberships (ADR-0021 §1): reaching it is a normal state — a first sign-in after joining a second
+// Team, or the remembered Team's membership ending — not an error, and the copy has to read that way.
+const TEAMS: TeamRef[] = [
+  { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' },
+  { id: 't2', name: 'Tovo Heren 5', slug: 'tovo-heren-5' },
+]
+
+const meta = {
+  title: 'features/switch-team/SelectTeamView',
+  component: SelectTeamView,
+  args: { teams: TEAMS, onSelect: fn() },
+} satisfies Meta<typeof SelectTeamView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const TwoTeams: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('heading', { name: 'Which team?' })).toBeInTheDocument()
+    await expect(canvas.getByText('Setpoint VT')).toBeInTheDocument()
+    await expect(canvas.getByText('Tovo Heren 5')).toBeInTheDocument()
+    // The slug is shown: it is the Team's public address, and what a shared link carries.
+    await expect(canvas.getByText('/setpoint-vt')).toBeInTheDocument()
+  },
+}
+
+export const ManyTeams: Story = {
+  args: {
+    teams: [
+      ...TEAMS,
+      { id: 't3', name: 'Tovo Dames 2', slug: 'tovo-dames-2' },
+      { id: 't4', name: 'Utrecht Mixed', slug: 'utrecht-mixed' },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByRole('button')).toHaveLength(4)
+  },
+}
+
+// The prop contract: choosing hands up the slug, which the container turns into a /t/:slug
+// navigation — and that navigation is what performs the authorized switch.
+export const ChoosingHandsUpTheSlug: Story = {
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByText('Tovo Heren 5'))
+    await expect(args.onSelect).toHaveBeenCalledWith('tovo-heren-5')
+  },
+}

--- a/app/src/features/switch-team/ui/SelectTeamView.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.tsx
@@ -1,0 +1,47 @@
+import { Users } from 'lucide-react'
+import type { TeamRef } from '@shared/api/teams'
+
+interface SelectTeamViewProps {
+  /** Every Team the caller is a Member of — at least two, or they would not be here. */
+  teams: TeamRef[]
+  onSelect: (slug: string) => void
+}
+
+/**
+ * "Which Team?" — the screen a Member of several Teams sees when none is active.
+ *
+ * Prop-only. It has no "remember my choice" control on purpose: picking a Team *is* the switch, and
+ * every switch is remembered (ADR-0021 §3). Offering the choice separately would imply there is a
+ * kind of switch that isn't remembered, which is exactly the invisible rule the ADR rejected.
+ */
+export function SelectTeamView({ teams, onSelect }: SelectTeamViewProps) {
+  return (
+    <div className="mx-auto mt-10 max-w-sm">
+      <h1 className="font-display text-2xl font-bold">Which team?</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        You play in more than one. Pick where you want to be — you can switch any time from the
+        header.
+      </p>
+
+      <ul className="mt-6 flex flex-col gap-2">
+        {teams.map((team) => (
+          <li key={team.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(team.slug)}
+              className="flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-card px-4 py-4 text-left transition-colors hover:border-blue/40 hover:bg-blue/5"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue/10 text-blue">
+                <Users size={18} />
+              </span>
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-semibold">{team.name}</span>
+                <span className="block truncate text-xs text-muted-foreground">/{team.slug}</span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/src/features/switch-team/ui/SelectTeamView.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.tsx
@@ -2,17 +2,14 @@ import { Users } from 'lucide-react'
 import type { TeamRef } from '@shared/api/teams'
 
 interface SelectTeamViewProps {
-  /** Every Team the caller is a Member of — at least two, or they would not be here. */
+  /** At least two, or the caller would not be here. */
   teams: TeamRef[]
   onSelect: (slug: string) => void
 }
 
 /**
- * "Which Team?" — the screen a Member of several Teams sees when none is active.
- *
- * Prop-only. It has no "remember my choice" control on purpose: picking a Team *is* the switch, and
- * every switch is remembered (ADR-0023 §3). Offering the choice separately would imply there is a
- * kind of switch that isn't remembered, which is exactly the invisible rule the ADR rejected.
+ * "Which Team?" — what a Member of several Teams sees when none is active. No "remember my choice"
+ * control on purpose: picking a Team *is* the switch, and every switch is remembered (ADR-0023 §3).
  */
 export function SelectTeamView({ teams, onSelect }: SelectTeamViewProps) {
   return (

--- a/app/src/features/switch-team/ui/SelectTeamView.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.tsx
@@ -11,7 +11,7 @@ interface SelectTeamViewProps {
  * "Which Team?" — the screen a Member of several Teams sees when none is active.
  *
  * Prop-only. It has no "remember my choice" control on purpose: picking a Team *is* the switch, and
- * every switch is remembered (ADR-0021 §3). Offering the choice separately would imply there is a
+ * every switch is remembered (ADR-0023 §3). Offering the choice separately would imply there is a
  * kind of switch that isn't remembered, which is exactly the invisible rule the ADR rejected.
  */
 export function SelectTeamView({ teams, onSelect }: SelectTeamViewProps) {

--- a/app/src/features/switch-team/ui/TeamSwitcher.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcher.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useAuthMe } from '@shared/api/auth'
+import { teamRoutes } from '@shared/lib/team-routes'
+import { TeamSwitcherView } from './TeamSwitcherView'
+
+/**
+ * Thin wiring for [TeamSwitcherView]: the caller's Teams from `/auth/me`, and a switch performed as
+ * an ordinary navigation to `/t/:slug`.
+ *
+ * Navigating rather than calling the switch endpoint here is deliberate — `/t/$slug`'s gate already
+ * performs the authorized switch for a shared link, and routing the switcher through the same door
+ * keeps one code path for both (ADR-0021 §2). A switcher that called activate itself would be the
+ * second tenant-resolution path the ADR exists to prevent.
+ */
+export function TeamSwitcher() {
+  const navigate = useNavigate()
+  const { data: user } = useAuthMe()
+
+  return (
+    <TeamSwitcherView
+      teams={user?.teams ?? []}
+      activeTeam={user?.activeTeam ?? null}
+      onSelect={(slug) => navigate({ to: teamRoutes(slug).events })}
+    />
+  )
+}

--- a/app/src/features/switch-team/ui/TeamSwitcher.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcher.tsx
@@ -9,7 +9,7 @@ import { TeamSwitcherView } from './TeamSwitcherView'
  *
  * Navigating rather than calling the switch endpoint here is deliberate — `/t/$slug`'s gate already
  * performs the authorized switch for a shared link, and routing the switcher through the same door
- * keeps one code path for both (ADR-0021 §2). A switcher that called activate itself would be the
+ * keeps one code path for both (ADR-0023 §2). A switcher that called activate itself would be the
  * second tenant-resolution path the ADR exists to prevent.
  */
 export function TeamSwitcher() {

--- a/app/src/features/switch-team/ui/TeamSwitcher.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcher.tsx
@@ -4,13 +4,8 @@ import { teamRoutes } from '@shared/lib/team-routes'
 import { TeamSwitcherView } from './TeamSwitcherView'
 
 /**
- * Thin wiring for [TeamSwitcherView]: the caller's Teams from `/auth/me`, and a switch performed as
- * an ordinary navigation to `/t/:slug`.
- *
- * Navigating rather than calling the switch endpoint here is deliberate — `/t/$slug`'s gate already
- * performs the authorized switch for a shared link, and routing the switcher through the same door
- * keeps one code path for both (ADR-0023 §2). A switcher that called activate itself would be the
- * second tenant-resolution path the ADR exists to prevent.
+ * Thin wiring for [TeamSwitcherView]. Switching is an ordinary navigation to `/t/:slug` rather than a
+ * call to the switch endpoint, so a tap and a shared link go through one door (ADR-0023 §2).
  */
 export function TeamSwitcher() {
   const navigate = useNavigate()

--- a/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
@@ -3,11 +3,8 @@ import { expect, fn, userEvent } from 'storybook/test'
 import type { TeamRef } from '@shared/api/teams'
 import { TeamSwitcherView } from './TeamSwitcherView'
 
-// The Team switcher (ADR-0023 §3). The behaviour worth pinning is not the dropdown mechanics but the
-// rule the ADR leans on: it ALWAYS names the current Team. One kind of switch means a teammate's
-// link silently re-homes your default, and the only thing that makes that a one-tap correction
-// rather than a mystery is being able to see which Team you are in — so every story below asserts
-// the name is on screen, including the single-Team case that has no menu at all.
+// The rule worth pinning is not the dropdown mechanics but the one ADR-0023 §3 leans on: the
+// switcher ALWAYS names the current Team, including in the single-Team case that has no menu.
 const SETPOINT: TeamRef = { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' }
 const TOVO: TeamRef = { id: 't2', name: 'Tovo Heren 5', slug: 'tovo-heren-5' }
 
@@ -21,7 +18,6 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-// A single-Team member gets a plain label: nothing to switch to, so no menu — but still the name.
 export const SingleTeam: Story = {
   args: { teams: [SETPOINT] },
   play: async ({ canvas }) => {
@@ -34,7 +30,6 @@ export const SeveralTeams: Story = {
   play: async ({ canvas }) => {
     const trigger = canvas.getByRole('button', { name: /Current team: Setpoint VT/ })
     await expect(trigger).toBeInTheDocument()
-    // Closed by default: the Teams are a menu away, the current one is not.
     await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument()
   },
 }
@@ -43,14 +38,12 @@ export const MenuOpen: Story = {
   play: async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
     await expect(canvas.getByRole('listbox', { name: 'Your teams' })).toBeInTheDocument()
-    // Both Teams listed, and the active one is marked as such for a screen reader too.
     await expect(canvas.getByRole('option', { name: /Setpoint VT/ })).toHaveAttribute('aria-selected', 'true')
     await expect(canvas.getByRole('option', { name: /Tovo Heren 5/ })).toHaveAttribute('aria-selected', 'false')
   },
 }
 
-// The prop contract: picking the other Team hands its SLUG up, because the slug is what the
-// team-scoped URL carries and opening that URL is what performs the switch.
+// The slug, not the id: it is what the team-scoped URL carries, and opening that URL is the switch.
 export const SwitchesToTheOtherTeam: Story = {
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
@@ -59,8 +52,7 @@ export const SwitchesToTheOtherTeam: Story = {
   },
 }
 
-// Re-picking the Team you are already in is not a switch. It must not fire one: every switch is
-// remembered and re-pins the session routing, so a no-op switch is a pointless round-trip.
+// Re-picking the current Team is not a switch, and must not fire one.
 export const PickingTheActiveTeamDoesNothing: Story = {
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
@@ -70,7 +62,6 @@ export const PickingTheActiveTeamDoesNothing: Story = {
   },
 }
 
-// Nothing to name yet — a caller mid-onboarding, or one who has not chosen between their Teams.
 export const NoActiveTeam: Story = {
   args: { activeTeam: null },
   play: async ({ canvas }) => {

--- a/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, userEvent } from 'storybook/test'
+import type { TeamRef } from '@shared/api/teams'
+import { TeamSwitcherView } from './TeamSwitcherView'
+
+// The Team switcher (ADR-0021 §3). The behaviour worth pinning is not the dropdown mechanics but the
+// rule the ADR leans on: it ALWAYS names the current Team. One kind of switch means a teammate's
+// link silently re-homes your default, and the only thing that makes that a one-tap correction
+// rather than a mystery is being able to see which Team you are in — so every story below asserts
+// the name is on screen, including the single-Team case that has no menu at all.
+const SETPOINT: TeamRef = { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' }
+const TOVO: TeamRef = { id: 't2', name: 'Tovo Heren 5', slug: 'tovo-heren-5' }
+
+const meta = {
+  title: 'features/switch-team/TeamSwitcherView',
+  component: TeamSwitcherView,
+  args: { teams: [SETPOINT, TOVO], activeTeam: SETPOINT, onSelect: fn() },
+} satisfies Meta<typeof TeamSwitcherView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// A single-Team member gets a plain label: nothing to switch to, so no menu — but still the name.
+export const SingleTeam: Story = {
+  args: { teams: [SETPOINT] },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Setpoint VT')).toBeInTheDocument()
+    await expect(canvas.queryByRole('button')).not.toBeInTheDocument()
+  },
+}
+
+export const SeveralTeams: Story = {
+  play: async ({ canvas }) => {
+    const trigger = canvas.getByRole('button', { name: /Current team: Setpoint VT/ })
+    await expect(trigger).toBeInTheDocument()
+    // Closed by default: the Teams are a menu away, the current one is not.
+    await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument()
+  },
+}
+
+export const MenuOpen: Story = {
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
+    await expect(canvas.getByRole('listbox', { name: 'Your teams' })).toBeInTheDocument()
+    // Both Teams listed, and the active one is marked as such for a screen reader too.
+    await expect(canvas.getByRole('option', { name: /Setpoint VT/ })).toHaveAttribute('aria-selected', 'true')
+    await expect(canvas.getByRole('option', { name: /Tovo Heren 5/ })).toHaveAttribute('aria-selected', 'false')
+  },
+}
+
+// The prop contract: picking the other Team hands its SLUG up, because the slug is what the
+// team-scoped URL carries and opening that URL is what performs the switch.
+export const SwitchesToTheOtherTeam: Story = {
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
+    await userEvent.click(canvas.getByRole('option', { name: /Tovo Heren 5/ }))
+    await expect(args.onSelect).toHaveBeenCalledWith('tovo-heren-5')
+  },
+}
+
+// Re-picking the Team you are already in is not a switch. It must not fire one: every switch is
+// remembered and re-pins the session routing, so a no-op switch is a pointless round-trip.
+export const PickingTheActiveTeamDoesNothing: Story = {
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
+    await userEvent.click(canvas.getByRole('option', { name: /Setpoint VT/ }))
+    await expect(args.onSelect).not.toHaveBeenCalled()
+    await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument()
+  },
+}
+
+// Nothing to name yet — a caller mid-onboarding, or one who has not chosen between their Teams.
+export const NoActiveTeam: Story = {
+  args: { activeTeam: null },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByText('Setpoint VT')).not.toBeInTheDocument()
+  },
+}

--- a/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, userEvent } from 'storybook/test'
 import type { TeamRef } from '@shared/api/teams'
 import { TeamSwitcherView } from './TeamSwitcherView'
 
-// The Team switcher (ADR-0021 §3). The behaviour worth pinning is not the dropdown mechanics but the
+// The Team switcher (ADR-0023 §3). The behaviour worth pinning is not the dropdown mechanics but the
 // rule the ADR leans on: it ALWAYS names the current Team. One kind of switch means a teammate's
 // link silently re-homes your default, and the only thing that makes that a one-tap correction
 // rather than a mystery is being able to see which Team you are in — so every story below asserts

--- a/app/src/features/switch-team/ui/TeamSwitcherView.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import type { TeamRef } from '@shared/api/teams'
+
+interface TeamSwitcherViewProps {
+  /** Every Team the caller is a Member of. */
+  teams: TeamRef[]
+  /** The Team this screen is scoped to, or null when none is active yet. */
+  activeTeam: TeamRef | null
+  /** Called with the chosen Team's slug. Opening `/t/:slug` is what performs the switch. */
+  onSelect: (slug: string) => void
+}
+
+/**
+ * The Team switcher, prop-only: it always **names the current Team** (ADR-0021 §3).
+ *
+ * That naming is not decoration. There is one kind of switch, so tapping a teammate's link to your
+ * secondary Team re-homes your default and you may open the app later in the other Team. The rule
+ * that makes that acceptable is that the switcher is permanent UI and states which Team you are in,
+ * so the re-homing is self-evident and a one-tap correction — as opposed to a hidden rule about
+ * deliberate-vs-link-induced switches that no user could see.
+ *
+ * A caller with a single Team gets a plain label, not a menu: there is nothing to switch to, and a
+ * dropdown that only ever offers what you are already looking at is noise. The name still shows,
+ * which is the part the rule above actually depends on.
+ */
+export function TeamSwitcherView({ teams, activeTeam, onSelect }: TeamSwitcherViewProps) {
+  const [open, setOpen] = useState(false)
+
+  // Nothing to name: a teamless caller, or one who has not chosen yet. The screens they are on
+  // (onboarding, the picker) say where they are; a chip saying nothing would only take up room.
+  if (!activeTeam) return null
+
+  if (teams.length < 2) {
+    return (
+      <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
+        <span className="h-1.5 w-1.5 rounded-full bg-green" />
+        {activeTeam.name}
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Current team: ${activeTeam.name}. Switch team`}
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue transition-colors hover:bg-blue/15"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-green" />
+        {activeTeam.name}
+        <ChevronsUpDown size={13} />
+      </button>
+
+      {open && (
+        <>
+          {/* Full-screen catcher so a tap anywhere closes the menu — the same affordance as Escape,
+              on a device with no Escape key. */}
+          <button
+            type="button"
+            aria-hidden="true"
+            tabIndex={-1}
+            className="fixed inset-0 z-40 cursor-default"
+            onClick={() => setOpen(false)}
+          />
+          <ul
+            role="listbox"
+            aria-label="Your teams"
+            className="absolute right-0 z-50 mt-2 min-w-56 overflow-hidden rounded-2xl border border-border/60 bg-card py-1 shadow-lg"
+          >
+            {teams.map((team) => {
+              const isActive = team.id === activeTeam.id
+              return (
+                <li key={team.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    onClick={() => {
+                      setOpen(false)
+                      if (!isActive) onSelect(team.slug)
+                    }}
+                    className={[
+                      'flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors',
+                      isActive ? 'font-semibold text-blue' : 'text-foreground hover:bg-blue/8',
+                    ].join(' ')}
+                  >
+                    {team.name}
+                    {isActive && <Check size={15} className="shrink-0" />}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/src/features/switch-team/ui/TeamSwitcherView.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.tsx
@@ -12,23 +12,15 @@ interface TeamSwitcherViewProps {
 }
 
 /**
- * The Team switcher, prop-only: it always **names the current Team** (ADR-0023 §3).
+ * Always **names the current Team** (ADR-0023 §3) — not decoration: with one kind of switch, opening
+ * a teammate's link re-homes your default, and seeing which Team you are in is what makes that a
+ * one-tap correction rather than a mystery.
  *
- * That naming is not decoration. There is one kind of switch, so tapping a teammate's link to your
- * secondary Team re-homes your default and you may open the app later in the other Team. The rule
- * that makes that acceptable is that the switcher is permanent UI and states which Team you are in,
- * so the re-homing is self-evident and a one-tap correction — as opposed to a hidden rule about
- * deliberate-vs-link-induced switches that no user could see.
- *
- * A caller with a single Team gets a plain label, not a menu: there is nothing to switch to, and a
- * dropdown that only ever offers what you are already looking at is noise. The name still shows,
- * which is the part the rule above actually depends on.
+ * A single-Team caller gets the name without a menu; there is nothing to switch to.
  */
 export function TeamSwitcherView({ teams, activeTeam, onSelect }: TeamSwitcherViewProps) {
   const [open, setOpen] = useState(false)
 
-  // Nothing to name: a teamless caller, or one who has not chosen yet. The screens they are on
-  // (onboarding, the picker) say where they are; a chip saying nothing would only take up room.
   if (!activeTeam) return null
 
   if (teams.length < 2) {
@@ -57,8 +49,7 @@ export function TeamSwitcherView({ teams, activeTeam, onSelect }: TeamSwitcherVi
 
       {open && (
         <>
-          {/* Full-screen catcher so a tap anywhere closes the menu — the same affordance as Escape,
-              on a device with no Escape key. */}
+          {/* Tap-anywhere-to-close, for devices with no Escape key. */}
           <button
             type="button"
             aria-hidden="true"

--- a/app/src/features/switch-team/ui/TeamSwitcherView.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.tsx
@@ -12,7 +12,7 @@ interface TeamSwitcherViewProps {
 }
 
 /**
- * The Team switcher, prop-only: it always **names the current Team** (ADR-0021 §3).
+ * The Team switcher, prop-only: it always **names the current Team** (ADR-0023 §3).
  *
  * That naming is not decoration. There is one kind of switch, so tapping a teammate's link to your
  * secondary Team re-homes your default and you may open the app later in the other Team. The rule

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -11,18 +11,20 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as SelectTeamRouteImport } from './routes/select-team'
 import { Route as AdminCreationCodesRouteImport } from './routes/admin/creation-codes'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
 import { Route as CreateTeamIndexRouteImport } from './routes/create-team/index'
-import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
-import { Route as GetStartedIndexRouteImport } from './routes/get-started/index'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
-import { Route as MembersIndexRouteImport } from './routes/members/index'
 import { Route as OnboardingIndexRouteImport } from './routes/onboarding/index'
 import { Route as OnboardingJoinRouteImport } from './routes/onboarding/join'
-import { Route as ProfileIndexRouteImport } from './routes/profile/index'
-import { Route as TeamIndexRouteImport } from './routes/team/index'
-import { Route as TeamSettingsRouteImport } from './routes/team/settings'
+import { Route as TSlugRouteRouteImport } from './routes/t/$slug/route'
+import { Route as TSlugIndexRouteImport } from './routes/t/$slug/index'
+import { Route as TSlugEventsEventIdRouteImport } from './routes/t/$slug/events/$eventId'
+import { Route as TSlugGetStartedIndexRouteImport } from './routes/t/$slug/get-started/index'
+import { Route as TSlugProfileIndexRouteImport } from './routes/t/$slug/profile/index'
+import { Route as TSlugTeamIndexRouteImport } from './routes/t/$slug/team/index'
+import { Route as TSlugTeamSettingsRouteImport } from './routes/t/$slug/team/settings'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -32,6 +34,11 @@ const IndexRoute = IndexRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SelectTeamRoute = SelectTeamRouteImport.update({
+  id: '/select-team',
+  path: '/select-team',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminCreationCodesRoute = AdminCreationCodesRouteImport.update({
@@ -49,24 +56,9 @@ const CreateTeamIndexRoute = CreateTeamIndexRouteImport.update({
   path: '/create-team/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const EventsEventIdRoute = EventsEventIdRouteImport.update({
-  id: '/events/$eventId',
-  path: '/events/$eventId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const GetStartedIndexRoute = GetStartedIndexRouteImport.update({
-  id: '/get-started/',
-  path: '/get-started/',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const InviteTokenRoute = InviteTokenRouteImport.update({
   id: '/invite/$token',
   path: '/invite/$token',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MembersIndexRoute = MembersIndexRouteImport.update({
-  id: '/members/',
-  path: '/members/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnboardingIndexRoute = OnboardingIndexRouteImport.update({
@@ -79,137 +71,163 @@ const OnboardingJoinRoute = OnboardingJoinRouteImport.update({
   path: '/onboarding/join',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ProfileIndexRoute = ProfileIndexRouteImport.update({
+const TSlugRouteRoute = TSlugRouteRouteImport.update({
+  id: '/t/$slug',
+  path: '/t/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TSlugIndexRoute = TSlugIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => TSlugRouteRoute,
+} as any)
+const TSlugEventsEventIdRoute = TSlugEventsEventIdRouteImport.update({
+  id: '/events/$eventId',
+  path: '/events/$eventId',
+  getParentRoute: () => TSlugRouteRoute,
+} as any)
+const TSlugGetStartedIndexRoute = TSlugGetStartedIndexRouteImport.update({
+  id: '/get-started/',
+  path: '/get-started/',
+  getParentRoute: () => TSlugRouteRoute,
+} as any)
+const TSlugProfileIndexRoute = TSlugProfileIndexRouteImport.update({
   id: '/profile/',
   path: '/profile/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => TSlugRouteRoute,
 } as any)
-const TeamIndexRoute = TeamIndexRouteImport.update({
+const TSlugTeamIndexRoute = TSlugTeamIndexRouteImport.update({
   id: '/team/',
   path: '/team/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => TSlugRouteRoute,
 } as any)
-const TeamSettingsRoute = TeamSettingsRouteImport.update({
+const TSlugTeamSettingsRoute = TSlugTeamSettingsRouteImport.update({
   id: '/team/settings',
   path: '/team/settings',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => TSlugRouteRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/select-team': typeof SelectTeamRoute
+  '/t/$slug': typeof TSlugRouteRouteWithChildren
   '/admin/creation-codes': typeof AdminCreationCodesRoute
   '/auth/verify': typeof AuthVerifyRoute
-  '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/onboarding/join': typeof OnboardingJoinRoute
-  '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
-  '/get-started/': typeof GetStartedIndexRoute
-  '/members/': typeof MembersIndexRoute
   '/onboarding/': typeof OnboardingIndexRoute
-  '/profile/': typeof ProfileIndexRoute
-  '/team/': typeof TeamIndexRoute
+  '/t/$slug/': typeof TSlugIndexRoute
+  '/t/$slug/events/$eventId': typeof TSlugEventsEventIdRoute
+  '/t/$slug/team/settings': typeof TSlugTeamSettingsRoute
+  '/t/$slug/get-started/': typeof TSlugGetStartedIndexRoute
+  '/t/$slug/profile/': typeof TSlugProfileIndexRoute
+  '/t/$slug/team/': typeof TSlugTeamIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/select-team': typeof SelectTeamRoute
   '/admin/creation-codes': typeof AdminCreationCodesRoute
   '/auth/verify': typeof AuthVerifyRoute
-  '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/onboarding/join': typeof OnboardingJoinRoute
-  '/team/settings': typeof TeamSettingsRoute
   '/create-team': typeof CreateTeamIndexRoute
-  '/get-started': typeof GetStartedIndexRoute
-  '/members': typeof MembersIndexRoute
   '/onboarding': typeof OnboardingIndexRoute
-  '/profile': typeof ProfileIndexRoute
-  '/team': typeof TeamIndexRoute
+  '/t/$slug': typeof TSlugIndexRoute
+  '/t/$slug/events/$eventId': typeof TSlugEventsEventIdRoute
+  '/t/$slug/team/settings': typeof TSlugTeamSettingsRoute
+  '/t/$slug/get-started': typeof TSlugGetStartedIndexRoute
+  '/t/$slug/profile': typeof TSlugProfileIndexRoute
+  '/t/$slug/team': typeof TSlugTeamIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/select-team': typeof SelectTeamRoute
+  '/t/$slug': typeof TSlugRouteRouteWithChildren
   '/admin/creation-codes': typeof AdminCreationCodesRoute
   '/auth/verify': typeof AuthVerifyRoute
-  '/events/$eventId': typeof EventsEventIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/onboarding/join': typeof OnboardingJoinRoute
-  '/team/settings': typeof TeamSettingsRoute
   '/create-team/': typeof CreateTeamIndexRoute
-  '/get-started/': typeof GetStartedIndexRoute
-  '/members/': typeof MembersIndexRoute
   '/onboarding/': typeof OnboardingIndexRoute
-  '/profile/': typeof ProfileIndexRoute
-  '/team/': typeof TeamIndexRoute
+  '/t/$slug/': typeof TSlugIndexRoute
+  '/t/$slug/events/$eventId': typeof TSlugEventsEventIdRoute
+  '/t/$slug/team/settings': typeof TSlugTeamSettingsRoute
+  '/t/$slug/get-started/': typeof TSlugGetStartedIndexRoute
+  '/t/$slug/profile/': typeof TSlugProfileIndexRoute
+  '/t/$slug/team/': typeof TSlugTeamIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/login'
+    | '/select-team'
+    | '/t/$slug'
     | '/admin/creation-codes'
     | '/auth/verify'
-    | '/events/$eventId'
     | '/invite/$token'
     | '/onboarding/join'
-    | '/team/settings'
     | '/create-team/'
-    | '/get-started/'
-    | '/members/'
     | '/onboarding/'
-    | '/profile/'
-    | '/team/'
+    | '/t/$slug/'
+    | '/t/$slug/events/$eventId'
+    | '/t/$slug/team/settings'
+    | '/t/$slug/get-started/'
+    | '/t/$slug/profile/'
+    | '/t/$slug/team/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/login'
+    | '/select-team'
     | '/admin/creation-codes'
     | '/auth/verify'
-    | '/events/$eventId'
     | '/invite/$token'
     | '/onboarding/join'
-    | '/team/settings'
     | '/create-team'
-    | '/get-started'
-    | '/members'
     | '/onboarding'
-    | '/profile'
-    | '/team'
+    | '/t/$slug'
+    | '/t/$slug/events/$eventId'
+    | '/t/$slug/team/settings'
+    | '/t/$slug/get-started'
+    | '/t/$slug/profile'
+    | '/t/$slug/team'
   id:
     | '__root__'
     | '/'
     | '/login'
+    | '/select-team'
+    | '/t/$slug'
     | '/admin/creation-codes'
     | '/auth/verify'
-    | '/events/$eventId'
     | '/invite/$token'
     | '/onboarding/join'
-    | '/team/settings'
     | '/create-team/'
-    | '/get-started/'
-    | '/members/'
     | '/onboarding/'
-    | '/profile/'
-    | '/team/'
+    | '/t/$slug/'
+    | '/t/$slug/events/$eventId'
+    | '/t/$slug/team/settings'
+    | '/t/$slug/get-started/'
+    | '/t/$slug/profile/'
+    | '/t/$slug/team/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  SelectTeamRoute: typeof SelectTeamRoute
+  TSlugRouteRoute: typeof TSlugRouteRouteWithChildren
   AdminCreationCodesRoute: typeof AdminCreationCodesRoute
   AuthVerifyRoute: typeof AuthVerifyRoute
-  EventsEventIdRoute: typeof EventsEventIdRoute
   InviteTokenRoute: typeof InviteTokenRoute
   OnboardingJoinRoute: typeof OnboardingJoinRoute
-  TeamSettingsRoute: typeof TeamSettingsRoute
   CreateTeamIndexRoute: typeof CreateTeamIndexRoute
-  GetStartedIndexRoute: typeof GetStartedIndexRoute
-  MembersIndexRoute: typeof MembersIndexRoute
   OnboardingIndexRoute: typeof OnboardingIndexRoute
-  ProfileIndexRoute: typeof ProfileIndexRoute
-  TeamIndexRoute: typeof TeamIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -226,6 +244,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/select-team': {
+      id: '/select-team'
+      path: '/select-team'
+      fullPath: '/select-team'
+      preLoaderRoute: typeof SelectTeamRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/creation-codes': {
@@ -249,32 +274,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CreateTeamIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/events/$eventId': {
-      id: '/events/$eventId'
-      path: '/events/$eventId'
-      fullPath: '/events/$eventId'
-      preLoaderRoute: typeof EventsEventIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/get-started/': {
-      id: '/get-started/'
-      path: '/get-started'
-      fullPath: '/get-started/'
-      preLoaderRoute: typeof GetStartedIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/invite/$token': {
       id: '/invite/$token'
       path: '/invite/$token'
       fullPath: '/invite/$token'
       preLoaderRoute: typeof InviteTokenRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/members/': {
-      id: '/members/'
-      path: '/members'
-      fullPath: '/members/'
-      preLoaderRoute: typeof MembersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/onboarding/': {
@@ -291,45 +295,91 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OnboardingJoinRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/profile/': {
-      id: '/profile/'
+    '/t/$slug': {
+      id: '/t/$slug'
+      path: '/t/$slug'
+      fullPath: '/t/$slug'
+      preLoaderRoute: typeof TSlugRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/t/$slug/': {
+      id: '/t/$slug/'
+      path: '/'
+      fullPath: '/t/$slug/'
+      preLoaderRoute: typeof TSlugIndexRouteImport
+      parentRoute: typeof TSlugRouteRoute
+    }
+    '/t/$slug/events/$eventId': {
+      id: '/t/$slug/events/$eventId'
+      path: '/events/$eventId'
+      fullPath: '/t/$slug/events/$eventId'
+      preLoaderRoute: typeof TSlugEventsEventIdRouteImport
+      parentRoute: typeof TSlugRouteRoute
+    }
+    '/t/$slug/get-started/': {
+      id: '/t/$slug/get-started/'
+      path: '/get-started'
+      fullPath: '/t/$slug/get-started/'
+      preLoaderRoute: typeof TSlugGetStartedIndexRouteImport
+      parentRoute: typeof TSlugRouteRoute
+    }
+    '/t/$slug/profile/': {
+      id: '/t/$slug/profile/'
       path: '/profile'
-      fullPath: '/profile/'
-      preLoaderRoute: typeof ProfileIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/t/$slug/profile/'
+      preLoaderRoute: typeof TSlugProfileIndexRouteImport
+      parentRoute: typeof TSlugRouteRoute
     }
-    '/team/': {
-      id: '/team/'
+    '/t/$slug/team/': {
+      id: '/t/$slug/team/'
       path: '/team'
-      fullPath: '/team/'
-      preLoaderRoute: typeof TeamIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/t/$slug/team/'
+      preLoaderRoute: typeof TSlugTeamIndexRouteImport
+      parentRoute: typeof TSlugRouteRoute
     }
-    '/team/settings': {
-      id: '/team/settings'
+    '/t/$slug/team/settings': {
+      id: '/t/$slug/team/settings'
       path: '/team/settings'
-      fullPath: '/team/settings'
-      preLoaderRoute: typeof TeamSettingsRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/t/$slug/team/settings'
+      preLoaderRoute: typeof TSlugTeamSettingsRouteImport
+      parentRoute: typeof TSlugRouteRoute
     }
   }
 }
 
+interface TSlugRouteRouteChildren {
+  TSlugIndexRoute: typeof TSlugIndexRoute
+  TSlugEventsEventIdRoute: typeof TSlugEventsEventIdRoute
+  TSlugTeamSettingsRoute: typeof TSlugTeamSettingsRoute
+  TSlugGetStartedIndexRoute: typeof TSlugGetStartedIndexRoute
+  TSlugProfileIndexRoute: typeof TSlugProfileIndexRoute
+  TSlugTeamIndexRoute: typeof TSlugTeamIndexRoute
+}
+
+const TSlugRouteRouteChildren: TSlugRouteRouteChildren = {
+  TSlugIndexRoute: TSlugIndexRoute,
+  TSlugEventsEventIdRoute: TSlugEventsEventIdRoute,
+  TSlugTeamSettingsRoute: TSlugTeamSettingsRoute,
+  TSlugGetStartedIndexRoute: TSlugGetStartedIndexRoute,
+  TSlugProfileIndexRoute: TSlugProfileIndexRoute,
+  TSlugTeamIndexRoute: TSlugTeamIndexRoute,
+}
+
+const TSlugRouteRouteWithChildren = TSlugRouteRoute._addFileChildren(
+  TSlugRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  SelectTeamRoute: SelectTeamRoute,
+  TSlugRouteRoute: TSlugRouteRouteWithChildren,
   AdminCreationCodesRoute: AdminCreationCodesRoute,
   AuthVerifyRoute: AuthVerifyRoute,
-  EventsEventIdRoute: EventsEventIdRoute,
   InviteTokenRoute: InviteTokenRoute,
   OnboardingJoinRoute: OnboardingJoinRoute,
-  TeamSettingsRoute: TeamSettingsRoute,
   CreateTeamIndexRoute: CreateTeamIndexRoute,
-  GetStartedIndexRoute: GetStartedIndexRoute,
-  MembersIndexRoute: MembersIndexRoute,
   OnboardingIndexRoute: OnboardingIndexRoute,
-  ProfileIndexRoute: ProfileIndexRoute,
-  TeamIndexRoute: TeamIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -45,7 +45,7 @@ export const Route = createRootRoute({
     }
     if (!user) throw redirect({ to: '/login' })
 
-    // Has-ANY-team gate (ADR-0021 §4, amending ADR-0019 §6). The question this gate asks changed
+    // Has-ANY-team gate (ADR-0023 §4, amending ADR-0019 §6). The question this gate asks changed
     // with #143: it is no longer "do you have a team" but "do you have *any* Team" — and *which* one
     // is active is a separate question, answered per-route by /t/$slug and never inferred from the
     // list's order. A teamless caller is a first-class state, routed to the join-vs-create fork
@@ -105,7 +105,7 @@ function RootLayout() {
             <Link to="/" className="font-display text-xl font-bold text-blue">
               Team<span className="text-green">Balance</span>
             </Link>
-            {/* The switcher is permanent UI and always names the current Team (ADR-0021 §3). That
+            {/* The switcher is permanent UI and always names the current Team (ADR-0023 §3). That
                 visibility is what makes one-kind-of-switch tolerable: opening a teammate's link
                 re-homes your default, and the only thing that makes it correctable is being able to
                 see, at a glance, which Team you are in. */}

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -17,8 +17,7 @@ function isAuthRoute(pathname: string): boolean {
   return pathname === '/login' || pathname.startsWith('/auth/') || /^\/invite\/[^/]+$/.test(pathname)
 }
 
-// The screens an authenticated caller can reach without being in a Team: the join-vs-create fork,
-// its two branches, and the picker a Member of several Teams lands on when none is active.
+// The screens an authenticated caller can reach without being in a Team.
 function isTeamlessRoute(pathname: string): boolean {
   const path = pathname.replace(/\/$/, '')
   return (
@@ -45,16 +44,10 @@ export const Route = createRootRoute({
     }
     if (!user) throw redirect({ to: '/login' })
 
-    // Has-ANY-team gate (ADR-0023 §4, amending ADR-0019 §6). The question this gate asks changed
-    // with #143: it is no longer "do you have a team" but "do you have *any* Team" — and *which* one
-    // is active is a separate question, answered per-route by /t/$slug and never inferred from the
-    // list's order. A teamless caller is a first-class state, routed to the join-vs-create fork
-    // before any tenant-scoped probe (which would 403 NO_TEAM_MEMBERSHIP and bounce them to /login).
-    // Teamlessness is read from the explicit teams list, not inferred from role == null (permission
-    // vs membership; see #26).
-    //
-    // The onboarding gate that used to live here moved to /t/$slug: onboarding is per-Team, so it
-    // can only be asked once the Active Team is settled.
+    // Has-ANY-team gate (ADR-0023 §4). Which Team is active is a separate question, answered by
+    // /t/$slug. Teamlessness is read from the explicit list, never inferred from role == null
+    // (permission vs membership; see #26), and is checked before any tenant-scoped probe, which
+    // would 403 NO_TEAM_MEMBERSHIP and bounce a teamless caller to /login.
     if (isTeamlessRoute(location.pathname)) return
     if (user.teams.length === 0) throw redirect({ to: '/onboarding' })
   },
@@ -105,10 +98,6 @@ function RootLayout() {
             <Link to="/" className="font-display text-xl font-bold text-blue">
               Team<span className="text-green">Balance</span>
             </Link>
-            {/* The switcher is permanent UI and always names the current Team (ADR-0023 §3). That
-                visibility is what makes one-kind-of-switch tolerable: opening a teammate's link
-                re-homes your default, and the only thing that makes it correctable is being able to
-                see, at a glance, which Team you are in. */}
             <TeamSwitcher />
           </div>
         </header>

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -4,10 +4,9 @@ import { Toaster } from 'sonner'
 import { Providers } from '@app/providers'
 import { BottomNav } from '@shared/ui/BottomNav'
 import { authMeQueryOptions } from '@shared/api/auth'
-import { currentMemberQueryOptions } from '@shared/api/members'
+import { TeamSwitcher } from '@features/switch-team/ui/TeamSwitcher'
 import { queryClient } from '@shared/api/query-client'
 import { directionFromIndices } from '@shared/lib/view-transition-direction'
-import { useUserStore } from '@shared/stores/user-store'
 import { useThemeSync } from '@shared/theme/theme-store'
 
 // Only the sign-in routes (and the invite landing page, reachable before a joiner has any
@@ -16,6 +15,19 @@ import { useThemeSync } from '@shared/theme/theme-store'
 // precise: only `/invite/<single-token>` is public; sub-paths like `/invite/manage` are NOT exempt.
 function isAuthRoute(pathname: string): boolean {
   return pathname === '/login' || pathname.startsWith('/auth/') || /^\/invite\/[^/]+$/.test(pathname)
+}
+
+// The screens an authenticated caller can reach without being in a Team: the join-vs-create fork,
+// its two branches, and the picker a Member of several Teams lands on when none is active.
+function isTeamlessRoute(pathname: string): boolean {
+  const path = pathname.replace(/\/$/, '')
+  return (
+    path === '/onboarding' ||
+    path === '/onboarding/join' ||
+    path === '/create-team' ||
+    path === '/select-team' ||
+    path === '/admin/creation-codes'
+  )
 }
 
 export const Route = createRootRoute({
@@ -33,36 +45,18 @@ export const Route = createRootRoute({
     }
     if (!user) throw redirect({ to: '/login' })
 
-    // Has-a-team gate: an authenticated but teamless user is a first-class state — route them to
-    // /onboarding (the join-vs-create fork), and do it BEFORE the onboarding gate's tenant-scoped
-    // /members/me probe (which would 403 NO_TEAM_MEMBERSHIP and bounce them to /login). /onboarding
-    // and its /onboarding/join and /create-team branches are exempt so the fork can render (mirroring
-    // how /get-started is exempt from the onboarding gate below). Teamlessness is read from the
-    // explicit team field, not inferred from role == null (permission vs membership; see #26).
-    if (
-      location.pathname === '/onboarding' ||
-      location.pathname === '/onboarding/' ||
-      location.pathname === '/onboarding/join' ||
-      location.pathname === '/onboarding/join/' ||
-      location.pathname === '/create-team' ||
-      location.pathname === '/create-team/'
-    )
-      return
-    if (!user.team) throw redirect({ to: '/onboarding' })
-
-    // Onboarding gate: a confirmed member who hasn't completed onboarding is routed to /get-started
-    // before any app screen mounts. /get-started itself is exempt (below) so the flow can render; the
-    // auth routes are already exempt (returned above). Read /members/me through the cache — race-
-    // free, same pattern as the /members admin gate. Fail OPEN if the state can't be determined:
-    // an onboarding-status blip shouldn't trap the user, and auth was already confirmed.
-    if (location.pathname === '/get-started' || location.pathname === '/get-started/') return
-    let member = null
-    try {
-      member = await queryClient.ensureQueryData(currentMemberQueryOptions)
-    } catch {
-      // Couldn't read onboarding state — don't trap the user.
-    }
-    if (member && !member.onboarded) throw redirect({ to: '/get-started' })
+    // Has-ANY-team gate (ADR-0021 §4, amending ADR-0019 §6). The question this gate asks changed
+    // with #143: it is no longer "do you have a team" but "do you have *any* Team" — and *which* one
+    // is active is a separate question, answered per-route by /t/$slug and never inferred from the
+    // list's order. A teamless caller is a first-class state, routed to the join-vs-create fork
+    // before any tenant-scoped probe (which would 403 NO_TEAM_MEMBERSHIP and bounce them to /login).
+    // Teamlessness is read from the explicit teams list, not inferred from role == null (permission
+    // vs membership; see #26).
+    //
+    // The onboarding gate that used to live here moved to /t/$slug: onboarding is per-Team, so it
+    // can only be asked once the Active Team is settled.
+    if (isTeamlessRoute(location.pathname)) return
+    if (user.teams.length === 0) throw redirect({ to: '/onboarding' })
   },
 })
 
@@ -91,7 +85,6 @@ function RootLayout() {
   // while the preference is `system`. index.html applies the first frame; this owns every frame
   // after it. The returned value is the resolved theme, which sonner needs as a prop.
   const theme = useThemeSync()
-  const teamName = useUserStore((s) => s.teamName)
 
   return (
     <Providers>
@@ -112,12 +105,11 @@ function RootLayout() {
             <Link to="/" className="font-display text-xl font-bold text-blue">
               Team<span className="text-green">Balance</span>
             </Link>
-            {teamName && (
-              <div className="flex items-center gap-2 rounded-full bg-blue/8 px-3 py-1.5 text-xs font-semibold text-blue">
-                <span className="h-1.5 w-1.5 rounded-full bg-green" />
-                {teamName}
-              </div>
-            )}
+            {/* The switcher is permanent UI and always names the current Team (ADR-0021 §3). That
+                visibility is what makes one-kind-of-switch tolerable: opening a teammate's link
+                re-homes your default, and the only thing that makes it correctable is being able to
+                see, at a glance, which Team you are in. */}
+            <TeamSwitcher />
           </div>
         </header>
         {/* Bottom padding clears the fixed nav (~6rem) plus the home-indicator inset, so the last

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -8,7 +8,7 @@ import { CreateTeamForm } from '@features/create-team/ui/CreateTeamForm'
 
 export const Route = createFileRoute('/create-team/')({
   // Authenticated callers only. There is no longer a teamless requirement: ADR-0019 §3's
-  // one-team-per-user guard was lifted by ADR-0021 (#143), so someone already playing in a Team can
+  // one-team-per-user guard was lifted by ADR-0023 (#143), so someone already playing in a Team can
   // start another from the switcher. The root gate exempts /create-team from its has-any-team
   // redirect, which is what lets a teamless caller reach it at all.
   beforeLoad: async () => {
@@ -54,7 +54,7 @@ function CreateTeamPage() {
                 if (!team) return
                 // Feed the X-Team-Id test shim; prod resolves the tenant from the session.
                 localStorage.setItem('teamId', team.id)
-                // The server already made the new Team the founder's Active Team (ADR-0021 §4), so
+                // The server already made the new Team the founder's Active Team (ADR-0023 §4), so
                 // reset the cache rather than merely refetching /me: a founder who came from another
                 // Team is now in a different tenant, and every cached tenant-scoped query belongs to
                 // the one they left. This is the same obligation /t/$slug's gate carries on a switch.

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -55,10 +55,10 @@ function CreateTeamPage() {
                 // Feed the X-Team-Id test shim; prod resolves the tenant from the session.
                 localStorage.setItem('teamId', team.id)
                 // The server already made the new Team the founder's Active Team (ADR-0021 §4), so
-                // drop the cache rather than merely refetching /me: a founder who came from another
+                // reset the cache rather than merely refetching /me: a founder who came from another
                 // Team is now in a different tenant, and every cached tenant-scoped query belongs to
                 // the one they left. This is the same obligation /t/$slug's gate carries on a switch.
-                client.clear()
+                await client.resetQueries()
                 // A brand-new team is empty: the roster is where the owner starts (invite people,
                 // then curate positions under team settings), not the events home.
                 navigate({ to: teamRoutes(team.slug).team })

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -3,15 +3,17 @@ import { useQueryClient } from '@tanstack/react-query'
 import { authMeQueryOptions } from '@shared/api/auth'
 import { queryClient } from '@shared/api/query-client'
 import { CreateTeamError, useCreateTeam } from '@shared/api/teams'
+import { teamRoutes } from '@shared/lib/team-routes'
 import { CreateTeamForm } from '@features/create-team/ui/CreateTeamForm'
 
 export const Route = createFileRoute('/create-team/')({
-  // Reachable only by an authenticated, teamless user. A user who already has a team is bounced home
-  // (the root gate exempts /create-team from its has-a-team redirect, so this self-guard owns that).
+  // Authenticated callers only. There is no longer a teamless requirement: ADR-0019 §3's
+  // one-team-per-user guard was lifted by ADR-0021 (#143), so someone already playing in a Team can
+  // start another from the switcher. The root gate exempts /create-team from its has-any-team
+  // redirect, which is what lets a teamless caller reach it at all.
   beforeLoad: async () => {
     const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
     if (!user) throw redirect({ to: '/login' })
-    if (user.team) throw redirect({ to: '/' })
   },
   component: CreateTeamPage,
 })
@@ -50,20 +52,16 @@ function CreateTeamPage() {
             createTeam.mutate(values, {
               onSuccess: async (team) => {
                 if (!team) return
-                // Feed the X-Team-Id test shim + future multi-team; prod resolves tenant from session.
+                // Feed the X-Team-Id test shim; prod resolves the tenant from the session.
                 localStorage.setItem('teamId', team.id)
-                // Refetch /auth/me so `team` is non-null before we navigate — both gates then pass.
-                await client.invalidateQueries({ queryKey: ['auth', 'me'] })
-                // A brand-new team is empty: the team roster is where the owner starts (invite
-                // people, then curate positions under /team/settings), not the events home.
-                navigate({ to: '/team' })
-              },
-              onError: async (err) => {
-                // Already-in-team race: send the user into the team they already have.
-                if (err instanceof CreateTeamError && err.code === 'ALREADY_IN_TEAM') {
-                  await client.invalidateQueries({ queryKey: ['auth', 'me'] })
-                  navigate({ to: '/' })
-                }
+                // The server already made the new Team the founder's Active Team (ADR-0021 §4), so
+                // drop the cache rather than merely refetching /me: a founder who came from another
+                // Team is now in a different tenant, and every cached tenant-scoped query belongs to
+                // the one they left. This is the same obligation /t/$slug's gate carries on a switch.
+                client.clear()
+                // A brand-new team is empty: the roster is where the owner starts (invite people,
+                // then curate positions under team settings), not the events home.
+                navigate({ to: teamRoutes(team.slug).team })
               },
             })
           }

--- a/app/src/routes/create-team/index.tsx
+++ b/app/src/routes/create-team/index.tsx
@@ -7,10 +7,8 @@ import { teamRoutes } from '@shared/lib/team-routes'
 import { CreateTeamForm } from '@features/create-team/ui/CreateTeamForm'
 
 export const Route = createFileRoute('/create-team/')({
-  // Authenticated callers only. There is no longer a teamless requirement: ADR-0019 §3's
-  // one-team-per-user guard was lifted by ADR-0023 (#143), so someone already playing in a Team can
-  // start another from the switcher. The root gate exempts /create-team from its has-any-team
-  // redirect, which is what lets a teamless caller reach it at all.
+  // Authenticated callers only: ADR-0023 lifted ADR-0019 §3's teamless requirement, so someone
+  // already playing in a Team can start another.
   beforeLoad: async () => {
     const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
     if (!user) throw redirect({ to: '/login' })
@@ -54,10 +52,8 @@ function CreateTeamPage() {
                 if (!team) return
                 // Feed the X-Team-Id test shim; prod resolves the tenant from the session.
                 localStorage.setItem('teamId', team.id)
-                // The server already made the new Team the founder's Active Team (ADR-0023 §4), so
-                // reset the cache rather than merely refetching /me: a founder who came from another
-                // Team is now in a different tenant, and every cached tenant-scoped query belongs to
-                // the one they left. This is the same obligation /t/$slug's gate carries on a switch.
+                // The server made the new Team Active (ADR-0023 §4), so a founder who came from
+                // another Team is now in a different tenant.
                 await client.resetQueries()
                 // A brand-new team is empty: the roster is where the owner starts (invite people,
                 // then curate positions under team settings), not the events home.

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,129 +1,28 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { useEffect, useMemo, useState } from 'react'
-import { useEvents } from '@shared/api/events'
-import { useEventTypes } from '@shared/api/event-types'
-import { useUserStore } from '@shared/stores/user-store'
-import { useNow } from '@shared/lib/use-now'
-import { EventListView } from '@entities/event/ui/EventListView'
-import { selectHeroEvent } from '@entities/event/lib/next-event'
-import { NextEventHero } from '@widgets/next-event-hero/ui/NextEventHero'
-import { CreateEventSheet } from '@widgets/create-event/ui/CreateEventSheet'
-import { EventFiltersView } from '@features/filter-event-types/ui/EventFiltersView'
-import { toggleTypeSelection } from '@features/filter-event-types/model/toggleTypeSelection'
-import { BulkAttendBar } from '@features/bulk-attend/ui/BulkAttendBar'
-import { eligibleEvents } from '@features/bulk-attend/lib/eligible-event-ids'
-
-export const Route = createFileRoute('/')({
-    component: EventListPage,
-})
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { authMeQueryOptions } from '@shared/api/auth'
+import { queryClient } from '@shared/api/query-client'
+import { teamRoutes } from '@shared/lib/team-routes'
 
 /**
- * The events page. Composition, in order: a compact header with the filter trigger, the Next Up
- * hero when (and only when) one is due, then one flat chronological list.
+ * The dispatcher. `/` names no Team, so it renders nothing — it answers "which Team am I in?" and
+ * sends the caller there.
  *
- * All the deciding happens here so the views below stay prop-only: which events survive the type
- * filter, whether there is a hero, and — because the hero must not appear twice — which event the
- * list drops.
+ * It exists because team-scoped screens live under `/t/:slug/…` (ADR-0021 §2) while the app's own
+ * entry points — the installed PWA's start_url, a bookmark, the post-login redirect — cannot know a
+ * slug. Resolving that here, from the Active Team the server already decided, keeps every one of
+ * them a plain `/`.
+ *
+ * Three outcomes, matching the three states `/auth/me` can report (ADR-0021 §4): an Active Team, so
+ * go there; no Teams at all, so onboarding; several Teams and none active, which is not an error but
+ * a choice the caller has to make.
  */
-function EventListPage() {
-    const [showPast, setShowPast] = useState(false)
-    const [activeTypeIds, setActiveTypeIds] = useState<Set<string>>(new Set())
-    const {data: events, isLoading, error} = useEvents(showPast)
-    const {data: eventTypes} = useEventTypes()
-    const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
-
-    useEffect(() => {
-        if (eventTypes && activeTypeIds.size === 0) {
-            setTimeout(() => setActiveTypeIds(new Set(eventTypes.map(t => t.id))))
-        }
-        /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [eventTypes])
-
-    // One ticking clock for the whole page, so the hero's countdown, the hero cut-off and every
-    // card's relative label are read off the same instant and can never disagree with each other —
-    // and so a screen left open overnight stops claiming "Tomorrow" about today.
-    const now = useNow()
-
-    const filteredEvents = useMemo(() => {
-        if (!events || !eventTypes) return events ?? []
-        if (activeTypeIds.size === eventTypes.length) return events
-        return events.filter(e => activeTypeIds.has(e.eventType.id))
-    }, [events, activeTypeIds, eventTypes])
-
-    // The API returns upcoming ascending but "all" descending, so sort here: the list is flat now,
-    // and flat only reads if it is chronological.
-    const sortedEvents = useMemo(
-        () => [...filteredEvents].sort((a, b) => a.startTime.localeCompare(b.startTime)),
-        [filteredEvents],
-    )
-
-    const heroEvent = selectHeroEvent(sortedEvents, now)
-    const listEvents = heroEvent ? sortedEvents.filter(e => e.id !== heroEvent.id) : sortedEvents
-
-    const isTypeFiltered = activeTypeIds.size < (eventTypes?.length ?? 0)
-
-    // Bulk Attend acts on exactly what the page shows (ADR-0020), so it reads `sortedEvents` — the
-    // hero included, since pulling it out of the list does not stop it being on screen. Past events
-    // are excluded by the selector, not by the surrounding UI: with the tabs gone, `showPast` merely
-    // adds past events to the same list, so the future-only rule has to live in the selector.
-    // It reads the page's shared `now`, so the button and the cards can never disagree about which
-    // events have started.
-    const bulkEvents = useMemo(
-        () => eligibleEvents(sortedEvents, activeTypeIds, now),
-        [sortedEvents, activeTypeIds, now],
-    )
-
-    return (
-        <div>
-            <div className="flex items-center justify-between gap-2">
-                <h2 className="font-display text-2xl font-bold">Events</h2>
-                <div className="flex items-center gap-2">
-                    {/* The invite link moved to the Team page (team-management action); Events keeps
-                        only event creation for admins. */}
-                    {isAdmin && <CreateEventSheet/>}
-                    {/* Always mounted: the popover now owns the only route to past events, so it
-                        must not disappear with the event types it also happens to host. */}
-                    <EventFiltersView
-                        eventTypes={eventTypes ?? []}
-                        activeTypeIds={activeTypeIds}
-                        showPast={showPast}
-                        onToggleType={(typeId) =>
-                            setActiveTypeIds(prev =>
-                                toggleTypeSelection(prev, (eventTypes ?? []).map(t => t.id), typeId))
-                        }
-                        onToggleShowPast={setShowPast}
-                    />
-                </div>
-            </div>
-
-            {/* No hero when nothing is within RELATIVE_WINDOW_DAYS — and no placeholder in its
-                place. The list carries the page. */}
-            {heroEvent && <NextEventHero event={heroEvent} now={now}/>}
-
-            {/* One button per event type with blanks left (ADR-0021); renders nothing at all when
-                there are none, so a fully-answered page reserves no empty row. */}
-            <BulkAttendBar events={bulkEvents}/>
-
-            <EventListView
-                events={listEvents}
-                // A rendered hero IS loaded data — it was pulled out of this very list — so an empty
-                // list beneath it means "nothing else", never a failure. Withholding the flags keeps
-                // the list from painting a skeleton or an error over a page that is plainly fine.
-                isLoading={heroEvent ? false : isLoading}
-                error={heroEvent ? undefined : error}
-                now={now}
-                emptyMessage={
-                    // With a hero on screen the page is not empty — the list just has nothing left
-                    // after the hero was pulled out of it.
-                    heroEvent
-                        ? 'Nothing else coming up.'
-                        : isTypeFiltered
-                            ? 'No events for this type.'
-                            : showPast
-                                ? 'No events yet.'
-                                : 'No upcoming events.'
-                }
-            />
-        </div>
-    )
-}
+export const Route = createFileRoute('/')({
+  beforeLoad: async () => {
+    // The root guard already confirmed the session and primed this query; read it back from cache.
+    const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
+    if (!user) throw redirect({ to: '/login' })
+    if (user.teams.length === 0) throw redirect({ to: '/onboarding' })
+    if (!user.activeTeam) throw redirect({ to: '/select-team' })
+    throw redirect({ to: teamRoutes(user.activeTeam.slug).events })
+  },
+})

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -7,12 +7,12 @@ import { teamRoutes } from '@shared/lib/team-routes'
  * The dispatcher. `/` names no Team, so it renders nothing — it answers "which Team am I in?" and
  * sends the caller there.
  *
- * It exists because team-scoped screens live under `/t/:slug/…` (ADR-0021 §2) while the app's own
+ * It exists because team-scoped screens live under `/t/:slug/…` (ADR-0023 §2) while the app's own
  * entry points — the installed PWA's start_url, a bookmark, the post-login redirect — cannot know a
  * slug. Resolving that here, from the Active Team the server already decided, keeps every one of
  * them a plain `/`.
  *
- * Three outcomes, matching the three states `/auth/me` can report (ADR-0021 §4): an Active Team, so
+ * Three outcomes, matching the three states `/auth/me` can report (ADR-0023 §4): an Active Team, so
  * go there; no Teams at all, so onboarding; several Teams and none active, which is not an error but
  * a choice the caller has to make.
  */

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -4,21 +4,12 @@ import { queryClient } from '@shared/api/query-client'
 import { teamRoutes } from '@shared/lib/team-routes'
 
 /**
- * The dispatcher. `/` names no Team, so it renders nothing — it answers "which Team am I in?" and
- * sends the caller there.
- *
- * It exists because team-scoped screens live under `/t/:slug/…` (ADR-0023 §2) while the app's own
- * entry points — the installed PWA's start_url, a bookmark, the post-login redirect — cannot know a
- * slug. Resolving that here, from the Active Team the server already decided, keeps every one of
- * them a plain `/`.
- *
- * Three outcomes, matching the three states `/auth/me` can report (ADR-0023 §4): an Active Team, so
- * go there; no Teams at all, so onboarding; several Teams and none active, which is not an error but
- * a choice the caller has to make.
+ * The dispatcher: `/` names no Team, so it renders nothing and sends the caller to theirs. It exists
+ * because the app's own entry points — the PWA start_url, a bookmark, the post-login redirect —
+ * cannot know a slug.
  */
 export const Route = createFileRoute('/')({
   beforeLoad: async () => {
-    // The root guard already confirmed the session and primed this query; read it back from cache.
     const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
     if (!user) throw redirect({ to: '/login' })
     if (user.teams.length === 0) throw redirect({ to: '/onboarding' })

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -32,9 +32,8 @@ function InvitePage() {
 
     acceptInvitation
       .mutateAsync(token)
-      // Reset rather than invalidate: accepting makes the joined Team Active (ADR-0023 §4), so a
-      // joiner who was already in another Team has just changed tenant, and every cached
-      // tenant-scoped query belongs to the Team they left. `/` then dispatches into the new one.
+      // Accepting makes the joined Team Active (ADR-0023 §4), so a joiner who was already in
+      // another Team has just changed tenant.
       .then(() => queryClient.resetQueries())
       .then(() => navigate({ to: '/', replace: true }))
       .catch(() => setError('This invite link is invalid or has expired.'))

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -32,7 +32,7 @@ function InvitePage() {
 
     acceptInvitation
       .mutateAsync(token)
-      // Reset rather than invalidate: accepting makes the joined Team Active (ADR-0021 §4), so a
+      // Reset rather than invalidate: accepting makes the joined Team Active (ADR-0023 §4), so a
       // joiner who was already in another Team has just changed tenant, and every cached
       // tenant-scoped query belongs to the Team they left. `/` then dispatches into the new one.
       .then(() => queryClient.resetQueries())

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -32,10 +32,10 @@ function InvitePage() {
 
     acceptInvitation
       .mutateAsync(token)
-      // Clear rather than invalidate: accepting makes the joined Team Active (ADR-0021 §4), so a
+      // Reset rather than invalidate: accepting makes the joined Team Active (ADR-0021 §4), so a
       // joiner who was already in another Team has just changed tenant, and every cached
       // tenant-scoped query belongs to the Team they left. `/` then dispatches into the new one.
-      .then(() => queryClient.clear())
+      .then(() => queryClient.resetQueries())
       .then(() => navigate({ to: '/', replace: true }))
       .catch(() => setError('This invite link is invalid or has expired.'))
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/routes/invite/$token.tsx
+++ b/app/src/routes/invite/$token.tsx
@@ -32,7 +32,10 @@ function InvitePage() {
 
     acceptInvitation
       .mutateAsync(token)
-      .then(() => queryClient.invalidateQueries({ queryKey: ['auth', 'me'] }))
+      // Clear rather than invalidate: accepting makes the joined Team Active (ADR-0021 §4), so a
+      // joiner who was already in another Team has just changed tenant, and every cached
+      // tenant-scoped query belongs to the Team they left. `/` then dispatches into the new one.
+      .then(() => queryClient.clear())
       .then(() => navigate({ to: '/', replace: true }))
       .catch(() => setError('This invite link is invalid or has expired.'))
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/routes/members/index.tsx
+++ b/app/src/routes/members/index.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
-
-// Retired. The roster now lives at /team (readable by every member); position management moved to
-// /team/settings. Bounce any lingering /members link there so there is only one roster surface.
-export const Route = createFileRoute('/members/')({
-  beforeLoad: () => {
-    throw redirect({ to: '/team' })
-  },
-})

--- a/app/src/routes/select-team.tsx
+++ b/app/src/routes/select-team.tsx
@@ -6,21 +6,15 @@ import { authMeQueryOptions } from '@shared/api/auth'
 import { SelectTeamView } from '@features/switch-team/ui/SelectTeamView'
 
 /**
- * "Which Team?" — the screen that exists because tenant resolution refuses to guess.
- *
- * A Member of several Teams with none remembered lands here rather than in an arbitrary one
- * (ADR-0023 §1/§3). Reaching it is a real state, not an error: it happens on a first sign-in after
- * joining a second Team, and after the remembered Team's membership ends.
- *
- * Picking a Team is an ordinary navigation to `/t/:slug` — that route's gate performs the authorized
- * switch, so this screen holds no switching logic of its own.
+ * "Which Team?" — where a Member of several Teams lands when none is remembered, because tenant
+ * resolution refuses to guess (ADR-0023 §1). Picking one is an ordinary navigation to `/t/:slug`,
+ * whose gate performs the switch.
  */
 export const Route = createFileRoute('/select-team')({
   beforeLoad: async () => {
     const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
     if (!user) throw redirect({ to: '/login' })
     if (user.teams.length === 0) throw redirect({ to: '/onboarding' })
-    // A caller who already has an Active Team has nothing to choose — `/` sends them into it.
     if (user.activeTeam) throw redirect({ to: '/' })
   },
   component: SelectTeamPage,

--- a/app/src/routes/select-team.tsx
+++ b/app/src/routes/select-team.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { useAuthMe } from '@shared/api/auth'
+import { teamRoutes } from '@shared/lib/team-routes'
+import { queryClient } from '@shared/api/query-client'
+import { authMeQueryOptions } from '@shared/api/auth'
+import { SelectTeamView } from '@features/switch-team/ui/SelectTeamView'
+
+/**
+ * "Which Team?" — the screen that exists because tenant resolution refuses to guess.
+ *
+ * A Member of several Teams with none remembered lands here rather than in an arbitrary one
+ * (ADR-0021 §1/§3). Reaching it is a real state, not an error: it happens on a first sign-in after
+ * joining a second Team, and after the remembered Team's membership ends.
+ *
+ * Picking a Team is an ordinary navigation to `/t/:slug` — that route's gate performs the authorized
+ * switch, so this screen holds no switching logic of its own.
+ */
+export const Route = createFileRoute('/select-team')({
+  beforeLoad: async () => {
+    const user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
+    if (!user) throw redirect({ to: '/login' })
+    if (user.teams.length === 0) throw redirect({ to: '/onboarding' })
+    // A caller who already has an Active Team has nothing to choose — `/` sends them into it.
+    if (user.activeTeam) throw redirect({ to: '/' })
+  },
+  component: SelectTeamPage,
+})
+
+function SelectTeamPage() {
+  const navigate = useNavigate()
+  const { data: user } = useAuthMe()
+
+  return (
+    <SelectTeamView
+      teams={user?.teams ?? []}
+      onSelect={(slug) => navigate({ to: teamRoutes(slug).events })}
+    />
+  )
+}

--- a/app/src/routes/select-team.tsx
+++ b/app/src/routes/select-team.tsx
@@ -9,7 +9,7 @@ import { SelectTeamView } from '@features/switch-team/ui/SelectTeamView'
  * "Which Team?" — the screen that exists because tenant resolution refuses to guess.
  *
  * A Member of several Teams with none remembered lands here rather than in an arbitrary one
- * (ADR-0021 §1/§3). Reaching it is a real state, not an error: it happens on a first sign-in after
+ * (ADR-0023 §1/§3). Reaching it is a real state, not an error: it happens on a first sign-in after
  * joining a second Team, and after the remembered Team's membership ends.
  *
  * Picking a Team is an ordinary navigation to `/t/:slug` — that route's gate performs the authorized

--- a/app/src/routes/t/$slug/events/$eventId.tsx
+++ b/app/src/routes/t/$slug/events/$eventId.tsx
@@ -19,8 +19,9 @@ import { AttendanceToggle, type AttendanceState } from '@features/attendance-tog
 import { EditEventDialog } from '@features/edit-event/ui/EditEventDialog'
 import { DeleteEventDialog } from '@features/edit-event/ui/DeleteEventDialog'
 import { PageHeader } from '@widgets/page-header/ui/PageHeader'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
-export const Route = createFileRoute('/events/$eventId')({
+export const Route = createFileRoute('/t/$slug/events/$eventId')({
   component: EventDetailPage,
 })
 
@@ -52,6 +53,7 @@ function AttendeeRow({ attendance }: { attendance: AttendanceEntry }) {
 
 function EventDetailPage() {
   const { eventId } = Route.useParams()
+  const routes = useTeamRoutes()
   const { data: event, isLoading, isError, refetch } = useEvent(eventId)
   const currentUserId = useUserStore((s) => s.userId)
   const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
@@ -69,7 +71,7 @@ function EventDetailPage() {
         onRetry={() => refetch()}
       >
         <Button asChild variant="ghost">
-          <Link to="/">Back to events</Link>
+          <Link to={routes.events}>Back to events</Link>
         </Button>
       </QueryErrorState>
     )
@@ -91,7 +93,7 @@ function EventDetailPage() {
   return (
     <div>
       {/* Sticky sub-header — offset comes from --header-height via PageHeader, not a magic pixel */}
-      <PageHeader title={event.title} backTo="/" backLabel="Back to events" />
+      <PageHeader title={event.title} backTo={routes.events} backLabel="Back to events" />
 
       {/* Event header */}
       <div className="mt-2 flex items-start gap-4">

--- a/app/src/routes/t/$slug/get-started/index.tsx
+++ b/app/src/routes/t/$slug/get-started/index.tsx
@@ -2,19 +2,20 @@ import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { currentMemberQueryOptions, useCurrentMember, useCompleteOnboarding, MemberUpdateError } from '@shared/api/members'
 import { usePositions } from '@shared/api/positions'
 import { queryClient } from '@shared/api/query-client'
+import { useTeamRoutes, teamRoutes } from '@shared/lib/team-routes'
 import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
 
-export const Route = createFileRoute('/get-started/')({
+export const Route = createFileRoute('/t/$slug/get-started/')({
   // A member who has already onboarded has no business here — bounce them home before render.
   // Reads the same cached /members/me the root gate primed (race-free, like the /members gate).
-  beforeLoad: async () => {
+  beforeLoad: async ({ params }) => {
     let member = null
     try {
       member = await queryClient.ensureQueryData(currentMemberQueryOptions)
     } catch {
       // Session/member unconfirmed — let the root guard handle it; don't block this screen.
     }
-    if (member?.onboarded) throw redirect({ to: '/' })
+    if (member?.onboarded) throw redirect({ to: teamRoutes(params.slug).events })
   },
   component: GetStartedPage,
 })
@@ -27,6 +28,7 @@ export const Route = createFileRoute('/get-started/')({
  */
 function GetStartedPage() {
   const navigate = useNavigate()
+  const routes = useTeamRoutes()
   const { data: member, isLoading, error } = useCurrentMember()
   const { data: positions } = usePositions()
   const completeOnboarding = useCompleteOnboarding()
@@ -54,7 +56,7 @@ function GetStartedPage() {
             onSubmit={(name, positionId) =>
               completeOnboarding.mutate(
                 { displayName: name, role: member.role, positionId },
-                { onSuccess: () => navigate({ to: '/' }) },
+                { onSuccess: () => navigate({ to: routes.events }) },
               )
             }
           />

--- a/app/src/routes/t/$slug/index.tsx
+++ b/app/src/routes/t/$slug/index.tsx
@@ -1,0 +1,129 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useMemo, useState } from 'react'
+import { useEvents } from '@shared/api/events'
+import { useEventTypes } from '@shared/api/event-types'
+import { useUserStore } from '@shared/stores/user-store'
+import { useNow } from '@shared/lib/use-now'
+import { EventListView } from '@entities/event/ui/EventListView'
+import { selectHeroEvent } from '@entities/event/lib/next-event'
+import { NextEventHero } from '@widgets/next-event-hero/ui/NextEventHero'
+import { CreateEventSheet } from '@widgets/create-event/ui/CreateEventSheet'
+import { EventFiltersView } from '@features/filter-event-types/ui/EventFiltersView'
+import { toggleTypeSelection } from '@features/filter-event-types/model/toggleTypeSelection'
+import { BulkAttendBar } from '@features/bulk-attend/ui/BulkAttendBar'
+import { eligibleEvents } from '@features/bulk-attend/lib/eligible-event-ids'
+
+export const Route = createFileRoute('/t/$slug/')({
+    component: EventListPage,
+})
+
+/**
+ * The events page. Composition, in order: a compact header with the filter trigger, the Next Up
+ * hero when (and only when) one is due, then one flat chronological list.
+ *
+ * All the deciding happens here so the views below stay prop-only: which events survive the type
+ * filter, whether there is a hero, and — because the hero must not appear twice — which event the
+ * list drops.
+ */
+function EventListPage() {
+    const [showPast, setShowPast] = useState(false)
+    const [activeTypeIds, setActiveTypeIds] = useState<Set<string>>(new Set())
+    const {data: events, isLoading, error} = useEvents(showPast)
+    const {data: eventTypes} = useEventTypes()
+    const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
+
+    useEffect(() => {
+        if (eventTypes && activeTypeIds.size === 0) {
+            setTimeout(() => setActiveTypeIds(new Set(eventTypes.map(t => t.id))))
+        }
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [eventTypes])
+
+    // One ticking clock for the whole page, so the hero's countdown, the hero cut-off and every
+    // card's relative label are read off the same instant and can never disagree with each other —
+    // and so a screen left open overnight stops claiming "Tomorrow" about today.
+    const now = useNow()
+
+    const filteredEvents = useMemo(() => {
+        if (!events || !eventTypes) return events ?? []
+        if (activeTypeIds.size === eventTypes.length) return events
+        return events.filter(e => activeTypeIds.has(e.eventType.id))
+    }, [events, activeTypeIds, eventTypes])
+
+    // The API returns upcoming ascending but "all" descending, so sort here: the list is flat now,
+    // and flat only reads if it is chronological.
+    const sortedEvents = useMemo(
+        () => [...filteredEvents].sort((a, b) => a.startTime.localeCompare(b.startTime)),
+        [filteredEvents],
+    )
+
+    const heroEvent = selectHeroEvent(sortedEvents, now)
+    const listEvents = heroEvent ? sortedEvents.filter(e => e.id !== heroEvent.id) : sortedEvents
+
+    const isTypeFiltered = activeTypeIds.size < (eventTypes?.length ?? 0)
+
+    // Bulk Attend acts on exactly what the page shows (ADR-0020), so it reads `sortedEvents` — the
+    // hero included, since pulling it out of the list does not stop it being on screen. Past events
+    // are excluded by the selector, not by the surrounding UI: with the tabs gone, `showPast` merely
+    // adds past events to the same list, so the future-only rule has to live in the selector.
+    // It reads the page's shared `now`, so the button and the cards can never disagree about which
+    // events have started.
+    const bulkEvents = useMemo(
+        () => eligibleEvents(sortedEvents, activeTypeIds, now),
+        [sortedEvents, activeTypeIds, now],
+    )
+
+    return (
+        <div>
+            <div className="flex items-center justify-between gap-2">
+                <h2 className="font-display text-2xl font-bold">Events</h2>
+                <div className="flex items-center gap-2">
+                    {/* The invite link moved to the Team page (team-management action); Events keeps
+                        only event creation for admins. */}
+                    {isAdmin && <CreateEventSheet/>}
+                    {/* Always mounted: the popover now owns the only route to past events, so it
+                        must not disappear with the event types it also happens to host. */}
+                    <EventFiltersView
+                        eventTypes={eventTypes ?? []}
+                        activeTypeIds={activeTypeIds}
+                        showPast={showPast}
+                        onToggleType={(typeId) =>
+                            setActiveTypeIds(prev =>
+                                toggleTypeSelection(prev, (eventTypes ?? []).map(t => t.id), typeId))
+                        }
+                        onToggleShowPast={setShowPast}
+                    />
+                </div>
+            </div>
+
+            {/* No hero when nothing is within RELATIVE_WINDOW_DAYS — and no placeholder in its
+                place. The list carries the page. */}
+            {heroEvent && <NextEventHero event={heroEvent} now={now}/>}
+
+            {/* One button per event type with blanks left (ADR-0021); renders nothing at all when
+                there are none, so a fully-answered page reserves no empty row. */}
+            <BulkAttendBar events={bulkEvents}/>
+
+            <EventListView
+                events={listEvents}
+                // A rendered hero IS loaded data — it was pulled out of this very list — so an empty
+                // list beneath it means "nothing else", never a failure. Withholding the flags keeps
+                // the list from painting a skeleton or an error over a page that is plainly fine.
+                isLoading={heroEvent ? false : isLoading}
+                error={heroEvent ? undefined : error}
+                now={now}
+                emptyMessage={
+                    // With a hero on screen the page is not empty — the list just has nothing left
+                    // after the hero was pulled out of it.
+                    heroEvent
+                        ? 'Nothing else coming up.'
+                        : isTypeFiltered
+                            ? 'No events for this type.'
+                            : showPast
+                                ? 'No events yet.'
+                                : 'No upcoming events.'
+                }
+            />
+        </div>
+    )
+}

--- a/app/src/routes/t/$slug/profile/index.tsx
+++ b/app/src/routes/t/$slug/profile/index.tsx
@@ -7,7 +7,7 @@ import { useUserStore } from '@shared/stores/user-store'
 import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
 import { ThemeToggle } from '@features/theme-toggle/ui/ThemeToggle'
 
-export const Route = createFileRoute('/profile/')({
+export const Route = createFileRoute('/t/$slug/profile/')({
   component: ProfilePage,
 })
 

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -19,11 +19,17 @@ import { teamRoutes } from '@shared/lib/team-routes'
  * The switch is skipped when the URL already names the Active Team — the common case, every
  * in-app navigation — so this costs one request per actual change of Team, not per page.
  *
- * **The cache is dropped on a real switch.** Every tenant-scoped query (events, members, positions,
+ * **The cache is reset on a real switch.** Every tenant-scoped query (events, members, positions,
  * the season) is keyed without the Team in it, because a request has exactly one Active Team; that
  * makes the cache the frontend's mirror of `TenantRoutingSession`'s memo, and it inherits the same
  * obligation. Keeping it across a switch would paint the previous Team's roster onto the new Team's
  * screens.
+ *
+ * `resetQueries`, specifically, and not `clear()`: a switch between two team-scoped routes keeps the
+ * same components mounted, and `clear()` empties the cache without telling those observers to fetch
+ * again — so the screen sits there showing the Team you just left, indefinitely. `resetQueries`
+ * discards the data *and* refetches what is on screen, which is the pair of things a tenant change
+ * actually needs.
  */
 export const Route = createFileRoute('/t/$slug')({
   beforeLoad: async ({ params, location }) => {
@@ -34,7 +40,7 @@ export const Route = createFileRoute('/t/$slug')({
       const activated = await activateTeam(params.slug).catch(() => null)
       // Unknown slug, or not theirs — indistinguishable by design. `/` decides where they do belong.
       if (!activated) throw redirect({ to: '/' })
-      queryClient.clear()
+      await queryClient.resetQueries()
       user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
       if (!user) throw redirect({ to: '/login' })
     }

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -8,7 +8,7 @@ import { teamRoutes } from '@shared/lib/team-routes'
 /**
  * The layout every team-scoped screen hangs off, and the one place the Active Team changes.
  *
- * **Opening a `/t/:slug/…` URL performs an authorized switch** (ADR-0021 §2) — that is the whole
+ * **Opening a `/t/:slug/…` URL performs an authorized switch** (ADR-0023 §2) — that is the whole
  * point of putting the slug in the URL: a teammate's link opens for anyone entitled to it, and there
  * is exactly one kind of switch, so a link-induced one and a tap in the switcher are the same
  * request and are remembered the same way (§3). A slug the caller may not have, and one that does
@@ -22,7 +22,7 @@ import { teamRoutes } from '@shared/lib/team-routes'
  * **The session, not this URL, is the authority on the tenant.** The slug asks for a Team; the
  * session decides. So two tabs cannot sit in two Teams: opening a link in a second tab switches the
  * one session, and the first tab then shows the other Team's data under its own slug until it
- * navigates. ADR-0021 §2 weighed exactly this — request-carried tenancy would have fixed it — and
+ * navigates. ADR-0023 §2 weighed exactly this — request-carried tenancy would have fixed it — and
  * took it as the price of keeping the installed PWA's navigation team-less. It is a stale *view*,
  * never a cross-tenant write to the wrong place: every request is scoped by the session the server
  * holds, and the slug influences it only through the authorized switch above. Revisit with the ADR

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -1,0 +1,53 @@
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+import { authMeQueryOptions } from '@shared/api/auth'
+import { currentMemberQueryOptions } from '@shared/api/members'
+import { queryClient } from '@shared/api/query-client'
+import { activateTeam } from '@shared/api/teams'
+import { teamRoutes } from '@shared/lib/team-routes'
+
+/**
+ * The layout every team-scoped screen hangs off, and the one place the Active Team changes.
+ *
+ * **Opening a `/t/:slug/…` URL performs an authorized switch** (ADR-0021 §2) — that is the whole
+ * point of putting the slug in the URL: a teammate's link opens for anyone entitled to it, and there
+ * is exactly one kind of switch, so a link-induced one and a tap in the switcher are the same
+ * request and are remembered the same way (§3). A slug the caller may not have, and one that does
+ * not exist, both fail the same way here: back to `/`, which re-resolves and lands them somewhere
+ * they are entitled to. No error screen names the Team, because the backend deliberately does not
+ * say which of the two happened.
+ *
+ * The switch is skipped when the URL already names the Active Team — the common case, every
+ * in-app navigation — so this costs one request per actual change of Team, not per page.
+ *
+ * **The cache is dropped on a real switch.** Every tenant-scoped query (events, members, positions,
+ * the season) is keyed without the Team in it, because a request has exactly one Active Team; that
+ * makes the cache the frontend's mirror of `TenantRoutingSession`'s memo, and it inherits the same
+ * obligation. Keeping it across a switch would paint the previous Team's roster onto the new Team's
+ * screens.
+ */
+export const Route = createFileRoute('/t/$slug')({
+  beforeLoad: async ({ params, location }) => {
+    let user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
+    if (!user) throw redirect({ to: '/login' })
+
+    if (user.activeTeam?.slug !== params.slug) {
+      const activated = await activateTeam(params.slug).catch(() => null)
+      // Unknown slug, or not theirs — indistinguishable by design. `/` decides where they do belong.
+      if (!activated) throw redirect({ to: '/' })
+      queryClient.clear()
+      user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
+      if (!user) throw redirect({ to: '/login' })
+    }
+
+    // Onboarding gate: a Member who hasn't completed onboarding is routed to /get-started before any
+    // team screen mounts. It lives here rather than in the root guard because onboarding is
+    // per-Team — joining a second Team means onboarding into it — so it can only be asked once the
+    // Active Team is settled. /get-started itself is exempt so the flow can render. Fail OPEN if the
+    // state can't be read: an onboarding-status blip shouldn't trap the user, and auth is confirmed.
+    const routes = teamRoutes(params.slug)
+    if (location.pathname.replace(/\/$/, '') === routes.getStarted) return
+    const member = await queryClient.ensureQueryData(currentMemberQueryOptions).catch(() => null)
+    if (member && !member.onboarded) throw redirect({ to: routes.getStarted })
+  },
+  component: () => <Outlet />,
+})

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -6,39 +6,12 @@ import { activateTeam } from '@shared/api/teams'
 import { teamRoutes } from '@shared/lib/team-routes'
 
 /**
- * The layout every team-scoped screen hangs off, and the one place the Active Team changes.
+ * The layout every team-scoped screen hangs off, and the one place the Active Team changes: opening
+ * a `/t/:slug/…` URL performs an authorized switch (ADR-0023 §2), so a teammate's link opens for
+ * anyone entitled to it.
  *
- * **Opening a `/t/:slug/…` URL performs an authorized switch** (ADR-0023 §2) — that is the whole
- * point of putting the slug in the URL: a teammate's link opens for anyone entitled to it, and there
- * is exactly one kind of switch, so a link-induced one and a tap in the switcher are the same
- * request and are remembered the same way (§3). A slug the caller may not have, and one that does
- * not exist, both fail the same way here: back to `/`, which re-resolves and lands them somewhere
- * they are entitled to. No error screen names the Team, because the backend deliberately does not
- * say which of the two happened.
- *
- * The switch is skipped when the URL already names the Active Team — the common case, every
- * in-app navigation — so this costs one request per actual change of Team, not per page.
- *
- * **The session, not this URL, is the authority on the tenant.** The slug asks for a Team; the
- * session decides. So two tabs cannot sit in two Teams: opening a link in a second tab switches the
- * one session, and the first tab then shows the other Team's data under its own slug until it
- * navigates. ADR-0023 §2 weighed exactly this — request-carried tenancy would have fixed it — and
- * took it as the price of keeping the installed PWA's navigation team-less. It is a stale *view*,
- * never a cross-tenant write to the wrong place: every request is scoped by the session the server
- * holds, and the slug influences it only through the authorized switch above. Revisit with the ADR
- * if tab-per-team ergonomics become a real complaint, not by making the URL authoritative here.
- *
- * **The cache is reset on a real switch.** Every tenant-scoped query (events, members, positions,
- * the season) is keyed without the Team in it, because a request has exactly one Active Team; that
- * makes the cache the frontend's mirror of `TenantRoutingSession`'s memo, and it inherits the same
- * obligation. Keeping it across a switch would paint the previous Team's roster onto the new Team's
- * screens.
- *
- * `resetQueries`, specifically, and not `clear()`: a switch between two team-scoped routes keeps the
- * same components mounted, and `clear()` empties the cache without telling those observers to fetch
- * again — so the screen sits there showing the Team you just left, indefinitely. `resetQueries`
- * discards the data *and* refetches what is on screen, which is the pair of things a tenant change
- * actually needs.
+ * The session, not this URL, is the authority on the tenant — two tabs therefore share one Active
+ * Team, which ADR-0023 §2 accepted as the price of team-less PWA navigation.
  */
 export const Route = createFileRoute('/t/$slug')({
   beforeLoad: async ({ params, location }) => {
@@ -47,18 +20,17 @@ export const Route = createFileRoute('/t/$slug')({
 
     if (user.activeTeam?.slug !== params.slug) {
       const activated = await activateTeam(params.slug).catch(() => null)
-      // Unknown slug, or not theirs — indistinguishable by design. `/` decides where they do belong.
       if (!activated) throw redirect({ to: '/' })
+      // Tenant-scoped queries are keyed without the Team in them, so they belong to the Team just
+      // left. resetQueries, not clear(): a switch keeps the same components mounted, and clear()
+      // empties the cache without telling those observers to refetch.
       await queryClient.resetQueries()
       user = await queryClient.ensureQueryData(authMeQueryOptions).catch(() => null)
       if (!user) throw redirect({ to: '/login' })
     }
 
-    // Onboarding gate: a Member who hasn't completed onboarding is routed to /get-started before any
-    // team screen mounts. It lives here rather than in the root guard because onboarding is
-    // per-Team — joining a second Team means onboarding into it — so it can only be asked once the
-    // Active Team is settled. /get-started itself is exempt so the flow can render. Fail OPEN if the
-    // state can't be read: an onboarding-status blip shouldn't trap the user, and auth is confirmed.
+    // Onboarding is per-Team, so it can only be asked once the Active Team is settled — hence here
+    // rather than in the root guard. Fails open: a status blip must not trap a confirmed caller.
     const routes = teamRoutes(params.slug)
     if (location.pathname.replace(/\/$/, '') === routes.getStarted) return
     const member = await queryClient.ensureQueryData(currentMemberQueryOptions).catch(() => null)

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -19,6 +19,15 @@ import { teamRoutes } from '@shared/lib/team-routes'
  * The switch is skipped when the URL already names the Active Team — the common case, every
  * in-app navigation — so this costs one request per actual change of Team, not per page.
  *
+ * **The session, not this URL, is the authority on the tenant.** The slug asks for a Team; the
+ * session decides. So two tabs cannot sit in two Teams: opening a link in a second tab switches the
+ * one session, and the first tab then shows the other Team's data under its own slug until it
+ * navigates. ADR-0021 §2 weighed exactly this — request-carried tenancy would have fixed it — and
+ * took it as the price of keeping the installed PWA's navigation team-less. It is a stale *view*,
+ * never a cross-tenant write to the wrong place: every request is scoped by the session the server
+ * holds, and the slug influences it only through the authorized switch above. Revisit with the ADR
+ * if tab-per-team ergonomics become a real complaint, not by making the URL authoritative here.
+ *
  * **The cache is reset on a real switch.** Every tenant-scoped query (events, members, positions,
  * the season) is keyed without the Team in it, because a request has exactly one Active Team; that
  * makes the cache the frontend's mirror of `TenantRoutingSession`'s memo, and it inherits the same

--- a/app/src/routes/t/$slug/team/index.tsx
+++ b/app/src/routes/t/$slug/team/index.tsx
@@ -9,7 +9,7 @@ import { useUserStore } from '@shared/stores/user-store'
 // Admins additionally get the invite link + the gear in the header (below) linking into
 // /team/settings, where member management lives — the team actions on the team screen, under the
 // new tab-bar nav.
-export const Route = createFileRoute('/team/')({
+export const Route = createFileRoute('/t/$slug/team/')({
   component: TeamPage,
 })
 

--- a/app/src/routes/t/$slug/team/settings.tsx
+++ b/app/src/routes/t/$slug/team/settings.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/t/$slug/team/settings')({
     } catch {
       // Session unconfirmed — treat as not authorized.
     }
-    // `role` is the caller's Role in the ACTIVE Team (ADR-0021 §4) — and /t/$slug's gate has
+    // `role` is the caller's Role in the ACTIVE Team (ADR-0023 §4) — and /t/$slug's gate has
     // already switched to this slug, so it is the Role here. Someone who is an Admin of their other
     // Team is a plain member on this screen.
     if (user?.role !== 'ADMIN') throw redirect({ to: teamRoutes(params.slug).events })

--- a/app/src/routes/t/$slug/team/settings.tsx
+++ b/app/src/routes/t/$slug/team/settings.tsx
@@ -1,21 +1,25 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { authMeQueryOptions } from '@shared/api/auth'
 import { queryClient } from '@shared/api/query-client'
+import { teamRoutes } from '@shared/lib/team-routes'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
 import { TeamSettings } from '@features/team-settings/ui/TeamSettings'
 import { ManagePositions } from '@features/manage-positions/ui/ManagePositions'
 
-export const Route = createFileRoute('/team/settings')({
+export const Route = createFileRoute('/t/$slug/team/settings')({
   // Admin-only. Read the same /me query the root guard primed (from cache) and bounce non-admins
   // home before the settings mount — race-free, mirroring the /members admin gate.
-  beforeLoad: async () => {
+  beforeLoad: async ({ params }) => {
     let user = null
     try {
       user = await queryClient.ensureQueryData(authMeQueryOptions)
     } catch {
       // Session unconfirmed — treat as not authorized.
     }
-    if (user?.role !== 'ADMIN') throw redirect({ to: '/' })
+    // `role` is the caller's Role in the ACTIVE Team (ADR-0021 §4) — and /t/$slug's gate has
+    // already switched to this slug, so it is the Role here. Someone who is an Admin of their other
+    // Team is a plain member on this screen.
+    if (user?.role !== 'ADMIN') throw redirect({ to: teamRoutes(params.slug).events })
   },
   component: TeamSettingsPage,
 })

--- a/app/src/shared/api/auth-redirect.test.ts
+++ b/app/src/shared/api/auth-redirect.test.ts
@@ -26,7 +26,7 @@ describe('shouldRedirectToLogin', () => {
   })
 
   // Since #143 this 403 no longer means "teamless" alone — it is also what a Member of several
-  // Teams gets before one is Active (ADR-0021 §1). The screens that exist to resolve that must not
+  // Teams gets before one is Active (ADR-0023 §1). The screens that exist to resolve that must not
   // be bounced off it, or picking a Team would log you out on the way to picking it.
   it.each(['/select-team', '/select-team/', '/onboarding', '/create-team'])(
     'does NOT redirect from %s, which owns the no-Active-Team question itself',

--- a/app/src/shared/api/auth-redirect.test.ts
+++ b/app/src/shared/api/auth-redirect.test.ts
@@ -24,4 +24,24 @@ describe('shouldRedirectToLogin', () => {
       shouldRedirectToLogin({ status: 403, code: NO_TEAM_MEMBERSHIP_CODE, currentPath: '/login' }),
     ).toBe(false)
   })
+
+  // Since #143 this 403 no longer means "teamless" alone — it is also what a Member of several
+  // Teams gets before one is Active (ADR-0021 §1). The screens that exist to resolve that must not
+  // be bounced off it, or picking a Team would log you out on the way to picking it.
+  it.each(['/select-team', '/select-team/', '/onboarding', '/create-team'])(
+    'does NOT redirect from %s, which owns the no-Active-Team question itself',
+    (currentPath) => {
+      expect(shouldRedirectToLogin({ status: 403, code: NO_TEAM_MEMBERSHIP_CODE, currentPath })).toBe(false)
+    },
+  )
+
+  it('still redirects from a team-scoped screen whose tenant could not be resolved', () => {
+    expect(
+      shouldRedirectToLogin({
+        status: 403,
+        code: NO_TEAM_MEMBERSHIP_CODE,
+        currentPath: '/t/setpoint-vt/team',
+      }),
+    ).toBe(true)
+  })
 })

--- a/app/src/shared/api/auth-redirect.test.ts
+++ b/app/src/shared/api/auth-redirect.test.ts
@@ -25,9 +25,8 @@ describe('shouldRedirectToLogin', () => {
     ).toBe(false)
   })
 
-  // Since #143 this 403 no longer means "teamless" alone — it is also what a Member of several
-  // Teams gets before one is Active (ADR-0023 §1). The screens that exist to resolve that must not
-  // be bounced off it, or picking a Team would log you out on the way to picking it.
+  // This 403 no longer means "teamless" alone — a Member of several Teams gets it before one is
+  // Active — so picking a Team must not log you out on the way to picking it.
   it.each(['/select-team', '/select-team/', '/onboarding', '/create-team'])(
     'does NOT redirect from %s, which owns the no-Active-Team question itself',
     (currentPath) => {

--- a/app/src/shared/api/auth-redirect.ts
+++ b/app/src/shared/api/auth-redirect.ts
@@ -4,11 +4,9 @@ export const LOGIN_PATH = '/login'
 export const NO_TEAM_MEMBERSHIP_CODE = 'NO_TEAM_MEMBERSHIP'
 
 /**
- * The routes that already own the "you have no Active Team" question and must therefore never be
- * bounced off it. Since #143 that 403 no longer means only "teamless": it is also what a Member of
- * several Teams gets before one is chosen, and what a request to a Team the caller may not have
- * resolves to (ADR-0023 §1 — a rejected team id resolves to *no tenant*). Bouncing those to login
- * would log out a perfectly authenticated person.
+ * Routes that already own the "you have no Active Team" question. The 403 no longer means only
+ * "teamless" — a Member of several Teams gets it before choosing — so bouncing these to login would
+ * log out a perfectly authenticated person.
  */
 const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team']
 
@@ -16,10 +14,10 @@ const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team']
  * Whether an API response means we should bounce the user to the login screen. Kept pure (no
  * window/router) so it is unit-testable; the effectful redirect lives in [redirectToLogin].
  *
- * A 403 with the "no team membership" code means the request resolved to no tenant. That is a
- * session-shaped problem everywhere except on the screens that exist to fix it, which resolve it
- * themselves. Other 403s (e.g. "not a team admin") are genuine permission errors and stay inline.
- * The unauthenticated (401) case is handled by the route guard via the session probe, not here.
+ * A 403 with the "no team membership" code means the request resolved to no tenant — a
+ * session-shaped problem everywhere except on the screens that exist to fix it. Other 403s (e.g.
+ * "not a team admin") are genuine permission errors and stay inline. The 401 case is the route
+ * guard's, not this one's.
  */
 export function shouldRedirectToLogin(params: {
   status: number

--- a/app/src/shared/api/auth-redirect.ts
+++ b/app/src/shared/api/auth-redirect.ts
@@ -1,15 +1,25 @@
 export const LOGIN_PATH = '/login'
 
-/** Backend `code` (GlobalExceptionHandler) for an authenticated user who belongs to no team yet. */
+/** Backend `code` (GlobalExceptionHandler) for a request that resolved to no tenant. */
 export const NO_TEAM_MEMBERSHIP_CODE = 'NO_TEAM_MEMBERSHIP'
+
+/**
+ * The routes that already own the "you have no Active Team" question and must therefore never be
+ * bounced off it. Since #143 that 403 no longer means only "teamless": it is also what a Member of
+ * several Teams gets before one is chosen, and what a request to a Team the caller may not have
+ * resolves to (ADR-0021 §1 — a rejected team id resolves to *no tenant*). Bouncing those to login
+ * would log out a perfectly authenticated person.
+ */
+const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team']
 
 /**
  * Whether an API response means we should bounce the user to the login screen. Kept pure (no
  * window/router) so it is unit-testable; the effectful redirect lives in [redirectToLogin].
  *
- * A 403 with the "no team membership" code is a teamless authenticated user (send to login); other
- * 403s (e.g. "not a team admin") are genuine permission errors and stay inline. The unauthenticated
- * (401) case is handled by the route guard via the session probe, not here.
+ * A 403 with the "no team membership" code means the request resolved to no tenant. That is a
+ * session-shaped problem everywhere except on the screens that exist to fix it, which resolve it
+ * themselves. Other 403s (e.g. "not a team admin") are genuine permission errors and stay inline.
+ * The unauthenticated (401) case is handled by the route guard via the session probe, not here.
  */
 export function shouldRedirectToLogin(params: {
   status: number
@@ -17,7 +27,9 @@ export function shouldRedirectToLogin(params: {
   currentPath: string
 }): boolean {
   const { status, code, currentPath } = params
-  if (currentPath === LOGIN_PATH) return false
+  const path = currentPath.replace(/\/$/, '') || '/'
+  if (path === LOGIN_PATH) return false
+  if (TENANT_RESOLVING_PATHS.includes(path)) return false
   return status === 403 && code === NO_TEAM_MEMBERSHIP_CODE
 }
 

--- a/app/src/shared/api/auth-redirect.ts
+++ b/app/src/shared/api/auth-redirect.ts
@@ -7,7 +7,7 @@ export const NO_TEAM_MEMBERSHIP_CODE = 'NO_TEAM_MEMBERSHIP'
  * The routes that already own the "you have no Active Team" question and must therefore never be
  * bounced off it. Since #143 that 403 no longer means only "teamless": it is also what a Member of
  * several Teams gets before one is chosen, and what a request to a Team the caller may not have
- * resolves to (ADR-0021 §1 — a rejected team id resolves to *no tenant*). Bouncing those to login
+ * resolves to (ADR-0023 §1 — a rejected team id resolves to *no tenant*). Bouncing those to login
  * would log out a perfectly authenticated person.
  */
 const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team']

--- a/app/src/shared/api/teams.test.ts
+++ b/app/src/shared/api/teams.test.ts
@@ -7,7 +7,7 @@ describe('toCreateTeamError', () => {
     expect(err.code).toBe('INVALID_CREATION_CODE')
   })
 
-  // ADR-0019 §3's 409 ALREADY_IN_TEAM was lifted by ADR-0021 (#143), so a 409 now means one thing:
+  // ADR-0019 §3's 409 ALREADY_IN_TEAM was lifted by ADR-0023 (#143), so a 409 now means one thing:
   // the slug is taken. A stale backend still sending the old code must not be read as a slug clash
   // *message* by accident — it still lands on the slug field, which is the closest honest placement,
   // and the code no longer exists for the form to branch on.

--- a/app/src/shared/api/teams.test.ts
+++ b/app/src/shared/api/teams.test.ts
@@ -7,11 +7,11 @@ describe('toCreateTeamError', () => {
     expect(err.code).toBe('INVALID_CREATION_CODE')
   })
 
-  it('maps 409 ALREADY_IN_TEAM to a banner error', () => {
-    expect(toCreateTeamError(409, 'ALREADY_IN_TEAM').code).toBe('ALREADY_IN_TEAM')
-  })
-
-  it('maps any other 409 (backend TEAM_SLUG_TAKEN) to a slug-taken error', () => {
+  // ADR-0019 §3's 409 ALREADY_IN_TEAM was lifted by ADR-0021 (#143), so a 409 now means one thing:
+  // the slug is taken. A stale backend still sending the old code must not be read as a slug clash
+  // *message* by accident — it still lands on the slug field, which is the closest honest placement,
+  // and the code no longer exists for the form to branch on.
+  it('maps every 409 to a slug-taken error, the only conflict create-team has left', () => {
     expect(toCreateTeamError(409, 'TEAM_SLUG_TAKEN').code).toBe('SLUG_TAKEN')
     expect(toCreateTeamError(409, undefined).code).toBe('SLUG_TAKEN')
   })

--- a/app/src/shared/api/teams.test.ts
+++ b/app/src/shared/api/teams.test.ts
@@ -7,10 +7,7 @@ describe('toCreateTeamError', () => {
     expect(err.code).toBe('INVALID_CREATION_CODE')
   })
 
-  // ADR-0019 §3's 409 ALREADY_IN_TEAM was lifted by ADR-0023 (#143), so a 409 now means one thing:
-  // the slug is taken. A stale backend still sending the old code must not be read as a slug clash
-  // *message* by accident — it still lands on the slug field, which is the closest honest placement,
-  // and the code no longer exists for the form to branch on.
+  // ADR-0023 lifted ALREADY_IN_TEAM, so a 409 now means one thing: the slug is taken.
   it('maps every 409 to a slug-taken error, the only conflict create-team has left', () => {
     expect(toCreateTeamError(409, 'TEAM_SLUG_TAKEN').code).toBe('SLUG_TAKEN')
     expect(toCreateTeamError(409, undefined).code).toBe('SLUG_TAKEN')

--- a/app/src/shared/api/teams.ts
+++ b/app/src/shared/api/teams.ts
@@ -71,7 +71,7 @@ export function useCreateTeam() {
 }
 
 /**
- * Switches the caller's Active Team to the Team at [slug] — the authorized switch (ADR-0021 §2).
+ * Switches the caller's Active Team to the Team at [slug] — the authorized switch (ADR-0023 §2).
  * Both the Team switcher and opening a shared `/t/:slug/…` link perform exactly this request; there
  * is deliberately only one kind of switch.
  *

--- a/app/src/shared/api/teams.ts
+++ b/app/src/shared/api/teams.ts
@@ -71,13 +71,8 @@ export function useCreateTeam() {
 }
 
 /**
- * Switches the caller's Active Team to the Team at [slug] — the authorized switch (ADR-0023 §2).
- * Both the Team switcher and opening a shared `/t/:slug/…` link perform exactly this request; there
- * is deliberately only one kind of switch.
- *
- * Returns null when the slug is unknown *or* not the caller's — the backend answers both with the
- * same bare 404 so the Team address space cannot be probed, and this preserves that: callers get one
- * "you cannot go there", never a reason.
+ * The authorized switch (ADR-0023 §2). Null for an unknown slug *and* for one that is not the
+ * caller's — the backend answers both with the same bare 404, and this preserves that.
  */
 export async function activateTeam(slug: string): Promise<TeamRef | null> {
   const res = await api.ActivateTeam({ slug })

--- a/app/src/shared/api/teams.ts
+++ b/app/src/shared/api/teams.ts
@@ -1,8 +1,10 @@
 import { useMutation } from '@tanstack/react-query'
 import { api } from './wirespec-client'
+import type { TeamRef } from './generated/model/TeamRef'
 
-// Re-export the generated contract type so the app has a single source of truth.
+// Re-export the generated contract types so the app has a single source of truth.
 export type { Team } from './generated/model/Team'
+export type { TeamRef } from './generated/model/TeamRef'
 
 // Create-team can fail in ways the form must place differently: some inline on a specific field
 // (recoverable), some as a screen banner. The stable frontend code drives that placement + copy; it is
@@ -12,7 +14,6 @@ export type CreateTeamErrorCode =
   | 'SLUG_TAKEN'
   | 'INVALID_SLUG'
   | 'INVALID_NAME'
-  | 'ALREADY_IN_TEAM'
   | 'GENERIC'
 
 export class CreateTeamError extends Error {
@@ -36,7 +37,6 @@ export function toCreateTeamError(status: number, code: string | undefined): Cre
     return new CreateTeamError('INVALID_CREATION_CODE', "That creation code isn't valid.")
   }
   if (status === 409) {
-    if (code === 'ALREADY_IN_TEAM') return new CreateTeamError('ALREADY_IN_TEAM', "You're already on a team.")
     return new CreateTeamError('SLUG_TAKEN', 'That address is already taken — try another.')
   }
   if (status === 400) {
@@ -68,4 +68,18 @@ export function useCreateTeam() {
       throw toCreateTeamError(res.status, code)
     },
   })
+}
+
+/**
+ * Switches the caller's Active Team to the Team at [slug] — the authorized switch (ADR-0021 §2).
+ * Both the Team switcher and opening a shared `/t/:slug/…` link perform exactly this request; there
+ * is deliberately only one kind of switch.
+ *
+ * Returns null when the slug is unknown *or* not the caller's — the backend answers both with the
+ * same bare 404 so the Team address space cannot be probed, and this preserves that: callers get one
+ * "you cannot go there", never a reason.
+ */
+export async function activateTeam(slug: string): Promise<TeamRef | null> {
+  const res = await api.ActivateTeam({ slug })
+  return res.status === 200 ? res.body : null
 }

--- a/app/src/shared/lib/team-routes.test.ts
+++ b/app/src/shared/lib/team-routes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { teamRoutes, teamSlugFromPath } from './team-routes'
+
+describe('teamSlugFromPath', () => {
+  it('reads the slug from a team-scoped path', () => {
+    expect(teamSlugFromPath('/t/setpoint-vt')).toBe('setpoint-vt')
+    expect(teamSlugFromPath('/t/setpoint-vt/')).toBe('setpoint-vt')
+    expect(teamSlugFromPath('/t/setpoint-vt/team/settings')).toBe('setpoint-vt')
+  })
+
+  it('is null for paths that are not team-scoped', () => {
+    expect(teamSlugFromPath('/')).toBeNull()
+    expect(teamSlugFromPath('/login')).toBeNull()
+    expect(teamSlugFromPath('/onboarding/join')).toBeNull()
+    expect(teamSlugFromPath('/create-team')).toBeNull()
+  })
+
+  // A near-miss must not be read as a Team: `/team` is a legacy path and `/t/` names no Team at all.
+  // Getting this wrong would send the route gate off to switch to a Team called "eam".
+  it('is null for near-misses', () => {
+    expect(teamSlugFromPath('/team')).toBeNull()
+    expect(teamSlugFromPath('/team/settings')).toBeNull()
+    expect(teamSlugFromPath('/t/')).toBeNull()
+    expect(teamSlugFromPath('/things')).toBeNull()
+  })
+
+  it('decodes a percent-encoded slug', () => {
+    expect(teamSlugFromPath('/t/tovo%20heren/team')).toBe('tovo heren')
+  })
+})
+
+describe('teamRoutes', () => {
+  it('builds every team-scoped destination under the slug', () => {
+    const routes = teamRoutes('setpoint-vt')
+    expect(routes.events).toBe('/t/setpoint-vt')
+    expect(routes.event('abc-123')).toBe('/t/setpoint-vt/events/abc-123')
+    expect(routes.team).toBe('/t/setpoint-vt/team')
+    expect(routes.teamSettings).toBe('/t/setpoint-vt/team/settings')
+    expect(routes.profile).toBe('/t/setpoint-vt/profile')
+    expect(routes.getStarted).toBe('/t/setpoint-vt/get-started')
+  })
+
+  // Without a Team in the URL there is no team-scoped destination to name; `/` is the dispatcher
+  // that resolves the Active Team and redirects into it.
+  it('collapses to the dispatcher when no Team is in scope', () => {
+    const routes = teamRoutes(null)
+    expect(routes.events).toBe('/')
+    expect(routes.event('abc-123')).toBe('/')
+    expect(routes.teamSettings).toBe('/')
+  })
+
+  it('round-trips through teamSlugFromPath', () => {
+    expect(teamSlugFromPath(teamRoutes('setpoint-vt').teamSettings)).toBe('setpoint-vt')
+  })
+})

--- a/app/src/shared/lib/team-routes.ts
+++ b/app/src/shared/lib/team-routes.ts
@@ -1,0 +1,70 @@
+import { useRouterState } from '@tanstack/react-router'
+
+/**
+ * Team-scoped routes all live under `/t/:slug/…` (ADR-0021 §2), so a link a teammate shares opens
+ * for anyone entitled to it and opening one performs an authorized switch of the Active Team.
+ *
+ * The slug is read back out of the URL rather than threaded through props or a store. Two reasons:
+ * the URL is the authority on which Team the screen is showing (it is what the route gate switched
+ * to), and reading it keeps every linking component a pure function of the current location — which
+ * is what lets Storybook drive them by simply starting the router at a path.
+ */
+const TEAM_PREFIX = '/t/'
+
+/**
+ * The Team slug the given path is scoped to, or null for a path that is not team-scoped (`/login`,
+ * `/onboarding`, `/create-team`, …).
+ *
+ * Deliberately strict: the segment right after `/t/` and nothing else. `/t/` with no slug, and a
+ * `/team`-style path that merely starts with the same letters, are both "not team-scoped" — a
+ * near-miss must not be read as a Team named after whatever followed.
+ */
+export function teamSlugFromPath(pathname: string): string | null {
+  if (!pathname.startsWith(TEAM_PREFIX)) return null
+  const slug = pathname.slice(TEAM_PREFIX.length).split('/')[0]
+  return slug === '' ? null : decodeURIComponent(slug)
+}
+
+export interface TeamRoutes {
+  /** The Team's home — the events list. */
+  events: string
+  event: (eventId: string) => string
+  team: string
+  teamSettings: string
+  profile: string
+  getStarted: string
+}
+
+/**
+ * The team-scoped destinations for [slug].
+ *
+ * With no slug — a component rendered outside a Team route, which in the app happens only in
+ * Storybook — every destination collapses to `/`, the dispatcher that resolves the caller's Active
+ * Team and redirects into it. That is the honest answer: without a Team in the URL there is no
+ * team-scoped destination to name, and `/` is where the app decides which one it should be.
+ */
+export function teamRoutes(slug: string | null): TeamRoutes {
+  if (slug === null) {
+    return { events: '/', event: () => '/', team: '/', teamSettings: '/', profile: '/', getStarted: '/' }
+  }
+  const base = `${TEAM_PREFIX}${encodeURIComponent(slug)}`
+  return {
+    events: base,
+    event: (eventId) => `${base}/events/${encodeURIComponent(eventId)}`,
+    team: `${base}/team`,
+    teamSettings: `${base}/team/settings`,
+    profile: `${base}/profile`,
+    getStarted: `${base}/get-started`,
+  }
+}
+
+/** [teamRoutes] for the Team the caller is currently in, derived from the location. */
+export function useTeamRoutes(): TeamRoutes {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  return teamRoutes(teamSlugFromPath(pathname))
+}
+
+/** The Active Team's slug as the URL states it, or null outside a team-scoped route. */
+export function useTeamSlug(): string | null {
+  return useRouterState({ select: (s) => teamSlugFromPath(s.location.pathname) })
+}

--- a/app/src/shared/lib/team-routes.ts
+++ b/app/src/shared/lib/team-routes.ts
@@ -1,7 +1,7 @@
 import { useRouterState } from '@tanstack/react-router'
 
 /**
- * Team-scoped routes all live under `/t/:slug/…` (ADR-0021 §2), so a link a teammate shares opens
+ * Team-scoped routes all live under `/t/:slug/…` (ADR-0023 §2), so a link a teammate shares opens
  * for anyone entitled to it and opening one performs an authorized switch of the Active Team.
  *
  * The slug is read back out of the URL rather than threaded through props or a store. Two reasons:

--- a/app/src/shared/lib/team-routes.ts
+++ b/app/src/shared/lib/team-routes.ts
@@ -1,24 +1,13 @@
 import { useRouterState } from '@tanstack/react-router'
 
 /**
- * Team-scoped routes all live under `/t/:slug/…` (ADR-0023 §2), so a link a teammate shares opens
- * for anyone entitled to it and opening one performs an authorized switch of the Active Team.
- *
- * The slug is read back out of the URL rather than threaded through props or a store. Two reasons:
- * the URL is the authority on which Team the screen is showing (it is what the route gate switched
- * to), and reading it keeps every linking component a pure function of the current location — which
- * is what lets Storybook drive them by simply starting the router at a path.
+ * Team-scoped routes live under `/t/:slug/…` (ADR-0023 §2). The slug is read back out of the URL
+ * rather than threaded through props or a store, which keeps every linking component a pure function
+ * of the current location — and lets Storybook drive them by starting the router at a path.
  */
 const TEAM_PREFIX = '/t/'
 
-/**
- * The Team slug the given path is scoped to, or null for a path that is not team-scoped (`/login`,
- * `/onboarding`, `/create-team`, …).
- *
- * Deliberately strict: the segment right after `/t/` and nothing else. `/t/` with no slug, and a
- * `/team`-style path that merely starts with the same letters, are both "not team-scoped" — a
- * near-miss must not be read as a Team named after whatever followed.
- */
+/** Null for a path that is not team-scoped. Strict: the segment right after `/t/` and nothing else. */
 export function teamSlugFromPath(pathname: string): string | null {
   if (!pathname.startsWith(TEAM_PREFIX)) return null
   const slug = pathname.slice(TEAM_PREFIX.length).split('/')[0]
@@ -36,12 +25,8 @@ export interface TeamRoutes {
 }
 
 /**
- * The team-scoped destinations for [slug].
- *
- * With no slug — a component rendered outside a Team route, which in the app happens only in
- * Storybook — every destination collapses to `/`, the dispatcher that resolves the caller's Active
- * Team and redirects into it. That is the honest answer: without a Team in the URL there is no
- * team-scoped destination to name, and `/` is where the app decides which one it should be.
+ * With no slug every destination collapses to `/`, the dispatcher that resolves the Active Team:
+ * outside a Team route there is no team-scoped destination to name.
  */
 export function teamRoutes(slug: string | null): TeamRoutes {
   if (slug === null) {
@@ -58,7 +43,7 @@ export function teamRoutes(slug: string | null): TeamRoutes {
   }
 }
 
-/** [teamRoutes] for the Team the caller is currently in, derived from the location. */
+/** [teamRoutes] for the Team the caller is currently in. */
 export function useTeamRoutes(): TeamRoutes {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   return teamRoutes(teamSlugFromPath(pathname))

--- a/app/src/shared/stores/user-store.test.ts
+++ b/app/src/shared/stores/user-store.test.ts
@@ -47,7 +47,7 @@ describe('user-store', () => {
     })
   })
 
-  // The whole point of ADR-0021: which Teams you are a Member of and which one this session is
+  // The whole point of ADR-0023: which Teams you are a Member of and which one this session is
   // scoped to are different questions. The store names the ACTIVE one — never the first of the list.
   it('names the Active Team, not the first of several memberships', () => {
     useUserStore.getState().setCurrentUser({

--- a/app/src/shared/stores/user-store.test.ts
+++ b/app/src/shared/stores/user-store.test.ts
@@ -5,7 +5,18 @@ import { useUserStore } from './user-store'
 // Pure store logic — the setCurrentUser mapping from AuthenticatedUser onto the flat store shape.
 // No rendering (that would be Storybook's job); this is the "stores" case the strategy assigns to
 // Vitest. Reset to the initial snapshot between tests so ordering can't leak state.
-const INITIAL = { userId: null, displayName: null, email: null, role: null, teamName: null, isPlatformAdmin: false }
+const INITIAL = {
+  userId: null,
+  displayName: null,
+  email: null,
+  role: null,
+  teamName: null,
+  teamSlug: null,
+  isPlatformAdmin: false,
+}
+
+const HEREN_3 = { id: 't-1', name: 'Heren 3', slug: 'heren-3' }
+const DAMES_2 = { id: 't-2', name: 'Dames 2', slug: 'dames-2' }
 
 describe('user-store', () => {
   beforeEach(() => {
@@ -18,7 +29,8 @@ describe('user-store', () => {
       email: 'alice@example.com',
       displayName: 'Alice',
       role: 'ADMIN',
-      team: { id: 't-1', name: 'Heren 3', slug: 'heren-3' },
+      teams: [HEREN_3],
+      activeTeam: HEREN_3,
       isPlatformAdmin: true,
     }
 
@@ -30,17 +42,52 @@ describe('user-store', () => {
       email: 'alice@example.com',
       role: 'ADMIN',
       teamName: 'Heren 3',
+      teamSlug: 'heren-3',
       isPlatformAdmin: true,
     })
   })
 
-  it('defaults teamName to null when the user has no team', () => {
+  // The whole point of ADR-0021: which Teams you are a Member of and which one this session is
+  // scoped to are different questions. The store names the ACTIVE one — never the first of the list.
+  it('names the Active Team, not the first of several memberships', () => {
+    useUserStore.getState().setCurrentUser({
+      id: 'u-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      role: 'USER',
+      teams: [HEREN_3, DAMES_2],
+      activeTeam: DAMES_2,
+      isPlatformAdmin: false,
+    })
+
+    expect(useUserStore.getState()).toMatchObject({ teamName: 'Dames 2', teamSlug: 'dames-2' })
+  })
+
+  // A Member of several Teams with none chosen yet: they have memberships, but no Team is active,
+  // so there is nothing to name. Reading the list's first entry here would be the old bug wearing
+  // frontend clothes.
+  it('names no Team when memberships exist but none is active', () => {
+    useUserStore.getState().setCurrentUser({
+      id: 'u-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      role: undefined,
+      teams: [HEREN_3, DAMES_2],
+      activeTeam: undefined,
+      isPlatformAdmin: false,
+    })
+
+    expect(useUserStore.getState()).toMatchObject({ teamName: null, teamSlug: null, role: null })
+  })
+
+  it('defaults teamName to null for a teamless user', () => {
     useUserStore.getState().setCurrentUser({
       id: 'u-3',
       email: 'carol@example.com',
       displayName: 'Carol',
       role: undefined,
-      team: undefined,
+      teams: [],
+      activeTeam: undefined,
       isPlatformAdmin: false,
     })
 
@@ -53,7 +100,8 @@ describe('user-store', () => {
       email: 'bob@example.com',
       displayName: 'Bob',
       role: undefined,
-      team: undefined,
+      teams: [],
+      activeTeam: undefined,
       isPlatformAdmin: false,
     })
 
@@ -66,7 +114,8 @@ describe('user-store', () => {
       email: 'dave@example.com',
       displayName: 'Dave',
       role: 'USER',
-      team: undefined,
+      teams: [],
+      activeTeam: undefined,
       isPlatformAdmin: false,
     })
 
@@ -79,7 +128,8 @@ describe('user-store', () => {
       email: 'alice@example.com',
       displayName: 'Alice',
       role: 'ADMIN',
-      team: undefined,
+      teams: [HEREN_3],
+      activeTeam: HEREN_3,
       isPlatformAdmin: true,
     })
 

--- a/app/src/shared/stores/user-store.test.ts
+++ b/app/src/shared/stores/user-store.test.ts
@@ -47,8 +47,6 @@ describe('user-store', () => {
     })
   })
 
-  // The whole point of ADR-0023: which Teams you are a Member of and which one this session is
-  // scoped to are different questions. The store names the ACTIVE one — never the first of the list.
   it('names the Active Team, not the first of several memberships', () => {
     useUserStore.getState().setCurrentUser({
       id: 'u-1',
@@ -63,9 +61,7 @@ describe('user-store', () => {
     expect(useUserStore.getState()).toMatchObject({ teamName: 'Dames 2', teamSlug: 'dames-2' })
   })
 
-  // A Member of several Teams with none chosen yet: they have memberships, but no Team is active,
-  // so there is nothing to name. Reading the list's first entry here would be the old bug wearing
-  // frontend clothes.
+  // Reading the list's first entry here would be the old misrouting wearing frontend clothes.
   it('names no Team when memberships exist but none is active', () => {
     useUserStore.getState().setCurrentUser({
       id: 'u-1',

--- a/app/src/shared/stores/user-store.ts
+++ b/app/src/shared/stores/user-store.ts
@@ -5,7 +5,7 @@ interface UserState {
   userId: string | null
   displayName: string | null
   email: string | null
-  /** The caller's Role **in the Active Team** — null when no Team is active (ADR-0021 §4). */
+  /** The caller's Role **in the Active Team** — null when no Team is active (ADR-0023 §4). */
   role: string | null
   /** The Active Team's name, or null when none is active. */
   teamName: string | null
@@ -25,7 +25,7 @@ export const useUserStore = create<UserState>((set) => ({
   isPlatformAdmin: false,
   // Everything Team-shaped is read off `activeTeam`, never off `teams`: which Team the caller is a
   // Member of and which one this session is scoped to are different questions, and the list's order
-  // answers neither (ADR-0021 §1).
+  // answers neither (ADR-0023 §1).
   setCurrentUser: (user) =>
     set({
       userId: user?.id ?? null,

--- a/app/src/shared/stores/user-store.ts
+++ b/app/src/shared/stores/user-store.ts
@@ -5,8 +5,12 @@ interface UserState {
   userId: string | null
   displayName: string | null
   email: string | null
+  /** The caller's Role **in the Active Team** — null when no Team is active (ADR-0021 §4). */
   role: string | null
+  /** The Active Team's name, or null when none is active. */
   teamName: string | null
+  /** The Active Team's slug — the address its screens live under (`/t/:slug/…`). */
+  teamSlug: string | null
   isPlatformAdmin: boolean
   setCurrentUser: (user: AuthenticatedUser | null) => void
 }
@@ -17,14 +21,19 @@ export const useUserStore = create<UserState>((set) => ({
   email: null,
   role: null,
   teamName: null,
+  teamSlug: null,
   isPlatformAdmin: false,
+  // Everything Team-shaped is read off `activeTeam`, never off `teams`: which Team the caller is a
+  // Member of and which one this session is scoped to are different questions, and the list's order
+  // answers neither (ADR-0021 §1).
   setCurrentUser: (user) =>
     set({
       userId: user?.id ?? null,
       displayName: user?.displayName ?? null,
       email: user?.email ?? null,
       role: user?.role ?? null,
-      teamName: user?.team?.name ?? null,
+      teamName: user?.activeTeam?.name ?? null,
+      teamSlug: user?.activeTeam?.slug ?? null,
       isPlatformAdmin: user?.isPlatformAdmin ?? false,
     }),
 }))

--- a/app/src/shared/stores/user-store.ts
+++ b/app/src/shared/stores/user-store.ts
@@ -23,9 +23,7 @@ export const useUserStore = create<UserState>((set) => ({
   teamName: null,
   teamSlug: null,
   isPlatformAdmin: false,
-  // Everything Team-shaped is read off `activeTeam`, never off `teams`: which Team the caller is a
-  // Member of and which one this session is scoped to are different questions, and the list's order
-  // answers neither (ADR-0023 §1).
+  // Read off `activeTeam`, never `teams`: the list's order says nothing about which is active.
   setCurrentUser: (user) =>
     set({
       userId: user?.id ?? null,

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -4,9 +4,14 @@ import { withRouter } from '@shared/testing/router-decorator'
 import { BottomNav } from './BottomNav'
 
 // BottomNav renders TanStack Router <Link>s, so it needs a router in context — supplied by the
-// shared withRouter decorator. It is now a live three-tab bar (Events · Team · Profile) with no
-// disabled tabs; the active tab is derived from the current route. Each story starts the router at
-// a different path (via parameters.router.initialEntries) to pin the active-state wiring.
+// shared withRouter decorator. It is a live three-tab bar (Events · Team · Profile) with no disabled
+// tabs; the active tab is derived from the current route. Each story starts the router at a
+// different path (via parameters.router.initialEntries) to pin the active-state wiring.
+//
+// Every tab is team-scoped since #143: the targets are built from the slug in the path the bar is
+// rendered on (ADR-0021 §2), which is exactly why starting the router at a path is enough to drive
+// them — there is no store to prime. The href assertions below are what would catch a tab that
+// stopped following the Active Team and started pointing at some other Team's screens.
 const meta = {
   title: 'shared/ui/BottomNav',
   component: BottomNav,
@@ -19,9 +24,9 @@ type Story = StoryObj<typeof meta>
 
 // Every tab routes to a real destination — assert the href wiring holds regardless of which is active.
 async function expectTabTargets(canvas: Parameters<NonNullable<Story['play']>>[0]['canvas']) {
-  await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('href', '/')
-  await expect(canvas.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/team')
-  await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/profile')
+  await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('href', '/t/setpoint-vt')
+  await expect(canvas.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/t/setpoint-vt/team')
+  await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/t/setpoint-vt/profile')
   // No dead tabs: nothing is disabled/non-interactive anymore.
   await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('pointer-events-none')
   await expect(canvas.getByRole('link', { name: 'Team' })).not.toHaveClass('pointer-events-none')
@@ -31,7 +36,7 @@ async function expectTabTargets(canvas: Parameters<NonNullable<Story['play']>>[0
 }
 
 export const EventsActive: Story = {
-  parameters: { router: { initialEntries: ['/'] } },
+  parameters: { router: { initialEntries: ['/t/setpoint-vt'] } },
   play: async ({ canvas }) => {
     await expectTabTargets(canvas)
     await expect(canvas.getByRole('link', { name: 'Events' })).toHaveClass('text-blue')
@@ -42,7 +47,7 @@ export const EventsActive: Story = {
 }
 
 export const TeamActive: Story = {
-  parameters: { router: { initialEntries: ['/team'] } },
+  parameters: { router: { initialEntries: ['/t/setpoint-vt/team'] } },
   play: async ({ canvas }) => {
     await expectTabTargets(canvas)
     await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('text-blue')
@@ -55,7 +60,7 @@ export const TeamActive: Story = {
 
 // The Team tab stays active on nested team routes (e.g. the admin settings sub-page).
 export const TeamSettingsActive: Story = {
-  parameters: { router: { initialEntries: ['/team/settings'] } },
+  parameters: { router: { initialEntries: ['/t/setpoint-vt/team/settings'] } },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('text-blue')
     await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')
@@ -63,7 +68,7 @@ export const TeamSettingsActive: Story = {
 }
 
 export const ProfileActive: Story = {
-  parameters: { router: { initialEntries: ['/profile'] } },
+  parameters: { router: { initialEntries: ['/t/setpoint-vt/profile'] } },
   play: async ({ canvas }) => {
     await expectTabTargets(canvas)
     await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveClass('text-blue')

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -8,10 +8,8 @@ import { BottomNav } from './BottomNav'
 // tabs; the active tab is derived from the current route. Each story starts the router at a
 // different path (via parameters.router.initialEntries) to pin the active-state wiring.
 //
-// Every tab is team-scoped since #143: the targets are built from the slug in the path the bar is
-// rendered on (ADR-0023 §2), which is exactly why starting the router at a path is enough to drive
-// them — there is no store to prime. The href assertions below are what would catch a tab that
-// stopped following the Active Team and started pointing at some other Team's screens.
+// The tab targets are built from the slug in the path the bar is rendered on (ADR-0023 §2), which is
+// why starting the router at a path is enough to drive them — there is no store to prime.
 const meta = {
   title: 'shared/ui/BottomNav',
   component: BottomNav,

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -9,7 +9,7 @@ import { BottomNav } from './BottomNav'
 // different path (via parameters.router.initialEntries) to pin the active-state wiring.
 //
 // Every tab is team-scoped since #143: the targets are built from the slug in the path the bar is
-// rendered on (ADR-0021 §2), which is exactly why starting the router at a path is enough to drive
+// rendered on (ADR-0023 §2), which is exactly why starting the router at a path is enough to drive
 // them — there is no store to prime. The href assertions below are what would catch a tab that
 // stopped following the Active Team and started pointing at some other Team's screens.
 const meta = {

--- a/app/src/shared/ui/BottomNav.tsx
+++ b/app/src/shared/ui/BottomNav.tsx
@@ -12,7 +12,7 @@ interface TabConfig {
   isActive: (pathname: string) => boolean
 }
 
-// The tabs are team-scoped (ADR-0021 §2), built from the slug in the URL the bar is rendered on
+// The tabs are team-scoped (ADR-0023 §2), built from the slug in the URL the bar is rendered on
 // rather than from a store. Deriving them from the location is what keeps this component a pure
 // function of where you are: switch Team and every tab follows, with nothing to keep in sync.
 function tabsFor(routes: TeamRoutes): TabConfig[] {

--- a/app/src/shared/ui/BottomNav.tsx
+++ b/app/src/shared/ui/BottomNav.tsx
@@ -12,9 +12,7 @@ interface TabConfig {
   isActive: (pathname: string) => boolean
 }
 
-// The tabs are team-scoped (ADR-0023 §2), built from the slug in the URL the bar is rendered on
-// rather than from a store. Deriving them from the location is what keeps this component a pure
-// function of where you are: switch Team and every tab follows, with nothing to keep in sync.
+// Built from the slug in the URL rather than a store, so switching Team makes every tab follow.
 function tabsFor(routes: TeamRoutes): TabConfig[] {
   const exact = (path: string) => (p: string) => p.replace(/\/$/, '') === path
   const prefix = (path: string) => (p: string) => p === path || p.startsWith(`${path}/`)

--- a/app/src/shared/ui/BottomNav.tsx
+++ b/app/src/shared/ui/BottomNav.tsx
@@ -1,23 +1,33 @@
 import { Link, useRouterState } from '@tanstack/react-router'
 import { Calendar, Users, User, type LucideIcon } from 'lucide-react'
+import { teamRoutes, teamSlugFromPath, type TeamRoutes } from '@shared/lib/team-routes'
 
 interface TabConfig {
   icon: LucideIcon
   label: string
   to: string
-  // How to match the current path to this tab. Events is exact ('/' would prefix-match everything);
-  // Team also owns its nested routes (e.g. /team/settings), so it matches by prefix.
+  // How to match the current path to this tab. Events is exact (the Team home would otherwise
+  // prefix-match every screen under it); Team also owns its nested routes (e.g. .../team/settings),
+  // so it matches by prefix.
   isActive: (pathname: string) => boolean
 }
 
-const TABS: TabConfig[] = [
-  { icon: Calendar, label: 'Events', to: '/', isActive: (p) => p === '/' },
-  { icon: Users, label: 'Team', to: '/team', isActive: (p) => p === '/team' || p.startsWith('/team/') },
-  { icon: User, label: 'Profile', to: '/profile', isActive: (p) => p === '/profile' || p.startsWith('/profile/') },
-]
+// The tabs are team-scoped (ADR-0021 §2), built from the slug in the URL the bar is rendered on
+// rather than from a store. Deriving them from the location is what keeps this component a pure
+// function of where you are: switch Team and every tab follows, with nothing to keep in sync.
+function tabsFor(routes: TeamRoutes): TabConfig[] {
+  const exact = (path: string) => (p: string) => p.replace(/\/$/, '') === path
+  const prefix = (path: string) => (p: string) => p === path || p.startsWith(`${path}/`)
+  return [
+    { icon: Calendar, label: 'Events', to: routes.events, isActive: exact(routes.events) },
+    { icon: Users, label: 'Team', to: routes.team, isActive: prefix(routes.team) },
+    { icon: User, label: 'Profile', to: routes.profile, isActive: prefix(routes.profile) },
+  ]
+}
 
 export function BottomNav() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const TABS = tabsFor(teamRoutes(teamSlugFromPath(pathname)))
 
   return (
     <nav

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
@@ -3,6 +3,7 @@ import { Check, Clock, MapPin, X } from 'lucide-react'
 import type { Event } from '@shared/api/events'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { heroCountdown } from '../lib/countdown'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
 interface NextEventHeroViewProps {
   event: Event
@@ -39,6 +40,7 @@ export function NextEventHeroView({
   onRespond,
   now = new Date(),
 }: NextEventHeroViewProps) {
+  const routes = useTeamRoutes()
   const date = new Date(event.startTime)
   const countdown = heroCountdown(event.startTime, now)
   const going = myState === 'ATTENDING'
@@ -85,8 +87,7 @@ export function NextEventHeroView({
             would navigate, and stay quiet over the controls, which are not part of it. The ring is
             inset so `overflow-hidden` can't clip it, and traces the real target — the whole card. */}
         <Link
-          to="/events/$eventId"
-          params={{ eventId: event.id }}
+          to={routes.event(event.id)}
           className="after:absolute after:inset-0 after:rounded-3xl after:bg-white/0 after:transition-colors after:duration-200 hover:underline hover:after:bg-white/[0.07] focus-visible:outline-none focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-white"
         >
           {event.title}

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -6,10 +6,15 @@ import { TeamHeader } from './TeamHeader'
 
 // TeamHeader renders a TanStack Router <Link> for the admin gear, so it needs a router in context.
 // The two stories pin the only behaviour that matters: admins see the settings entry, members don't.
+//
+// The gear's target is team-scoped (ADR-0021 §2), derived from the slug in the path the header is
+// rendered on — hence the initialEntries below. That is the whole reason it can be asserted here at
+// all: the destination is a function of the URL, not of a store the story would have to prime.
 const meta = {
   title: 'widgets/team-header/TeamHeader',
   component: TeamHeader,
   decorators: [withRouter],
+  parameters: { router: { initialEntries: ['/t/setpoint-vt/team'] } },
 } satisfies Meta<typeof TeamHeader>
 
 export default meta
@@ -28,7 +33,7 @@ export const Admin: Story = {
   play: async ({ canvas }) => {
     const gear = canvas.getByRole('link', { name: 'Team settings' })
     await expect(gear).toBeInTheDocument()
-    await expect(gear).toHaveAttribute('href', '/team/settings')
+    await expect(gear).toHaveAttribute('href', '/t/setpoint-vt/team/settings')
     // The admin actions slot (invite link) renders alongside the gear.
     await expect(canvas.getByRole('button', { name: 'Invite Link' })).toBeInTheDocument()
   },

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -7,7 +7,7 @@ import { TeamHeader } from './TeamHeader'
 // TeamHeader renders a TanStack Router <Link> for the admin gear, so it needs a router in context.
 // The two stories pin the only behaviour that matters: admins see the settings entry, members don't.
 //
-// The gear's target is team-scoped (ADR-0021 §2), derived from the slug in the path the header is
+// The gear's target is team-scoped (ADR-0023 §2), derived from the slug in the path the header is
 // rendered on — hence the initialEntries below. That is the whole reason it can be asserted here at
 // all: the destination is a function of the URL, not of a store the story would have to prime.
 const meta = {

--- a/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.stories.tsx
@@ -7,9 +7,8 @@ import { TeamHeader } from './TeamHeader'
 // TeamHeader renders a TanStack Router <Link> for the admin gear, so it needs a router in context.
 // The two stories pin the only behaviour that matters: admins see the settings entry, members don't.
 //
-// The gear's target is team-scoped (ADR-0023 §2), derived from the slug in the path the header is
-// rendered on — hence the initialEntries below. That is the whole reason it can be asserted here at
-// all: the destination is a function of the URL, not of a store the story would have to prime.
+// The gear's target is derived from the slug in the path the header is rendered on — hence the
+// initialEntries below.
 const meta = {
   title: 'widgets/team-header/TeamHeader',
   component: TeamHeader,

--- a/app/src/widgets/team-header/ui/TeamHeader.tsx
+++ b/app/src/widgets/team-header/ui/TeamHeader.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Settings } from 'lucide-react'
+import { useTeamRoutes } from '@shared/lib/team-routes'
 
 interface TeamHeaderProps {
   /** Only admins get the entry into /team/settings; the page itself is read-only for everyone. */
@@ -19,6 +20,8 @@ interface TeamHeaderProps {
  * the role and supplies isAdmin and the admin actions.
  */
 export function TeamHeader({ isAdmin, actions }: TeamHeaderProps) {
+  const routes = useTeamRoutes()
+
   return (
     <div className="flex items-center justify-between">
       <h2 className="font-display text-2xl font-bold">Team</h2>
@@ -26,7 +29,7 @@ export function TeamHeader({ isAdmin, actions }: TeamHeaderProps) {
         <div className="flex items-center gap-2">
           {actions}
           <Link
-            to="/team/settings"
+            to={routes.teamSettings}
             aria-label="Team settings"
             className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-blue/8 hover:text-foreground"
           >

--- a/docs/adr/0019-self-service-team-onboarding.md
+++ b/docs/adr/0019-self-service-team-onboarding.md
@@ -4,9 +4,9 @@
 - Date: 2026-08-03
 - Amends: [ADR-0001](0001-product-ambition-hobby-tool-built-to-grow.md) (team creation is back-office in v1)
 - Relates to: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (magic-link auth, invite onboarding), [ADR-0013](0013-member-profile-position-role-management.md) (member/position/role)
-- Amended by: [ADR-0021](0021-active-team-explicit-tenant-resolution.md) (§3's one-team-per-user guard
+- Amended by: [ADR-0023](0023-active-team-explicit-tenant-resolution.md) (§3's one-team-per-user guard
   lifted; §6's singular `team` on `/auth/me` becomes `teams[]` + `activeTeam`), and
-  [ADR-0022](0022-platform-admin-act-as.md) (§5's "creator becomes founding admin" no longer holds when
+  [ADR-0024](0024-platform-admin-act-as.md) (§5's "creator becomes founding admin" no longer holds when
   a Platform Admin creates a team memberless)
 
 > Numbering note: the originating PRD (#154) named this ADR-0015. By the time it was written, 0015
@@ -154,7 +154,7 @@ flows). Net e2e count unchanged.
   docker-Flyway step is retired.
 - **One-team-per-user** matches routing's `ORDER BY … LIMIT 1`. Multi-team membership + a team
   switcher were deferred to **#143** and are now decided in
-  [ADR-0021](0021-active-team-explicit-tenant-resolution.md) — which also records that this guard never
+  [ADR-0023](0023-active-team-explicit-tenant-resolution.md) — which also records that this guard never
   actually closed the hole: it lives only in `createTeam`, while the invite path (`addMember`) has
   always been able to create a second membership. Public/www marketing signup + a resetting demo team are **#152**.
 - **Boot cost rises slightly** (tenant migrations run at startup). Kept cheap by idempotency, but see

--- a/docs/adr/0023-active-team-explicit-tenant-resolution.md
+++ b/docs/adr/0023-active-team-explicit-tenant-resolution.md
@@ -1,9 +1,9 @@
-# ADR-0021: The Active Team — explicit, session-carried tenant resolution
+# ADR-0023: The Active Team — explicit, session-carried tenant resolution
 
 - Status: Accepted
 - Date: 2026-08-22
 - Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§3 one-team-per-user, §6 `/auth/me`'s singular `team`)
-- Relates to: [ADR-0014](0014-jdbc-backed-shared-sessions-survive-restart.md) (JDBC sessions), [ADR-0015](0015-session-lifetime-long-sliding-idle-plus-absolute-cap.md) (session lifetime), [ADR-0022](0022-platform-admin-act-as.md) (act-as rides this seam)
+- Relates to: [ADR-0014](0014-jdbc-backed-shared-sessions-survive-restart.md) (JDBC sessions), [ADR-0015](0015-session-lifetime-long-sliding-idle-plus-absolute-cap.md) (session lifetime), [ADR-0024](0024-platform-admin-act-as.md) (act-as rides this seam)
 - Resolves: [#143](https://github.com/ZzAve/teambalance-app/issues/143)
 - Enables: [#239](https://github.com/ZzAve/teambalance-app/issues/239) (act-as), [#240](https://github.com/ZzAve/teambalance-app/issues/240) (club rollout)
 
@@ -38,7 +38,7 @@ double membership (a player who also trains another squad, a season-long fill-in
 A request is scoped to exactly one **Active Team**, **explicitly selected and never inferred**.
 `AuthorizationService`'s `findRole(teamId, userId)` remains the single authorization chokepoint and
 answers from one of two sources: a real `team_members` row, or the **Virtual Member** synthesized by
-**Act-as** (ADR-0022).
+**Act-as** (ADR-0024).
 
 `ORDER BY … LIMIT 1` is **deleted, not sidestepped**. `findTeamRoutingByUserId` and
 `findTeamIdByUserId` stop meaning "resolve the user's team" and become "resolve *this* team for this
@@ -88,7 +88,7 @@ rediscover.
 - **ADR-0019 §6 is amended**: `/auth/me`'s `team: TeamRef?` becomes `teams: TeamRef[]` plus an
   `activeTeam`. The frontend route gate's question changes from "do you have a team" to "do you have
   *any* team, and which is active", and gains a third branch for a teamless **Platform Admin**
-  (ADR-0022).
+  (ADR-0024).
 - **`AuthorizationService`'s security-contract comment is reworded.** It currently forbids `teamId`
   from being "a raw request parameter". Under this ADR the team id *is* a caller-influenced input,
   made safe by being validated at the one chokepoint. The prohibition it should carry instead: a
@@ -100,7 +100,7 @@ rediscover.
 ## Non-goals
 
 No cross-team data views or aggregation. No simultaneously-active roles across teams — one Active
-Team, one role, at a time. No cross-team identity merging (see ADR-0022: the two accounts a
+Team, one role, at a time. No cross-team identity merging (see ADR-0024: the two accounts a
 platform-running player holds must never be linked or auto-switched between).
 
 ## Consequences
@@ -109,5 +109,5 @@ platform-running player holds must never be linked or auto-switched between).
   leaves the codebase.
 - Every team-scoped screen gains a team slug in its route, and the switcher becomes permanent UI.
 - Session memo invalidation is now load-bearing; a missed invalidation is a cross-tenant read.
-- Act-as (ADR-0022) builds no tenant-resolution machinery of its own — it supplies a second
+- Act-as (ADR-0024) builds no tenant-resolution machinery of its own — it supplies a second
   authorization source to this one.

--- a/docs/adr/0024-platform-admin-act-as.md
+++ b/docs/adr/0024-platform-admin-act-as.md
@@ -1,8 +1,8 @@
-# ADR-0022: Platform Admin Act-as — entering a team you are not a member of
+# ADR-0024: Platform Admin Act-as — entering a team you are not a member of
 
 - Status: Accepted
 - Date: 2026-08-22
-- Builds on: [ADR-0021](0021-active-team-explicit-tenant-resolution.md) (the Active Team seam)
+- Builds on: [ADR-0023](0023-active-team-explicit-tenant-resolution.md) (the Active Team seam)
 - Amends: [ADR-0019](0019-self-service-team-onboarding.md) (§4 platform-admin identity, §5 founder becomes a member)
 - Relates to: [#237](https://github.com/ZzAve/teambalance-app/issues/237) (general audit log — deliberately decoupled)
 - Resolves: [#239](https://github.com/ZzAve/teambalance-app/issues/239); §5 is delivered by [#240](https://github.com/ZzAve/teambalance-app/issues/240)
@@ -42,14 +42,14 @@ of on gates.
 ### 2. Virtual Member — synthesized, never written
 
 Authorization inside act-as comes from a **Virtual Member**: `findRole(teamId, userId)` — the single
-chokepoint from ADR-0021 — returns `ADMIN`. **No `team_members` row is ever written.** The team's
+chokepoint from ADR-0023 — returns `ADMIN`. **No `team_members` row is ever written.** The team's
 roster, attendance denominators, Position breakdown and contributor rankings are untouched.
 
 **The synthesis keys off an actively-entered act-as state, never off `isPlatformAdmin(userId)`
 alone.** If the chokepoint learned "ADMIN when the caller is a platform admin", an ordinary session
 would silently be admin of every tenant it happened to be routed to, and act-as would stop being a
 mode you enter and become a property you carry. That is the same class of mistake as the `LIMIT 1`
-ADR-0021 removes: a rule invisible at the call site and only wrong later.
+ADR-0023 removes: a rule invisible at the call site and only wrong later.
 
 **Rejected: per-call-site bypasses** (`… || isPlatformAdmin`), which turn one chokepoint into N, and
 the one that gets forgotten is the vulnerability. **Rejected: a real-but-hidden `team_members` row**,

--- a/docs/ops/provision-team.md
+++ b/docs/ops/provision-team.md
@@ -53,7 +53,7 @@ since #143 a founder who already plays in a Team can reach it too, from the Team
 then **atomically** consumes the code and inserts the `teams` row + the founder's `team_members`
 row (ADMIN, `onboarded_at = now()`, `position_id NULL`); and finally makes the new team the
 founder's **Active Team**, so they land straight in the new, empty team rather than staying in
-whichever team they were in before (ADR-0021).
+whichever team they were in before (ADR-0023).
 
 The founder is now the team's admin. From there, onboarding the rest of the team is the ordinary
 in-app flow (unchanged, ADR-0008 / ADR-0013):

--- a/docs/ops/provision-team.md
+++ b/docs/ops/provision-team.md
@@ -37,9 +37,9 @@ can be spent at most once.
 
 ### Step 2 — The founder self-creates
 
-The founder logs in (magic link → their `users.email` is the identity key), and — while **teamless**
-— the has-a-team route gate (driven by `/auth/me`'s `team` field) lands them on the create-team
-screen. They enter:
+The founder logs in (magic link → their `users.email` is the identity key). While **teamless** the
+has-any-team route gate (driven by `/auth/me`'s `teams` list) lands them on the create-team screen;
+since #143 a founder who already plays in a Team can reach it too, from the Team switcher. They enter:
 
 - **Team name** — free text, ≤ 100 chars, **not** required to be unique.
 - **Slug** — the URL address, **user-editable and validated**: `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤ 58 chars,
@@ -47,13 +47,13 @@ screen. They enter:
   shown.
 - **Creation code** — from Step 1.
 
-`POST /api/teams` then, in order: rejects a caller who already has a team (`409 ALREADY_IN_TEAM`);
-validates name/slug (`400 INVALID_NAME` / `400 INVALID_SLUG`); rejects a taken slug
+`POST /api/teams` then, in order: validates name/slug (`400 INVALID_NAME` / `400 INVALID_SLUG`); rejects a taken slug
 (`409 TEAM_SLUG_TAKEN`) or a bad/expired/consumed code (opaque `403 INVALID_CREATION_CODE`);
 **provisions the tenant schema** (`db/tenant-migration`, recorded in `flyway_tenant_schema_history`);
 then **atomically** consumes the code and inserts the `teams` row + the founder's `team_members`
-row (ADMIN, `onboarded_at = now()`, `position_id NULL`). The founder lands straight in the new,
-empty team.
+row (ADMIN, `onboarded_at = now()`, `position_id NULL`); and finally makes the new team the
+founder's **Active Team**, so they land straight in the new, empty team rather than staying in
+whichever team they were in before (ADR-0021).
 
 The founder is now the team's admin. From there, onboarding the rest of the team is the ordinary
 in-app flow (unchanged, ADR-0008 / ADR-0013):


### PR DESCRIPTION
Implements #143 / [ADR-0023](../blob/main/docs/adr/0023-active-team-explicit-tenant-resolution.md).

## The bug this fixes is live on main

Tenant routing resolved *"the user's team"* with `ORDER BY tm.team_id LIMIT 1` in **three** places — ordering by **UUID**, so with two `team_members` rows the choice was arbitrary, and `TenantRoutingSession` memoized it onto the session, making the arbitrary choice sticky. The member's other Team didn't error; it silently did not exist for them.

A second row is reachable today: the one-team guard lives only in `TeamService.createTeam`, and the invite path has none.

All three sites are **deleted, not sidestepped**:

| Was | Now |
|---|---|
| `findTeamRoutingByUserId` | `findTeamRouting(teamId, userId)` — the team id is an *input*, and the `user_id AND active` predicate **is** the membership check |
| `findTeamIdByUserId` | gone — nothing needed "some team of this user" |
| `JdbcTeamRepositoryAdapter.findByUserId` | `findTeamsOf` (a list, for the switcher) + `findBySlug` (for the authorized switch) |

## One seam

`ActiveTeamService` is the single tenant-resolution seam. Landing resolution is **remembered team → sole membership → nothing**; the remembered team is re-verified rather than trusted, because sessions slide for four weeks and outlive memberships. With several Teams and none remembered the answer is *nothing*, which forces an explicit choice instead of a UUID-ordered pick. Act-as ([ADR-0024](../blob/main/docs/adr/0024-platform-admin-act-as.md), #239) plugs a second *authorization* source into this, not a second path.

`public.users.last_active_team_id` (V009) remembers per user, not per session — a session-only memory is lost exactly at the fresh magic-link login on a phone. Every switch re-pins the session routing; that re-pin **is** the memo invalidation, so it lives inside `activate` rather than being left to callers.

## Contract (amends ADR-0019 §3 and §6)

- `POST /api/teams/{slug}/activate` → `200 TeamRef` / `404`. Addressed by **slug** because that's what a shared `/t/:slug/…` link carries: opening one *is* this call. "Not yours" and "no such team" answer byte-identically, so the slug space can't be probed.
- `/auth/me`: `team: TeamRef?` → `teams: TeamRef[]` + `activeTeam: TeamRef?`; `role` now means the Role **in the Active Team**.
- `409 ALREADY_IN_TEAM` lifted from create-team; creating a team makes it the founder's Active Team.
- `acceptInvitation` stops being fire-and-forget — the joined Team becomes Active, so a member lands where they just accepted.
- `AuthorizationService`'s security contract reworded: a caller-influenced team id is now allowed, made safe by validation at the chokepoint.

## Frontend

Team-scoped screens move under `/t/:slug/…`. `/` becomes a dispatcher (Active Team → go there; no Teams → onboarding; several with none active → `/select-team`). The switcher is permanent header UI and **always names the current Team** — load-bearing, not decoration: with one kind of switch, tapping a teammate's link re-homes your default, and seeing which Team you're in is what makes that a one-tap correction.

The query cache is **reset** on every tenant change (switch, invite accept, create-team). Tenant-scoped queries are keyed without the Team in them, which makes the cache the frontend's mirror of `TenantRoutingSession`'s memo — same obligation.

## Testing — and the e2e justification

**A new e2e is justified.** Multi-Team switching is a genuinely new **cross-tenant** seam: every other spec runs as a caller with exactly one Team, where tenant resolution has only one possible answer, so neither the login nor the attendance flow exercises any of it. One flow (`switch-team.spec.ts`) covers join-second-team → switch → correct tenant data, proving four things nothing else can: a second `team_members` row is reachable and both Teams stay visible; accepting makes the joined Team Active; switching re-routes the tenant across two real schemas; and the choice survives a full page load. The e2e fixture gains a second real tenant for it — a second team row on the same schema would show the same events and prove nothing about routing.

Everything else sits at the lowest layer that proves it: switcher/picker states are `*View` stories with `fn()` spies; slug↔route mapping, the store mapping and the teamless-bounce rule are Vitest units; resolution, the deleted `LIMIT 1`, last-used ordering, memo invalidation and the 404-indistinguishability are backend units/ITs.

`make test` (458 backend + 512 frontend), `make lint` and `make e2e` (10/10) are green, and a two-Team user was switched by hand against the real stack.

## Found while building

- Two IT fixtures shared a user id across specs with **different** Teams. They passed only because the UUID-ordered pick happened to land on the shared Team — the suite was quietly depending on the misrouting. Made spec-unique.
- `queryClient.clear()` empties the cache but doesn't tell mounted observers to refetch, so a switch between two team-scoped routes left the previous Team's data on screen indefinitely. `resetQueries()` does both.
- Three gaps closed in review: sign-in could inherit a previous caller's pinned tenant (the pin is conditional, so the clear has to be unconditional); a removed member couldn't re-join, since `(team_id, user_id)` is UNIQUE and their deactivated row blocked the insert — accept answered 200 and left them out; and the switcher's `ORDER BY t.name` had no tiebreaker while team names are deliberately non-unique.

## Known and accepted (ADR-0023)

- The **session**, not the URL slug, is the authority on the tenant, so two tabs can't sit in two Teams — §2 weighed request-carried tenancy against exactly this and took it as the price of team-less PWA navigation. It's a stale *view*, never a write to the wrong tenant.
- A memo hit isn't re-verified against `team_members`, so a member removed mid-session keeps tenant *reads* until their session ends. Unchanged by this work and out of its scope; per-action authorization still runs every request.

Out of scope, as the issue states: act-as (#239) and memberless creation (#240). This ships the seam they build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gxPoXxEc7okK2untiWaEH

---
_Generated by [Claude Code](https://claude.ai/code/session_015gxPoXxEc7okK2untiWaEH)_



https://github.com/user-attachments/assets/c83f8ebc-8f36-4beb-afad-29d1ff373253


https://github.com/user-attachments/assets/990a6bf6-b464-40a2-ae62-a0333849b3a0


https://github.com/user-attachments/assets/3ab0fa22-389f-484a-85f1-f8974f64003e

