### PR TITLE
test(app): add open-dialog baselines for RevokeConfirm / DeleteConfirm

### DIFF
--- a/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.stories.tsx
+++ b/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.stories.tsx
@@ -81,7 +81,8 @@ export const GenerateCode: Story = {
 
 export const RevokeConfirm: Story = {
   // Behavioural twin of WithItems — the confirm dialog closes on confirm and settles back to the
-  // items picture; the open-dialog frame is an untracked gap (#263, ADR-0027 §2).
+  // items picture; the open-dialog frame keeps its own baseline via RevokeConfirmOpen below
+  // (#263, ADR-0027 §2).
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     // Open the confirm dialog from the first (active) code's Revoke button.
@@ -91,6 +92,18 @@ export const RevokeConfirm: Story = {
     // While the modal is open the list buttons are aria-hidden, so only the dialog's Revoke resolves.
     await userEvent.click(dialog.getByRole('button', { name: 'Revoke' }))
     await expect(args.onRevoke).toHaveBeenCalledWith(CODES[0])
+  },
+}
+
+// Open-dialog baseline: the first (active) code's Revoke opens the confirm dialog (a portal); we
+// stop with it open — no confirm click — so the open dialog frame gets its own keep-baseline
+// snapshot. The RevokeConfirm spy above closes on confirm, so it never pictures the open dialog.
+export const RevokeConfirmOpen: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Revoke' })[0])
+    const dialog = within(document.body)
+    await expect(await dialog.findByText(/can no longer be used to create a team/)).toBeInTheDocument()
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   },
 }
 

--- a/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
@@ -89,7 +89,8 @@ export const RenamePosition: Story = {
 
 export const DeleteConfirm: Story = {
   // Behavioural twin of WithItems — the confirm dialog closes on confirm and settles back to the
-  // items picture; the open-dialog frame is an untracked gap (#263, ADR-0027 §2).
+  // items picture; the open-dialog frame keeps its own baseline via DeleteConfirmOpen below
+  // (#263, ADR-0027 §2).
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
@@ -99,6 +100,20 @@ export const DeleteConfirm: Story = {
     ).toBeInTheDocument()
     await userEvent.click(dialog.getByRole('button', { name: 'Delete' }))
     await expect(args.onDelete).toHaveBeenCalledWith(POSITIONS[0])
+  },
+}
+
+// Open-dialog baseline: the first row's Delete opens the confirm dialog (a portal); we stop with it
+// open — no confirm click — so the open dialog frame gets its own keep-baseline snapshot. The
+// DeleteConfirm spy above closes on confirm, so it never pictures the open dialog.
+export const DeleteConfirmOpen: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
+    const dialog = within(document.body)
+    await expect(
+      await dialog.findByText(/Members with this position will become Unassigned/),
+    ).toBeInTheDocument()
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   },
 }
 


### PR DESCRIPTION
Closes #263.

## The gap

`ManageCreationCodesView.RevokeConfirm` and `ManagePositionsView.DeleteConfirm` are spy stories that click **confirm**, which closes the dialog via `setConfirmTarget(null)` before Chromatic captures the final frame. So each snapshot settles back to the `WithItems` data state and the open confirm dialog is never pixel-guarded — a coverage gap surfaced by the ADR-0027 snapshot audit (#259).

`MemberRosterView` does this right with a separate `RemoveConfirmOpen` story that opens the dialog and leaves it open. Codes and positions had no equivalent.

## Change

Add an open-dialog `keep-baseline` story to each, mirroring the exemplar `features/manage-members/MemberRosterView.stories.tsx → RemoveConfirmOpen`: open the confirm dialog in `play` and stop — no confirm click — so the open dialog frame gets its own baseline.

- `features/manage-creation-codes/ManageCreationCodesView` — add `RevokeConfirmOpen`
- `features/manage-positions/ManagePositionsView` — add `DeleteConfirmOpen`

The existing `RevokeConfirm` / `DeleteConfirm` spy stories are left otherwise untouched — they still prove the confirm→callback wiring and keep the `disableSnapshot` marker #266 added. Same CSF3 / `storybook/test` style and shared `meta.args` baseline as the siblings.

## Rebased on #266

Rebased onto latest `main`, which now carries #266 (the ADR-0027 / #259 rollout). #266 marked these two spy stories `disableSnapshot` with a comment calling the open-dialog frame an "untracked gap (#263)". Since this PR now *closes* that gap, the diff also updates those two comments to point at the new `RevokeConfirmOpen` / `DeleteConfirmOpen` baselines instead — keeping the snapshot-intent comments true, per ADR-0027 §4.

## Snapshot impact

Net **+2** baselines (on top of the #266 baseline): one open confirm dialog per feature, nothing removed.

## Verification

- Two changed story files run headless (18 stories) and pass; `make test-app` full suite was green pre-rebase (93 files / 607 tests).
- `eslint` — clean. Only `.stories.tsx` files changed, so detekt (Kotlin) is unaffected.

No new e2e: no new seam is introduced — this only adds Storybook baselines, consistent with the CLAUDE.md PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)