### PR TITLE
docs: plan to fix app caching blank screens and stale deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,9 +302,15 @@ jobs:
           AWS_DEFAULT_REGION: fr-par
         run: |
           set -euo pipefail
-          # SPA: content-hashed assets are immutable + pruned; index.html must never cache.
+          # SPA: content-hashed assets are immutable; index.html must never cache.
+          # --delete removed on purpose: a client still on the previous shell (a long-open tab,
+          # the installed PWA, or a stale SW) keeps referencing the last deploy's hashed chunks —
+          # pruning them the instant a new deploy lands 404s those clients into a blank screen.
+          # Hashes are content-addressed + immutable, so re-uploading unchanged hashes is a
+          # harmless no-op and stale hashes never collide; reclaiming space is handed to a bucket
+          # lifecycle rule (expire assets/ 90 days after last-modified — see docs/ops/deploy.md).
           aws --endpoint-url "$S3_ENDPOINT" s3 sync app/dist/assets "s3://${SPA_BUCKET}/assets" \
-            --cache-control "public,max-age=31536000,immutable" --delete
+            --cache-control "public,max-age=31536000,immutable"
           aws --endpoint-url "$S3_ENDPOINT" s3 cp app/dist/index.html "s3://${SPA_BUCKET}/index.html" \
             --cache-control no-cache
           # PWA shell (F2): icons, master SVG and the hashed workbox runtime live at the bucket
@@ -327,10 +333,19 @@ jobs:
           # Landing page: index.html + style.css at root, tokens.css under /design-tokens/.
           aws --endpoint-url "$S3_ENDPOINT" s3 cp www/index.html "s3://${WWW_BUCKET}/index.html" \
             --cache-control no-cache
-          aws --endpoint-url "$S3_ENDPOINT" s3 cp www/style.css "s3://${WWW_BUCKET}/style.css"
-          aws --endpoint-url "$S3_ENDPOINT" s3 cp design-tokens/tokens.css "s3://${WWW_BUCKET}/design-tokens/tokens.css"
+          # style.css + tokens.css are unhashed and referenced by name from index.html's <head>,
+          # so they must revalidate in lockstep with it: no-cache matches index.html and prevents
+          # a half-updated landing (fresh HTML, stale CSS served under the CDN default TTL).
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp www/style.css "s3://${WWW_BUCKET}/style.css" \
+            --cache-control no-cache
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp design-tokens/tokens.css "s3://${WWW_BUCKET}/design-tokens/tokens.css" \
+            --cache-control no-cache
 
       - name: Purge Edge Services cache
         run: |
+          # A silently-skipped purge lets the edge keep serving a stale index.html that points at
+          # pruned chunks. set -euo pipefail (matching the sync step) makes a failed purge fail the
+          # job — explicit, and robust to any repo-level default-shell override that drops -e.
+          set -euo pipefail
           scw edge-services purge-request create pipeline-id="$SPA_PIPELINE" all=true
           scw edge-services purge-request create pipeline-id="$WWW_PIPELINE" all=true

--- a/app/index.html
+++ b/app/index.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>TeamBalance</title>
 
-    <!-- PWA shell (F2). The manifest, the service worker and the registerSW.js link are injected
-         by vite-plugin-pwa at build time; the icons below are committed under public/ and
-         generated from public/tb-monogram.svg (see app/pwa-assets.config.ts). -->
+    <!-- PWA shell (F2). The manifest and the service worker are emitted by vite-plugin-pwa at build
+         time; registration is bundled into the app itself (SwUpdateManager via
+         virtual:pwa-register/react), not a plugin-injected registerSW.js — so the app owns update
+         timing (caching plan Phase 3). The icons below are committed under public/ and generated
+         from public/tb-monogram.svg (see app/pwa-assets.config.ts). -->
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/tb-monogram.svg" sizes="any" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />

--- a/app/scripts/verify-pwa-build.mjs
+++ b/app/scripts/verify-pwa-build.mjs
@@ -6,7 +6,7 @@
 // The manifest's *shape* is asserted at the unit layer (src/app/pwa/manifest.test.ts); this
 // checks the artefacts that only exist after a build.
 
-import { readFileSync, existsSync } from 'node:fs'
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -22,7 +22,18 @@ const read = (file) => (existsSync(resolve(dist, file)) ? readFileSync(resolve(d
 // 1. Service worker + its registration.
 const sw = read('sw.js')
 check('dist/sw.js is missing — the app has no service worker', sw !== null)
-check('dist/registerSW.js is missing — the service worker is never registered', existsSync(resolve(dist, 'registerSW.js')))
+// Registration is bundled into the app itself (SwUpdateManager → virtual:pwa-register/react), not a
+// plugin-injected registerSW.js (`injectRegister: null`), so the app owns update timing (Phase 3).
+// Prove some hashed app chunk still registers the worker rather than checking for the dropped file.
+const assetsDir = resolve(dist, 'assets')
+const registersSW =
+  existsSync(assetsDir) &&
+  readdirSync(assetsDir).some((file) => {
+    if (!file.endsWith('.js')) return false
+    const code = readFileSync(resolve(assetsDir, file), 'utf8')
+    return code.includes('serviceWorker') && code.includes('sw.js')
+  })
+check('no app chunk registers the service worker — registration is bundled via virtual:pwa-register/react', registersSW)
 
 if (sw) {
   const precached = [...sw.matchAll(/url:"([^"]+)"/g)].map(([, url]) => url)
@@ -55,7 +66,9 @@ const html = read('index.html')
 check('dist/index.html is missing', html !== null)
 if (html) {
   check('index.html does not link the web manifest', /<link[^>]+rel="manifest"/.test(html))
-  check('index.html does not register the service worker', html.includes('registerSW.js'))
+  // The SW is no longer registered from index.html (no registerSW.js link); the app module below
+  // registers it (verified against the app chunk above). index.html must still load that module.
+  check('index.html does not load the app module bundle', /<script[^>]+type="module"[^>]+src="[^"]+"/.test(html))
   check('index.html has no theme-color', /<meta[^>]+name="theme-color"/.test(html))
   check('index.html has no apple-touch-icon', /<link[^>]+rel="apple-touch-icon"/.test(html))
   check('index.html still loads fonts from a third party — they are self-hosted (F13)', !html.includes('fonts.googleapis.com'))

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -3,12 +3,26 @@ import { createRoot } from 'react-dom/client'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../routeTree.gen'
 import { WakingSplash } from '@shared/ui/ColdStartSplash'
+import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+import { installChunkErrorHandler } from '@shared/lib/chunk-reload'
 import './styles/global.css'
+
+// A stale shell can dynamic-import a route chunk whose hash the last deploy pruned → a blank frame.
+// This reloads once to the fresh index.html (which references chunk hashes that exist) rather than
+// leaving the screen blank; a second failure falls through to the router fallback below (Phase 1).
+installChunkErrorHandler()
 
 // While the root guard probes the session (and on any route load), show the brand splash rather
 // than a blank frame. WakingSplash escalates its copy as it waits, so a cold-start backend wake
 // (~12s after scale-to-zero) reads as progress instead of a hang — warm loads only ever see the mark.
-const router = createRouter({ routeTree, defaultPendingComponent: WakingSplash })
+const router = createRouter({
+  routeTree,
+  defaultPendingComponent: WakingSplash,
+  // A route that still throws after the reload guard (e.g. the fresh shell also 404s a chunk — a
+  // real outage, not a stale-chunk race) renders the retry fallback instead of nothing. Retry does
+  // a full reload to re-fetch the shell and its current chunk hashes.
+  defaultErrorComponent: () => <RouteErrorFallback onRetry={() => window.location.reload()} />,
+})
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/app/src/app/pwa/manifest.ts
+++ b/app/src/app/pwa/manifest.ts
@@ -59,6 +59,9 @@ export const pwaWorkbox: VitePWAOptions['workbox'] = {
       handler: 'NetworkOnly',
     },
   ],
+  // Evict the precache of superseded builds once the new worker activates — keep it on.
   cleanupOutdatedCaches: true,
-  clientsClaim: true,
+  // `clientsClaim` deliberately omitted (caching plan Phase 3): control transfers on our own
+  // controlled reload (SwUpdateManager → updateServiceWorker → SKIP_WAITING → controllerchange →
+  // reload), so the worker never needs to seize already-open clients the moment it activates.
 }

--- a/app/src/app/pwa/sw-update.tsx
+++ b/app/src/app/pwa/sw-update.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { useIsMutating } from '@tanstack/react-query'
+import { useRouterState } from '@tanstack/react-router'
+import { decideUpdateAction } from '@shared/lib/update-decision'
+import { UpdateToast } from '@shared/ui/UpdateToast'
+
+// Knob 1 — how often we even look for an update while a tab stays open. A long interval, not
+// aggressive polling: the real triggers are page load (registration) and regaining visibility.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000 // hourly
+
+/**
+ * Owns the service-worker update lifecycle (caching plan Phase 3). Registers the worker via
+ * `virtual:pwa-register/react` and, when a new version is ready (`onNeedRefresh`), routes the
+ * decision through `decideUpdateAction`:
+ *
+ *  - `activate` / `auto` → apply immediately (invisible; perceived as a normal load).
+ *  - `defer`             → apply at the next safe seam — a route navigation or the tab going hidden —
+ *                          falling back to the prompt only if none arrives.
+ *  - `prompt`            → show the toast; the user reloads when their work is safe.
+ *
+ * Signals: `hasInteracted` (first real input this session) and `isDirty` (pending TanStack Query
+ * mutations via `useIsMutating` — the pragmatic minimal source; unsaved-form tracking can extend it
+ * later). Both are read through refs inside the SW callbacks, which `useRegisterSW` registers once
+ * and would otherwise close over stale values.
+ *
+ * This is the thin lifecycle shell the plan flags as manual-verified: the risk lives in
+ * decideUpdateAction (unit-tested) and the toast (storied), not here.
+ */
+export function SwUpdateManager() {
+  const [showPrompt, setShowPrompt] = useState(false)
+
+  // isDirty — pending mutations. Mirrored into a ref so the register-once SW callback reads it live.
+  const pendingMutations = useIsMutating()
+  const isDirtyRef = useRef(false)
+  useEffect(() => {
+    isDirtyRef.current = pendingMutations > 0
+  }, [pendingMutations])
+
+  const hasInteractedRef = useRef(false)
+  const deferredRef = useRef(false)
+  const updateSWRef = useRef<(reloadPage?: boolean) => Promise<void>>(() => Promise.resolve())
+
+  // First real user input this session flips hasInteracted — the point past which a silent
+  // auto-reload would read as an interruption rather than a normal load.
+  useEffect(() => {
+    const mark = () => {
+      hasInteractedRef.current = true
+    }
+    window.addEventListener('pointerdown', mark, { once: true })
+    window.addEventListener('keydown', mark, { once: true })
+    return () => {
+      window.removeEventListener('pointerdown', mark)
+      window.removeEventListener('keydown', mark)
+    }
+  }, [])
+
+  const { updateServiceWorker } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return
+      // Knob 1 — re-check on regaining visibility and on a long periodic interval. (The initial
+      // load check is the registration itself.) Never torn down: the manager lives for the app's
+      // lifetime, so the listener and interval are process-scoped by design.
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') void registration.update()
+      })
+      window.setInterval(() => void registration.update(), UPDATE_CHECK_INTERVAL_MS)
+    },
+    onNeedRefresh() {
+      const action = decideUpdateAction({
+        hasController: Boolean(navigator.serviceWorker?.controller),
+        hasInteracted: hasInteractedRef.current,
+        visibility: document.visibilityState,
+        isDirty: isDirtyRef.current,
+      })
+      if (action === 'activate' || action === 'auto') {
+        void updateSWRef.current(true)
+      } else if (action === 'defer') {
+        deferredRef.current = true
+      } else {
+        setShowPrompt(true)
+      }
+    },
+  })
+  // Keep the ref pointing at the latest updater so the register-once callbacks and the seam effects
+  // don't close over a stale one.
+  useEffect(() => {
+    updateSWRef.current = updateServiceWorker
+  }, [updateServiceWorker])
+
+  // Defer seam — a route navigation. A navigation already unmounts the current view, so applying a
+  // waiting update there loses nothing. Skips the first run (nothing deferred yet at mount).
+  const href = useRouterState({ select: (s) => s.location.href })
+  const didMountRef = useRef(false)
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+    if (deferredRef.current) void updateSWRef.current(true)
+  }, [href])
+
+  // Defer seam — the tab going hidden. Backgrounding is a safe moment to refresh silently.
+  useEffect(() => {
+    const onHidden = () => {
+      if (deferredRef.current && document.visibilityState === 'hidden') {
+        void updateSWRef.current(true)
+      }
+    }
+    document.addEventListener('visibilitychange', onHidden)
+    return () => document.removeEventListener('visibilitychange', onHidden)
+  }, [])
+
+  return <UpdateToast show={showPrompt} onReload={() => void updateSWRef.current(true)} />
+}

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, redirect, Outlet, Link, useRouterState } from '@tansta
 import { useEffect, useRef } from 'react'
 import { Toaster } from 'sonner'
 import { Providers } from '@app/providers'
+import { SwUpdateManager } from '@app/pwa/sw-update'
 import { BottomNav } from '@shared/ui/BottomNav'
 import { authMeQueryOptions } from '@shared/api/auth'
 import { TeamSwitcher } from '@features/switch-team/ui/TeamSwitcher'
@@ -123,6 +124,9 @@ function RootLayout() {
           resolved theme rather than sonner's own "system" so it follows the in-app preference —
           a user on Light with a dark OS must not get dark toasts. */}
       <Toaster position="top-center" richColors theme={theme} />
+      {/* Service-worker update lifecycle (caching plan Phase 3): auto-applies a new version by
+          default and only shows a reload prompt when a deploy lands mid-session with unsaved work. */}
+      <SwUpdateManager />
     </Providers>
   )
 }

--- a/app/src/shared/lib/chunk-reload.test.ts
+++ b/app/src/shared/lib/chunk-reload.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { shouldReloadForChunkError } from './chunk-reload'
+
+// The pure half of the chunk-error recovery: reload once, then fall back. The window/sessionStorage
+// wiring in installChunkErrorHandler is a thin shell around this decision (manual-verified).
+describe('shouldReloadForChunkError', () => {
+  it('reloads when no sentinel is set yet — the first stale-chunk failure this session', () => {
+    expect(shouldReloadForChunkError(false)).toBe('reload')
+  })
+
+  it('falls back when the sentinel is already set — the fresh shell failed too, a real outage', () => {
+    expect(shouldReloadForChunkError(true)).toBe('fallback')
+  })
+})

--- a/app/src/shared/lib/chunk-reload.ts
+++ b/app/src/shared/lib/chunk-reload.ts
@@ -1,0 +1,61 @@
+/**
+ * One-shot recovery for a failed dynamic import of a route chunk (caching plan Phase 1).
+ *
+ * A client running a stale shell can navigate to a route whose hashed chunk was pruned by the last
+ * deploy → the dynamic `import()` 404s → a blank screen. The fix is a single reload: fetching the
+ * fresh (no-cache) `index.html` yields a shell that references chunk hashes that still exist.
+ *
+ * A `sessionStorage` sentinel keeps it one-shot: if the *fresh* shell also fails to load a chunk the
+ * sentinel is already set, so it's a real outage (not a stale-chunk race) — we stop reloading and
+ * fall through to the router's error fallback instead of looping forever.
+ */
+
+/** Sentinel key: set once per tab session after we've reloaded for a chunk error. */
+export const CHUNK_RELOAD_SENTINEL = 'tb-chunk-reload'
+
+/**
+ * Pure decision: reload once when we haven't yet this session; otherwise the fresh shell also
+ * failed, so fall back rather than loop. The window/sessionStorage/reload wiring around this is thin
+ * and covered by manual verification; this is the irreducible logic.
+ */
+export function shouldReloadForChunkError(sentinelPresent: boolean): 'reload' | 'fallback' {
+  return sentinelPresent ? 'fallback' : 'reload'
+}
+
+function sentinelPresent(): boolean {
+  try {
+    return sessionStorage.getItem(CHUNK_RELOAD_SENTINEL) !== null
+  } catch {
+    // sessionStorage unavailable (private mode / disabled) — treat as not-yet-reloaded.
+    return false
+  }
+}
+
+/**
+ * Wire the chunk-error recovery at app bootstrap. Listens for Vite's `vite:preloadError` (dispatched
+ * by the built-in preload helper when a lazy chunk fails to load). On the first failure this session
+ * it sets the sentinel and reloads to the fresh shell; on a second it clears the sentinel and lets
+ * the router's `defaultErrorComponent` render the retry fallback.
+ */
+export function installChunkErrorHandler(): void {
+  window.addEventListener('vite:preloadError', (event) => {
+    // We own the recovery — suppress Vite's default (which rethrows the rejection).
+    event.preventDefault()
+    if (shouldReloadForChunkError(sentinelPresent()) === 'reload') {
+      try {
+        sessionStorage.setItem(CHUNK_RELOAD_SENTINEL, '1')
+      } catch {
+        // Can't persist the sentinel — a single reload attempt is still worth it.
+      }
+      window.location.reload()
+    } else {
+      // The fresh shell failed too → a real outage. Clear the sentinel so a later genuine
+      // stale-chunk race can reload again, and let the router error fallback take over.
+      try {
+        sessionStorage.removeItem(CHUNK_RELOAD_SENTINEL)
+      } catch {
+        // Nothing to clear — the fallback still renders.
+      }
+    }
+  })
+}

--- a/app/src/shared/lib/update-decision.test.ts
+++ b/app/src/shared/lib/update-decision.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { decideUpdateAction, type UpdateSignals } from './update-decision'
+
+// The plan's decision table IS the test matrix: each row is one situation → one action.
+const base: UpdateSignals = {
+  hasController: true,
+  hasInteracted: false,
+  visibility: 'visible',
+  isDirty: false,
+}
+
+describe('decideUpdateAction', () => {
+  it('activates on a first install — no existing controller, nothing to prompt', () => {
+    expect(decideUpdateAction({ ...base, hasController: false })).toBe('activate')
+    // First install wins even over dirty state: there is no prior version to preserve work against.
+    expect(
+      decideUpdateAction({ ...base, hasController: false, isDirty: true, hasInteracted: true }),
+    ).toBe('activate')
+  })
+
+  it('auto-applies silently when the tab is hidden and clean', () => {
+    expect(
+      decideUpdateAction({ ...base, hasInteracted: true, visibility: 'hidden' }),
+    ).toBe('auto')
+  })
+
+  it('auto-applies on a fresh load before the user has interacted', () => {
+    expect(decideUpdateAction({ ...base, hasInteracted: false })).toBe('auto')
+  })
+
+  it('defers to the next safe seam when focused, interacted, and clean', () => {
+    expect(decideUpdateAction({ ...base, hasInteracted: true })).toBe('defer')
+  })
+
+  it('prompts when there is unsaved / in-flight state', () => {
+    expect(decideUpdateAction({ ...base, hasInteracted: true, isDirty: true })).toBe('prompt')
+  })
+
+  it('protects dirty state even when the tab is hidden — never silently reload away work', () => {
+    expect(
+      decideUpdateAction({ ...base, hasInteracted: true, visibility: 'hidden', isDirty: true }),
+    ).toBe('prompt')
+  })
+})

--- a/app/src/shared/lib/update-decision.ts
+++ b/app/src/shared/lib/update-decision.ts
@@ -1,0 +1,43 @@
+/**
+ * Decides what to do when a new service worker is ready to take over (caching plan Phase 3).
+ *
+ * Auto-update stays the default: anyone who simply opens the app gets the fresh version with no UI.
+ * A visible prompt is a conditional fallback — shown only when a deploy lands while someone is
+ * actively working with unsaved / in-flight state, so we never reload the rug out from under them.
+ *
+ * This is the irreducible logic (the plan's decision table); the `useRegisterSW` wiring and the
+ * seam listeners around it are a thin SW-lifecycle shell with no story or real-backend path.
+ */
+export type UpdateAction = 'activate' | 'auto' | 'defer' | 'prompt'
+
+export interface UpdateSignals {
+  /** A previous worker already controls the page — false on a first install (nothing to prompt). */
+  hasController: boolean
+  /** The user has produced real input this session (first pointer/keydown). */
+  hasInteracted: boolean
+  /** Current document visibility — a hidden tab can be refreshed silently. */
+  visibility: DocumentVisibilityState
+  /** Unsaved forms or in-flight mutations — a reload would lose work, so never auto-apply. */
+  isDirty: boolean
+}
+
+export function decideUpdateAction({
+  hasController,
+  hasInteracted,
+  visibility,
+  isDirty,
+}: UpdateSignals): UpdateAction {
+  // First install — no existing controller to replace, so there is nothing to prompt about.
+  if (!hasController) return 'activate'
+  // Unsaved / in-flight state — never auto-reload; let the user pick the moment. This takes
+  // precedence over the hidden-tab case: a half-filled form still lives in memory even when the tab
+  // is backgrounded, and a silent reload there would discard it just the same.
+  if (isDirty) return 'prompt'
+  // Backgrounded / not focused, nothing to lose — refresh silently so it's fresh on return.
+  if (visibility === 'hidden') return 'auto'
+  // A fresh load before any interaction — applying now just reads as a normal load.
+  if (!hasInteracted) return 'auto'
+  // Focused, interacted, but clean — apply at the next safe seam (route change / tab hidden),
+  // falling back to a prompt only if none arrives before the app closes.
+  return 'defer'
+}

--- a/app/src/shared/ui/RouteErrorFallback.stories.tsx
+++ b/app/src/shared/ui/RouteErrorFallback.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { RouteErrorFallback } from './RouteErrorFallback'
+
+// The fallback the router shows when a route load still fails after the chunk-reload guard (Phase 1).
+// Prop-only: the retry callback comes in as a prop, so it stories with no router or network.
+const meta = {
+  title: 'shared/ui/RouteErrorFallback',
+  component: RouteErrorFallback,
+  args: { onRetry: fn() },
+} satisfies Meta<typeof RouteErrorFallback>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  // Prop-contract spy: proves Retry actually reaches onRetry, not merely that the shell renders.
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText("Couldn't load this page")).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /retry/i }))
+    await expect(args.onRetry).toHaveBeenCalled()
+  },
+}

--- a/app/src/shared/ui/RouteErrorFallback.tsx
+++ b/app/src/shared/ui/RouteErrorFallback.tsx
@@ -1,0 +1,22 @@
+import { QueryErrorState } from './QueryErrorState'
+
+interface RouteErrorFallbackProps {
+  /** Recover — typically a full reload to re-fetch the shell and its current chunk hashes. */
+  onRetry: () => void
+}
+
+/**
+ * The router's last-resort error fallback (caching plan Phase 1), rendered by the router's
+ * `defaultErrorComponent` when a route still throws after the one-shot chunk-reload guard has run —
+ * e.g. the fresh shell also failed to load a chunk. Reuses the shared QueryErrorState shell so a
+ * load failure is never a blank frame; Retry reloads to re-fetch the shell.
+ */
+export function RouteErrorFallback({ onRetry }: RouteErrorFallbackProps) {
+  return (
+    <QueryErrorState
+      title="Couldn't load this page"
+      description="Something went wrong loading the app. Please try again."
+      onRetry={onRetry}
+    />
+  )
+}

--- a/app/src/shared/ui/UpdateToast.stories.tsx
+++ b/app/src/shared/ui/UpdateToast.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, within } from 'storybook/test'
+import { UpdateToast } from './UpdateToast'
+
+// The update-available prompt (Phase 3), shown only when a deploy lands while the user is mid-session
+// with unsaved / in-flight state. Prop-only: hidden vs shown and the reload callback are props, so it
+// renders with no service worker.
+const meta = {
+  title: 'shared/ui/UpdateToast',
+  component: UpdateToast,
+  args: { show: true, onReload: fn() },
+} satisfies Meta<typeof UpdateToast>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Hidden: Story = {
+  args: { show: false },
+  play: async ({ canvasElement }) => {
+    // Nothing to nudge yet — the toast renders nothing rather than an empty bar.
+    await expect(within(canvasElement).queryByRole('alert')).not.toBeInTheDocument()
+  },
+}
+
+export const Shown: Story = {
+  // Prop-contract spy: proves Reload actually reaches onReload, not merely that the bar renders.
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText(/new version is available/i)).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /reload/i }))
+    await expect(args.onReload).toHaveBeenCalled()
+  },
+}

--- a/app/src/shared/ui/UpdateToast.tsx
+++ b/app/src/shared/ui/UpdateToast.tsx
@@ -1,0 +1,28 @@
+import { Button } from './button'
+
+interface UpdateToastProps {
+  /** Whether the update-available toast is shown. Hidden renders nothing. */
+  show: boolean
+  onReload: () => void
+}
+
+/**
+ * The update-available prompt (caching plan Phase 3), shown only in the one case SwUpdateManager
+ * won't auto-apply: a new version landed while the user is mid-session with unsaved / in-flight
+ * state. Presentational — hidden vs shown and the reload callback come in as props, so it stories
+ * with no service worker. Sits above the bottom nav, clear of the home-indicator inset.
+ */
+export function UpdateToast({ show, onReload }: UpdateToastProps) {
+  if (!show) return null
+  return (
+    <div
+      role="alert"
+      className="fixed inset-x-0 bottom-[calc(6rem+env(safe-area-inset-bottom))] z-50 mx-auto flex w-fit max-w-[calc(100%-2rem)] items-center gap-3 rounded-full border border-border bg-card px-4 py-2 shadow-lg"
+    >
+      <span className="text-sm">A new version is available.</span>
+      <Button size="sm" onClick={onReload}>
+        Reload
+      </Button>
+    </div>
+  )
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
 
 interface ImportMetaEnv {
   // Base URL for the API in a split-origin build (e.g. https://api.teambalance.nl).

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -17,12 +17,15 @@ export default defineConfig({
     tailwindcss(),
     // Installable app shell (F2). Workbox `generateSW` precaches the built shell and serves it
     // offline; see src/app/pwa/manifest.ts for the manifest and the never-cache-/api rule.
-    // `autoUpdate` + `injectRegister: 'auto'` keep registration out of the app bundle: the plugin
-    // emits registerSW.js and links it from index.html, so a new deploy takes over on next load.
-    // Left off in dev (the default) so the dev server and the real e2e never run against a stale SW.
+    // `registerType: 'prompt'` hands update *timing* to the app instead of the worker auto-skipping
+    // waiting: SwUpdateManager registers the worker via `virtual:pwa-register/react` and decides when
+    // to activate — auto by default, a toast only when a deploy lands mid-session (see
+    // decideUpdateAction, caching plan Phase 3). `injectRegister: null` because we register ourselves,
+    // so the plugin injects no registerSW.js. Left off in dev (the default) so the dev server and the
+    // real e2e never run against a stale SW.
     VitePWA({
-      registerType: 'autoUpdate',
-      injectRegister: 'auto',
+      registerType: 'prompt',
+      injectRegister: null,
       // The icon set and the master SVG are committed under public/ and generated ahead of the
       // build (`npm run generate-pwa-assets`), so the build itself needs no native image tooling;
       // Vite copies them to dist and the workbox globs pick them up (no `includeAssets` needed).

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -52,10 +52,13 @@ verify: check **Scaleway Cockpit** container logs for the boot crash, fix forwar
 
 **`deploy-frontend`** — builds the SPA (`vite build` auto-loads `app/.env.production` →
 `VITE_API_URL=https://api.teambalance.nl`), syncs `app/dist` → `s3://teambalance-spa`
-(hashed assets `immutable`, `index.html` `no-cache`, and the PWA shell: icons cached a day,
+(hashed assets `immutable` and **retained across deploys — no `--delete`**, see *Object Storage
+lifecycle* below; `index.html` `no-cache`, and the PWA shell: icons cached a day,
 `sw.js` / `registerSW.js` / `manifest.webmanifest` `no-cache` so an installed client is never
 pinned to a previous deploy's precache) and the landing page + design tokens
-→ `s3://teambalance-www`, then purges both Edge Services pipelines. S3 uses the **dedicated
+→ `s3://teambalance-www` (`index.html` **and** its unhashed `style.css` / `tokens.css` all
+`no-cache`, so the root-referenced CSS revalidates in lockstep with the HTML and can't be served
+stale), then purges both Edge Services pipelines. S3 uses the **dedicated
 Object Storage IAM key** (`SCW_S3_*`).
 
 ## Container resource config
@@ -64,6 +67,30 @@ The container's **cpu / memory / sandbox** (2 vCPU, 2 GB, gVisor v2) are set **m
 the Scaleway console**, not by the deploy — the pipeline only updates the image. To A/B the
 cold start, change the vCPU in the console (e.g. 4 vCPU) and re-read the `Started … in X
 seconds` line. Console fields: CPU in vCPU, memory in MB, sandbox v1/v2.
+
+## Object Storage lifecycle (assets retention — console/IaC, not in-repo)
+
+The `assets/` sync intentionally runs **without `--delete`**: content-hashed chunks from the
+*previous* deploy must survive, because a client still on the old shell (a long-open tab, the
+installed PWA, or a stale service-worker precache) keeps requesting those old hashes. Pruning
+them the instant a new deploy lands 404s those clients into a blank screen. Because the chunks
+are content-addressed and `immutable`, re-uploading unchanged hashes is a harmless no-op and
+stale hashes never collide — so retaining them costs only storage, which a lifecycle rule
+reclaims.
+
+**Required rule — apply once, in the Scaleway console (Object Storage → `teambalance-spa` →
+Lifecycle rules) or via IaC.** This is **not** in this repo (bucket config lives outside the
+codebase) and must be set by someone with console access:
+
+- **Prefix:** `assets/`
+- **Action:** expire (delete) objects **90 days** after last modification.
+
+**Why 90 days.** It comfortably outlives how long any client realistically stays on a stale
+shell, and it stays safe once the app is stable and deploys are infrequent: a low deploy cadence
+means an old-but-still-referenced hash may need to survive a long gap between releases, so the
+retention window must exceed that gap. A shorter window (e.g. 30 days) is only safe during heavy
+development, where a fresh build lands often and no hash stays referenced for long. Leave it at 90
+unless the deploy cadence changes.
 
 ## Required GitHub Actions secrets
 

--- a/docs/plans/2026-08-24-app-caching-blank-screen.md
+++ b/docs/plans/2026-08-24-app-caching-blank-screen.md
@@ -104,9 +104,12 @@ they stop being referenced.
 
 - Drop `--delete` from the `assets/` sync (`ci.yml:307`). Hashed + `immutable`, so re-uploading
   unchanged hashes is a harmless no-op and stale hashes never collide.
-- Reclaim space with a **bucket lifecycle rule** on `assets/` (e.g. expire objects N days after last
-  modification — 30 days is generous vs. how long a client stays on an old shell). Configure via
-  Scaleway; document the rule in `docs/ops/deploy.md` since bucket config isn't in-repo.
+- Reclaim space with a **bucket lifecycle rule** on `assets/` — expire objects **90 days** after last
+  modification. Rationale: 90 days comfortably outlives how long any client realistically stays on a
+  stale shell, and stays safe once the app is stable and deploys are infrequent (a low deploy cadence
+  means old-but-still-referenced hashes must survive longer between releases; a shorter window like 30
+  days is fine only during heavy development where a fresh build lands often). Configure via Scaleway;
+  document the rule in `docs/ops/deploy.md` since bucket config isn't in-repo.
 - Keep upload order as-is (assets **before** `index.html`, `ci.yml:306` then `:308`) so `index.html`
   never references a not-yet-uploaded hash.
 
@@ -118,32 +121,62 @@ unobservable.
 lifecycle rule; note the manual verification (deploy twice, confirm prior-deploy `assets/*` still
 GET-able) in the PR.
 
-### Phase 3 — Deterministic SW updates (kills the "didn't come through" lag)
+### Phase 3 — Auto-update by default; prompt only when the user is actively in the app
 
-**Change (`app/`):** Replace silent `autoUpdate` with an explicit update-and-reload.
+**Goal:** keep the zero-friction auto-update for the common case (a returning user opens the app →
+always gets the fresh version, no UI), and fall back to a prompt **only** when a new version lands
+while someone is mid-session — so we never reload the rug out from under active work, and prompts
+don't fire "all the time."
 
-- Switch `registerType` to `'prompt'` and register via `virtual:pwa-register/react`
-  (`useRegisterSW`) instead of `injectRegister: 'auto'` (`vite.config.ts:23-31`). On `needRefresh`,
-  show a lightweight "New version available — Reload" toast wired to `updateSW(true)`.
-- Reconsider `clientsClaim: true` (`manifest.ts:63`): with a prompt-driven reload the new SW takes
-  control on the user's reload, so immediate claim is no longer needed and its mid-session swap
-  risk goes away. Keep `cleanupOutdatedCaches: true`.
-- Net effect: the user gets a clear, one-click path to the new version; no silent mid-session flip,
-  no indefinite "still on old shell."
+The behaviour splits into two independent knobs.
 
-**Trade-off / decision:** this is a small UX addition (a toast) vs. the current zero-UI autoupdate.
-Chosen because the silent path is precisely what makes deploys feel like they "didn't land." If we'd
-rather keep zero-UI, the fallback is `autoUpdate` **plus** a `controllerchange` listener that reloads
-once — but that reintroduces an automatic mid-session reload, which is worse UX than a prompt.
-**Recommend the prompt.** Flagging for confirmation before implementing.
+**Knob 1 — how often we even look for an update.** Fewer checks → fewer chances to interrupt. Check
+on page load and on regaining focus/visibility (`visibilitychange` → visible), plus at most a long
+periodic `registration.update()` interval (e.g. hourly), rather than aggressive polling. Tune via the
+`useRegisterSW` `onRegisteredSW` hook. This alone addresses "I don't want that happening all the
+time."
 
-**Tests:**
-- **Storybook story** for the update-available toast: idle vs. update-available states; `fn()` spy on
-  the reload callback asserted with `toHaveBeenCalled` in `play`.
-- **Vitest unit** for any pure "should prompt" logic if extracted.
-- The `useRegisterSW` wiring is a network/SW seam with no story or real-backend path — thin container,
-  covered by manual verification (deploy, confirm toast, click, confirm fresh shell). Not a new
-  sanctioned MSW test (doesn't meet the fourth-exception bar in CLAUDE.md).
+**Knob 2 — what we do when an update *is* found**, decided by app state at that moment:
+
+| Situation when the new SW becomes ready | Action |
+|---|---|
+| First install (no existing `navigator.serviceWorker.controller`) | Nothing to prompt — just activate. |
+| Update found during a fresh load, before the user has interacted this session | **Auto-apply** (`updateSW(true)`) — perceived as a normal load, no UI. |
+| Tab hidden / app not focused | **Auto-apply silently** and reload while hidden, so it's fresh when they return. |
+| App open & focused, user has interacted, but **no** unsaved / in-flight state | Auto-apply at the **next safe seam** (a route navigation, or the next `visibilitychange` → hidden). Only if none arrives, show the prompt. |
+| App open with unsaved input / open modal / in-flight mutation | **Prompt only** — never auto-reload; the user clicks "Reload" when ready. |
+
+Net: it behaves exactly like autoupdate for everyone who simply opens the app, and it *only ever
+prompts* the small set of users who happen to be actively working the moment a deploy lands — and even
+then it auto-resolves at the next natural boundary unless a reload would lose their state.
+
+**Change (`app/`):**
+- Switch `registerType` from `'autoUpdate'` to `'prompt'` and register via `virtual:pwa-register/react`
+  (`useRegisterSW`) instead of `injectRegister: 'auto'` (`vite.config.ts:23-31`). `'prompt'` only means
+  "the SW does not auto-`skipWaiting`" — it hands *us* the timing; it does **not** force a visible
+  prompt. Our code calls `updateSW(true)` (posts `SKIP_WAITING`, reloads on `controllerchange`) under
+  the rules above; the toast is shown only in the last-two table rows.
+- Drive the table from two signals: a `hasInteracted` flag (first real user input this session) and an
+  `isDirty` signal (unsaved forms + pending TanStack Query mutations). Both already observable in-app.
+- `clientsClaim: true` (`manifest.ts:63`) is no longer needed — control transfers on our controlled
+  reload; keep `cleanupOutdatedCaches: true`.
+
+**Decision (updated):** auto-update stays the default; the prompt is a *conditional fallback*, not the
+primary path. This matches "auto-update should still be possible, prompt only when the app is open."
+The one nuance to confirm: for the "focused, interacted, not dirty" row, prefer **auto at next seam**
+(recommended — stays invisible) vs. **always prompt** (more conservative, more toasts). Recommend
+auto-at-next-seam.
+
+**Tests (lowest layer that proves it):**
+- **Vitest unit** for the pure decision function
+  `decideUpdateAction({ hasController, hasInteracted, visibility, isDirty }) → 'activate' | 'auto' | 'defer' | 'prompt'`
+  — the table above *is* the test matrix. This is the irreducible logic and where the real risk lives.
+- **Storybook story** for the update-available toast (hidden vs. shown states) with an `fn()` spy on the
+  reload callback asserted `toHaveBeenCalled` in `play`.
+- The `useRegisterSW` wiring + seam listeners are a thin SW/lifecycle shell with no story or
+  real-backend path — manual-verified (deploy; confirm silent refresh on reopen; confirm a toast only
+  appears when a deploy lands while typing in a form). Not a new sanctioned MSW test (doesn't meet the
+  fourth-exception bar in CLAUDE.md).
 
 ### Phase 4 — Landing page CSS: stop it going stale
 
@@ -183,6 +216,7 @@ matches how they're referenced.
   replay queue is unsafe for a multi-tenant cookie-authed backend (the very reason `manifest.ts:56-60`
   marks `/api` `NetworkOnly`), and its manual `SW_VERSION` bumping is more error-prone than the
   hashed precache manifest Workbox already generates. Its one good idea — gating client claim on tab
-  count — is subsumed by Phase 3's prompt-driven update. Not adopted.
+  count — is subsumed by Phase 3's app-state-aware update (auto by default, prompt only when actively
+  in the app). Not adopted.
 - **Dropping the service worker entirely.** Would fix stale content but lose the installable
   offline shell (F2, #159). Not warranted; the update flow is the real gap, not the SW itself.

--- a/docs/plans/2026-08-24-app-caching-blank-screen.md
+++ b/docs/plans/2026-08-24-app-caching-blank-screen.md
@@ -1,0 +1,188 @@
+# App Caching — Blank Screens & Stale Deploys Fix Plan
+
+**Goal:** Eliminate two user-reported symptoms on `app.teambalance.nl`:
+1. **Blank screen**, often right after a deploy.
+2. **"Changes didn't come through"** — a deploy appears not to take effect until much later.
+
+Both trace to the interaction between content-hashed immutable assets that are **deleted on
+every deploy**, lazy-loaded route chunks with **no load-failure recovery**, and a **Workbox
+service worker** that serves the precached old shell cache-first. This plan removes each root
+cause at the lowest layer that fixes it.
+
+**Status:** Draft — not yet implemented. No code changed.
+
+**Branch:** `claude/app-caching-blank-screen-dh3i9m`
+
+---
+
+## Diagnosis (evidence-based)
+
+All asset `Cache-Control` is set at upload time in the deploy step; there is **no** nginx/netlify/
+vercel/`_headers` config and the Spring API serves no static assets. Files served from Scaleway
+Object Storage behind Scaleway Edge Services (CDN).
+
+### Symptom A — Blank screen after deploy
+
+Three things combine, with no safety net:
+
+1. **Route chunks are lazy-loaded.** `app/vite.config.ts:14` — `autoCodeSplitting: true`. Each
+   TanStack route is a hashed chunk fetched via dynamic `import()` on navigation.
+2. **Old hashed chunks are deleted immediately on deploy.** `.github/workflows/ci.yml:306-307` —
+   the assets sync uses `--delete`, so the previous deploy's `assets/*-<hash>.js` vanish the
+   instant the new deploy lands.
+3. **No recovery for a failed dynamic import.** Grep of `app/src` finds no `vite:preloadError`,
+   `ChunkLoadError`, or router `defaultErrorComponent` handling (`app/src/app/index.tsx` sets only
+   `defaultPendingComponent`). A client still running the *old* shell (a long-open tab, the
+   installed PWA, or the SW serving the old precached `index.html`) navigates to a not-yet-loaded
+   route → requests a chunk hash that was just `--delete`d → **404 → import rejects → blank**.
+
+`cleanupOutdatedCaches: true` (`app/src/app/pwa/manifest.ts:62`) widens the window: once the new
+SW activates it evicts the old chunks from Cache Storage too, so even the offline fallback can't
+serve them.
+
+### Symptom B — Stale content / "didn't come through"
+
+The Workbox precache defeats the `no-cache` header on `index.html`:
+
+- `globPatterns: ['**/*.{js,css,html,...}']` (`manifest.ts:51`) precaches `index.html`, and
+  Workbox serves precached URLs **cache-first**. `navigateFallback: '/index.html'` (`manifest.ts:53`)
+  means installed clients get the **old shell from the SW cache**, never hitting the origin — so
+  `index.html`'s `no-cache` (`ci.yml:308-309`) is bypassed for exactly the returning users who
+  matter most.
+- `registerType: 'autoUpdate'` (`vite.config.ts:24`) installs the new SW in the background but the
+  running tab keeps the old shell; new content only appears on the **next** navigation. For an
+  installed PWA that's rarely fully closed, "next" can be a long time → looks like the deploy never
+  landed.
+
+### Secondary — landing page (`teambalance.nl`) stale CSS
+
+`www/index.html` is `no-cache` (`ci.yml:328`) but the **unhashed** files it references —
+`www/style.css` and `design-tokens/tokens.css` — are uploaded with **no `--cache-control`**
+(`ci.yml:330-331`), so they inherit the bucket/CDN default TTL. After a landing deploy the HTML
+updates while its CSS can be served stale → a half-updated landing page. (The SPA's own
+`tokens.css`/`style.css` are bundled+hashed by Vite and unaffected.)
+
+### Tertiary — edge purge is fire-and-forget
+
+`ci.yml:333-336` issues `scw edge-services purge-request ... all=true` for both pipelines and never
+verifies it. A skipped/failed purge, or the edge honoring its own TTL over `no-cache` briefly, is a
+third path to serving a stale `index.html` that points at pruned chunks.
+
+---
+
+## Fixes
+
+Ordered by impact. Phases 1–2 kill the blank screen; Phase 3 kills the stale-content lag; Phases
+4–5 close the landing-page and edge gaps. Phases are independent and shippable separately.
+
+### Phase 1 — Recover from failed chunk loads (kills the blank screen for clients already loaded)
+
+**Change (`app/`):** Add a global, one-shot reload guard for dynamic-import failures.
+
+- Listen for Vite's `vite:preloadError` event on `window` (dispatched by Vite's built-in preload
+  helper when a lazy chunk fails), and also catch router load errors.
+- On failure, if we have **not** already reloaded for this reason in the current session, set a
+  `sessionStorage` sentinel and `location.reload()` — the reload fetches the fresh (`no-cache`)
+  `index.html`, which references chunk hashes that *do* exist. If the sentinel is already set (the
+  fresh shell *also* failed → a real outage, not a stale-chunk race), **don't** loop: clear the
+  sentinel and render a small "couldn't load — retry" fallback instead.
+- Add a `defaultErrorComponent` to the router (`app/src/app/index.tsx`) so a route that still throws
+  renders that fallback rather than nothing.
+
+**Why this layer:** it's the missing safety net; it makes the deploy race self-healing regardless of
+how the stale shell was obtained (SW, tab, or edge).
+
+**Tests (lowest layer that proves it):**
+- **Vitest unit** for the pure decision function `shouldReloadForChunkError(sentinelPresent): 'reload' | 'fallback'` — reload when no sentinel, fallback when set. This is the irreducible logic; the `window` event + `location.reload` wiring is thin.
+- **Storybook story** for the fallback error component (data/error states) with an `fn()` spy on its retry callback asserted via `toHaveBeenCalled` in `play` (per the PR gate for interactive components).
+- **No new e2e**: this introduces no new auth/tenant/integration seam (per the gate, e2e is justified only then). State that in the PR.
+
+### Phase 2 — Keep old chunks alive briefly (removes the cause, not just the symptom)
+
+**Change (`.github/workflows/ci.yml` + bucket policy):** Stop deleting hashed assets on the same tick
+they stop being referenced.
+
+- Drop `--delete` from the `assets/` sync (`ci.yml:307`). Hashed + `immutable`, so re-uploading
+  unchanged hashes is a harmless no-op and stale hashes never collide.
+- Reclaim space with a **bucket lifecycle rule** on `assets/` (e.g. expire objects N days after last
+  modification — 30 days is generous vs. how long a client stays on an old shell). Configure via
+  Scaleway; document the rule in `docs/ops/deploy.md` since bucket config isn't in-repo.
+- Keep upload order as-is (assets **before** `index.html`, `ci.yml:306` then `:308`) so `index.html`
+  never references a not-yet-uploaded hash.
+
+**Why:** with old chunks retained, a client on the previous shell can still fetch its chunks during
+the overlap window; Phase 1 catches anything past the retention horizon. Together they make the race
+unobservable.
+
+**Tests:** infra change — no app test layer applies. Verify by inspecting the deploy step and the
+lifecycle rule; note the manual verification (deploy twice, confirm prior-deploy `assets/*` still
+GET-able) in the PR.
+
+### Phase 3 — Deterministic SW updates (kills the "didn't come through" lag)
+
+**Change (`app/`):** Replace silent `autoUpdate` with an explicit update-and-reload.
+
+- Switch `registerType` to `'prompt'` and register via `virtual:pwa-register/react`
+  (`useRegisterSW`) instead of `injectRegister: 'auto'` (`vite.config.ts:23-31`). On `needRefresh`,
+  show a lightweight "New version available — Reload" toast wired to `updateSW(true)`.
+- Reconsider `clientsClaim: true` (`manifest.ts:63`): with a prompt-driven reload the new SW takes
+  control on the user's reload, so immediate claim is no longer needed and its mid-session swap
+  risk goes away. Keep `cleanupOutdatedCaches: true`.
+- Net effect: the user gets a clear, one-click path to the new version; no silent mid-session flip,
+  no indefinite "still on old shell."
+
+**Trade-off / decision:** this is a small UX addition (a toast) vs. the current zero-UI autoupdate.
+Chosen because the silent path is precisely what makes deploys feel like they "didn't land." If we'd
+rather keep zero-UI, the fallback is `autoUpdate` **plus** a `controllerchange` listener that reloads
+once — but that reintroduces an automatic mid-session reload, which is worse UX than a prompt.
+**Recommend the prompt.** Flagging for confirmation before implementing.
+
+**Tests:**
+- **Storybook story** for the update-available toast: idle vs. update-available states; `fn()` spy on
+  the reload callback asserted with `toHaveBeenCalled` in `play`.
+- **Vitest unit** for any pure "should prompt" logic if extracted.
+- The `useRegisterSW` wiring is a network/SW seam with no story or real-backend path — thin container,
+  covered by manual verification (deploy, confirm toast, click, confirm fresh shell). Not a new
+  sanctioned MSW test (doesn't meet the fourth-exception bar in CLAUDE.md).
+
+### Phase 4 — Landing page CSS: stop it going stale
+
+**Change (`.github/workflows/ci.yml`):** Give the unhashed landing assets an explicit header that
+matches how they're referenced.
+
+- Add `--cache-control no-cache` to the `www/style.css` and `design-tokens/tokens.css` uploads
+  (`ci.yml:330-331`), matching `www/index.html`. Simplest correct fix for unhashed, root-referenced
+  CSS. (A longer-lived alternative would be to hash+fingerprint them, but the landing page is tiny
+  and rarely changes — `no-cache` is proportionate.)
+
+**Tests:** infra — verify header via `curl -I` post-deploy; note in PR.
+
+### Phase 5 (optional) — Make the edge purge verifiable
+
+**Change (`.github/workflows/ci.yml`):** Ensure a failed purge fails the job.
+
+- Confirm the purge step runs under `set -e` (the sync step at `:304` does; the purge step at
+  `:333-336` should too) and, if the API supports it, poll/verify the purge completed before the job
+  goes green. Low priority given Phases 1–2 already make a stale edge shell self-healing.
+
+---
+
+## Rollout & verification
+
+- Ship **Phase 1 first** on its own — it's pure app code, low risk, and immediately stops the blank
+  screen from being user-visible even before the deploy pipeline changes land.
+- Then **Phase 2** (pipeline + bucket rule), then **Phase 3** (SW UX), then **4/5**.
+- Manual verification per change (per CLAUDE.md feedback-loops): deploy to a `deploy*` branch, then
+  from a client on the *previous* build (a) navigate to an unvisited route → no blank; (b) confirm
+  the update toast appears and reload yields fresh content; (c) `curl -I` the landing CSS for
+  `no-cache`.
+
+## Considered and rejected
+
+- **Adopting the `pwa-today/basic-service-worker` hand-rolled worker.** Its offline POST/PUT/DELETE
+  replay queue is unsafe for a multi-tenant cookie-authed backend (the very reason `manifest.ts:56-60`
+  marks `/api` `NetworkOnly`), and its manual `SW_VERSION` bumping is more error-prone than the
+  hashed precache manifest Workbox already generates. Its one good idea — gating client claim on tab
+  count — is subsumed by Phase 3's prompt-driven update. Not adopted.
+- **Dropping the service worker entirely.** Would fix stale content but lose the installable
+  offline shell (F2, #159). Not warranted; the update flow is the real gap, not the SW itself.


### PR DESCRIPTION
Diagnoses the two reported symptoms (blank screen after deploy, stale
content) to their root causes — immediate --delete of hashed chunks +
no dynamic-import recovery, and the Workbox precache serving the old
shell cache-first — and lays out phased fixes: a chunk-load-error
reload guard, an asset retention grace period, a prompt-driven SW
update flow, and explicit cache headers for the unhashed landing CSS.