### PR TITLE
fix(deploy): stop uploading registerSW.js (no longer emitted)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,14 +318,14 @@ jobs:
           # No --delete here: the root also holds index.html, which is uploaded separately.
           aws --endpoint-url "$S3_ENDPOINT" s3 sync app/dist "s3://${SPA_BUCKET}" \
             --exclude "assets/*" --exclude "index.html" \
-            --exclude "sw.js" --exclude "registerSW.js" --exclude "manifest.webmanifest" \
+            --exclude "sw.js" --exclude "manifest.webmanifest" \
             --cache-control "public,max-age=86400"
-          # The service worker, its registration script and the manifest must never be cached:
-          # a stale sw.js pins every installed client to the previous deploy's precache.
-          for f in sw.js registerSW.js; do
-            aws --endpoint-url "$S3_ENDPOINT" s3 cp "app/dist/$f" "s3://${SPA_BUCKET}/$f" \
-              --cache-control no-cache
-          done
+          # The service worker and the manifest must never be cached: a stale sw.js pins every
+          # installed client to the previous deploy's precache. Registration is now bundled into the
+          # app entry (vite-plugin-pwa injectRegister: null), so there is no separate registerSW.js
+          # to upload — the SW is emitted, self-registered by a hashed app chunk, nothing else.
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp app/dist/sw.js "s3://${SPA_BUCKET}/sw.js" \
+            --cache-control no-cache
           # .webmanifest is not in the AWS CLI's mime table, so it would land as
           # application/octet-stream and be rejected as a manifest — set the type explicitly.
           aws --endpoint-url "$S3_ENDPOINT" s3 cp app/dist/manifest.webmanifest "s3://${SPA_BUCKET}/manifest.webmanifest" \


### PR DESCRIPTION
## What

The `deploy-frontend` job fails on `main` with:

```
aws: [ERROR]: The user-provided path app/dist/registerSW.js does not exist.
```

([run 32756992309](https://github.com/ZzAve/teambalance-app/actions/runs/32756992309/job/97527799973))

The caching PR (#247) set `vite-plugin-pwa`'s `injectRegister: null`, so SW registration is now bundled into a hashed app chunk and the plugin **no longer emits `registerSW.js`**. The deploy step still tried to `aws s3 cp app/dist/registerSW.js …`, and under `set -euo pipefail` the missing file aborts the entire frontend deploy.

## Change

`.github/workflows/ci.yml` only:
- Drop `--exclude "registerSW.js"` from the bulk root sync.
- Replace the `for f in sw.js registerSW.js` upload loop with a direct `aws s3 cp app/dist/sw.js …` (still `no-cache`).

`sw.js` is still emitted and uploaded; only the non-existent `registerSW.js` reference is removed.

## Verification

- Grepped the repo: no remaining `registerSW.js` *upload* — the only matches are comments/docs explaining its absence and the demo fixture's `(registerSW|sw)` regex.
- `ci.yml` parses cleanly (`yaml.safe_load`).
- Per the merged-PR rule this branch was restarted from latest `main`; it contains only this one-commit follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdRM1oJpBQvA8afP4WoTK6)_