### PR TITLE
docs: drop Google Sign-In (ADR-0027) — magic-link stays the sole auth method

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,15 +119,13 @@ any-team, self-service (see [ADR-0001](docs/adr/0001-product-ambition-hobby-tool
 
 ### Identity & onboarding ([ADR-0008](docs/adr/0008-auth-magic-link-and-shareable-invite.md), [ADR-0011](docs/adr/0011-add-google-signin-verified-email-linking.md))
 
-- **Magic Link** — A one-time, passwordless login link sent to a member's email. One of
-  two passwordless authentication methods (the other is **Google Sign-In**); both prove
-  control of an email. Sessions are server-side and stored in Postgres via Spring Session JDBC
+- **Magic Link** — A one-time, passwordless login link sent to a member's email, and **the sole
+  authentication method**: it proves control of an email, which is the only proof v1 accepts —
+  deliberately no passwords and no third-party OAuth ([ADR-0008](docs/adr/0008-auth-magic-link-and-shareable-invite.md);
+  Google Sign-In was dropped, [ADR-0027](docs/adr/0027-drop-google-signin-magic-link-only.md)).
+  Sessions are server-side and stored in Postgres via Spring Session JDBC
   (the `SESSION` cookie), so they survive a container restart / cold start / redeploy
   ([ADR-0014](docs/adr/0014-jdbc-backed-shared-sessions-survive-restart.md), supersedes ADR-0010).
-- **Google Sign-In** — Authenticating with a Google account. Treated as a second proof of
-  email control equivalent to a **Magic Link**: a Google login lands in the *same* account,
-  matched on verified email. There is no separate "Google account" in the model.
-  Deliberately **no passwords** — email control is the only proof v1 accepts.
   _Avoid_: OAuth login, social login, password.
 - **Invite Link** — A single shareable link an admin generates to onboard members into
   an existing Team. Clicking it → enter email → Magic Link → joined. One link, many

--- a/docs/adr/0011-add-google-signin-verified-email-linking.md
+++ b/docs/adr/0011-add-google-signin-verified-email-linking.md
@@ -1,6 +1,8 @@
 # ADR-0011: Add Google Sign-In via verified-email linking; no passwords
 
-- Status: Accepted
+- Status: Accepted — **Google Sign-In decision superseded by
+  [ADR-0027](0027-drop-google-signin-magic-link-only.md)** (dropped for good; passkeys explored
+  instead). The cut-username/password and `Email`-normalization decisions below **still stand**.
 - Date: 2026-07-14
 - Amends: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (which chose magic-link
   and explicitly excluded "passwords, no third-party OAuth provider")

--- a/docs/adr/0012-adopt-spring-security-session-fixation-csrf-unified-auth.md
+++ b/docs/adr/0012-adopt-spring-security-session-fixation-csrf-unified-auth.md
@@ -11,6 +11,8 @@ Three concrete gaps in the current hand-rolled filter model warranted adopting S
 (2) there is no CSRF stance for the cookie-session SPA;
 (3) the forthcoming Google Sign-In work introduces a second auth method — a unified `SecurityFilterChain` entry point is preferable to a second bespoke filter bolted on top.
 
+> **Update (ADR-0027):** Google Sign-In was subsequently dropped for good. Driver (3) is void, but the decision stands on drivers (1) and (2); the unified filter chain is where a future passkey provider would slot in, the way Google would have.
+
 CORS is not a driver — `WebMvcConfigurer.addCorsMappings` suffices, and the app currently relies on same-origin (Vite proxy in dev, same host in prod).
 
 ## Decision

--- a/docs/adr/0027-drop-google-signin-magic-link-only.md
+++ b/docs/adr/0027-drop-google-signin-magic-link-only.md
@@ -1,0 +1,54 @@
+# ADR-0027: Drop Google Sign-In — magic-link stays the sole auth method
+
+- Status: Accepted
+- Date: 2026-08-30
+- Supersedes: [ADR-0011](0011-add-google-signin-verified-email-linking.md), **the Google Sign-In
+  decision only** — ADR-0011's cut-username/password and `Email`-normalization decisions stand
+  unchanged
+- Relates to: [ADR-0008](0008-auth-magic-link-and-shareable-invite.md) (magic-link as the sole
+  method), [ADR-0012](0012-adopt-spring-security-session-fixation-csrf-unified-auth.md) (one of whose
+  justifications was the forthcoming Google work)
+
+## Context
+
+[ADR-0011](0011-add-google-signin-verified-email-linking.md) added Google Sign-In as a *second*
+passwordless method — another proof of email control landing in the same account, matched on verified
+email. In the clean-slate rewrite it was never carried forward, and it is now dropped **for good**:
+magic-link remains the sole authentication method.
+
+ADR-0011 bundled three decisions. Two are independent of Google and **remain in force**:
+
+- **No username/password** — the motivation was really dev-loop friction, solved for free by long-lived
+  sessions plus a dev login shortcut.
+- **The `Email` value object** — `trim().lowercase()` normalization with a lowered-unique guard. This is
+  load-bearing regardless of how many front doors exist (magic-link stored email as-typed before it),
+  and is entirely unaffected by dropping Google.
+
+Only the third — Google as a second front door — is reversed here.
+
+## Decision
+
+**Magic-link is the sole authentication method. Google Sign-In is dropped.**
+
+- Email control is the only proof v1 accepts (ADR-0008), and magic-link is the only mechanism providing
+  it. No Google Identity Services, no `GoogleIdentityVerifier` port, no `POST /api/auth/google/verify`,
+  no `VITE_GOOGLE_CLIENT_ID` / `teambalance.auth.google.client-id`. None of this was built in the
+  rewrite, so there is nothing to remove — this is a decision-and-doc reversal, not a code migration.
+- **Faster repeat login is being explored via passkeys, not Google.** The convenience ADR-0011
+  attributed to a Google button is now expected to be served by passkey (WebAuthn) login, which is under
+  investigation. That is its own decision and its own ADR when it lands; it is named here only to record
+  *why* the gap Google would have filled is not being reopened with Google.
+- **What stands from ADR-0011:** no username/password, and the `Email` normalization. Neither depends on
+  Google.
+
+## Consequences
+
+- **ADR-0011 is partially superseded**: its Google-Sign-In decision no longer holds; its other two
+  decisions do. ADR-0011's frontmatter carries a pointer here.
+- **ADR-0012 (Spring Security)** listed "the forthcoming Google Sign-In work introduces a second auth
+  method" among its three justifications. Spring Security adoption **stands** on its other grounds
+  (session-fixation rotation, CSRF, a unified `SecurityFilterChain`); the Google justification is void.
+  The unified filter chain is where a future passkey provider would slot in — the same seam Google would
+  have used.
+- We remain single-method. If passkeys land, they become the second front door under a new ADR, and the
+  "one identity, many proofs of email control" shape ADR-0011 established is the pattern they follow.


### PR DESCRIPTION
Google Sign-In (decided in ADR-0011) is **not carried into the clean-slate rewrite and is dropped for good**. Faster repeat login is being explored via **passkeys**, not Google. Surfaced during the post-merge act-as review as domain drift — `CONTEXT.md` and the ADRs still described Google as a live method.

Docs only; **no Google code existed in the rewrite to remove** (no `GoogleIdentityVerifier`, no `/api/auth/google/verify`, no client-id config).

## The nuance this handles

ADR-0011 bundled **three** decisions — only one is reversed:

| Decision from ADR-0011 | Status now |
|---|---|
| Add Google Sign-In (second passwordless method) | **Reversed** (this PR / ADR-0027) |
| Cut username/password | **Stands** |
| `Email` value object + `trim().lowercase()` normalization | **Stands** (still in use, independent of Google) |

So ADR-0011 is **partially superseded**, not blanket-reversed.

## Changes

- **New `docs/adr/0027-drop-google-signin-magic-link-only.md`** — supersedes *only* the Google decision of ADR-0011; preserves its other two; names passkeys as the direction now under investigation; records the knock-on to ADR-0012.
- **ADR-0011** — frontmatter now flags the Google decision as superseded by ADR-0027, noting the other two decisions still stand.
- **ADR-0012 (Spring Security)** — listed the "forthcoming Google Sign-In work" as one of three justifications; added a note that it's void, the decision standing on session-fixation + CSRF, with the unified filter chain as the future passkey seam.
- **`CONTEXT.md`** — Magic Link is now the *sole* authentication method; the Google Sign-In glossary term is removed.

## Relationship to #257

Separate concern from the act-as review PR (#257); no overlapping files. This one is the Google-drift cleanup that review turned up.

## Testing

Docs only — nothing to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh16eDT6kqXWGQgQuqhVKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh16eDT6kqXWGQgQuqhVKQ)_