### PR TITLE
fix(app): stop the cold-start /me error from blanking the screen

### DIFF
--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -3,11 +3,20 @@ import { setupServer } from 'msw/node'
 import { render, screen, waitFor } from '@testing-library/react'
 import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../../routeTree.gen'
+import { WakingSplash } from '@shared/ui/ColdStartSplash'
+import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+import { queryClient } from '@shared/api/query-client'
 import type { AuthenticatedUser } from '@shared/api/auth'
 
 // The guard is a true render gate: a protected route must not mount (and therefore must not
-// fetch protected data) until the session is confirmed. An unconfirmed session — a 401 probe OR
-// any /me error — fails closed to the login screen.
+// fetch protected data) until the session is confirmed. It distinguishes the two ways a session
+// fails to confirm:
+//   • a *clean* 401 (backend reachable, not signed in) → redirect to /login;
+//   • a *backend error* (network / 5xx while the scale-to-zero container is still waking) → the
+//     router's themed error fallback (Retry reloads), NOT /login. Redirecting to /login there
+//     would log out a still-valid session, and — because the errored /me query stayed in cache
+//     while the layout mounted — used to crash the initial render into a blank screen.
+// Either way it fails closed: the protected route never mounts and its data never fetches.
 
 const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
 
@@ -38,15 +47,33 @@ const server = setupServer(
 )
 
 beforeAll(() => server.listen())
+beforeEach(() => {
+  // The guard reads the shared query client, so the ['auth','me'] result must not leak between
+  // tests (a cached null from one case would skip the next case's probe). Also pin retry off for
+  // this seam: the retry/backoff timing is exercised in retry-policy.test.ts; here we only assert
+  // how the guard reacts to the settled outcome, and real backoff would make the test slow + flaky.
+  queryClient.clear()
+  queryClient.setQueryDefaults(['auth', 'me'], { retry: false })
+})
 afterEach(() => {
   server.resetHandlers()
   meStatus = 401
   eventsFetched = false
+  queryClient.clear()
+  queryClient.setQueryDefaults(['auth', 'me'], {})
 })
 afterAll(() => server.close())
 
+// Mirror the real router config from app/index.tsx so the gate is exercised with the same pending
+// and error components the app ships — the error fallback in particular is what a probe failure
+// must render instead of a blank frame.
 function renderAppAt(path: string) {
-  const router = createRouter({ routeTree, history: createMemoryHistory({ initialEntries: [path] }) })
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+    defaultPendingComponent: WakingSplash,
+    defaultErrorComponent: () => <RouteErrorFallback onRetry={() => {}} />,
+  })
   render(<RouterProvider router={router} />)
   return router
 }
@@ -63,11 +90,17 @@ describe('auth gate', () => {
     expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })
 
-  it('fails closed: a non-401 /me error also redirects to login and never mounts the route', async () => {
+  it('fails closed on a non-401 /me error to the error fallback — not /login, never mounts the route', async () => {
     meStatus = 500
     const router = renderAppAt('/')
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/login'), { timeout: 5000 })
+    // The themed retry fallback, not a blank frame and not the login screen: a cold-start backend
+    // error must not be mistaken for "signed out".
+    await waitFor(() => expect(screen.getByText(/couldn't load this page/i)).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    expect(router.state.location.pathname).not.toBe('/login')
+    // Still gated: the protected route never mounted, so its data fetch never fired.
     expect(eventsFetched).toBe(false)
     expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -36,15 +36,17 @@ export const Route = createRootRoute({
   component: RootLayout,
   // A true gate: the session is probed before a protected route loads, so its component never
   // mounts (and never fetches protected data) unless the session is confirmed. An unauthenticated
-  // 401 — or any /me error (fail closed) — redirects to login before render.
+  // 401 redirects to login before render; a backend error surfaces the router's error fallback
+  // (see below) — either way the protected route is never rendered.
   beforeLoad: async ({ location }) => {
     if (isAuthRoute(location.pathname)) return
-    let user = null
-    try {
-      user = await queryClient.ensureQueryData(authMeQueryOptions)
-    } catch {
-      // Session could not be confirmed (network / 5xx) — fail closed.
-    }
+    // A genuine 401 resolves to null → /login. A backend error (network / 5xx while the
+    // scale-to-zero container is still waking) REJECTS: let it propagate to the router's
+    // themed error fallback (Retry reloads, by which point the backend is warm) instead of
+    // failing closed to /login. Failing closed here both logged out a still-valid session
+    // and — because the errored /me query stayed in cache while RootLayout mounted — crashed
+    // the render into a blank frame.
+    const user = await queryClient.ensureQueryData(authMeQueryOptions)
     if (!user) throw redirect({ to: '/login' })
 
     // Has-ANY-team gate (ADR-0023 §4). Which Team is active is a separate question, answered by


### PR DESCRIPTION
On a scale-to-zero cold start the /me session probe can return a
transient error (5xx / connection reset) while the container wakes.
The root beforeLoad guard caught *every* such error and failed closed
with `throw redirect({ to: '/login' })`. With the errored ['auth','me']
query still in cache as RootLayout mounted, React surfaced an uncaught
`throw undefined` that emptied #root — a black screen in dark mode that
only a manual refresh (hitting a now-warm backend) cleared. Reproduced
in a real browser: any non-401 /me error → 5/5 blank; a clean 401 or a
200 → 0 blank.

Distinguish the two failure modes in the guard: a clean 401 still
resolves to null → /login, but a backend error now propagates to the
router's themed error fallback (RouteErrorFallback, whose Retry reloads
— by which point the backend is warm). This removes the black screen
and also stops logging a still-valid session out to /login on a
transient wake error. The protected route still never mounts, so the
gate stays fail-closed.

Update the auth-gate render-gate test to assert the corrected behavior
(non-401 error → error fallback, not /login), mirror the app's real
router config (pending + error components), and fix cross-test cache
pollution by clearing the shared query client between cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012V1v7o67D1QrpkVsbRarqN