### PR TITLE
feat(app): logout reachable from every state — clearSession() + team-independent /account (Slice 0 + 1)

### DIFF
--- a/app/e2e-real/auth-guard.spec.ts
+++ b/app/e2e-real/auth-guard.spec.ts
@@ -29,10 +29,11 @@ test.describe('logout', () => {
     await page.goto('/')
     await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible()
 
-    // The header no longer carries nav — the tab bar is the primary nav and Log out lives on the
-    // Profile page, whose URL is team-scoped (ADR-0023 §2).
+    // Log out lives on the team-independent Account tab now (ADR-0027 §1): the BottomNav Profile
+    // tab points at the constant /account regardless of team slug, so logout is reachable from
+    // every signed-in state — not only a fully-onboarded /t/:slug screen.
     await page.getByRole('link', { name: 'Profile' }).click()
-    await expect(page).toHaveURL(/\/t\/[^/]+\/profile\/?$/)
+    await expect(page).toHaveURL('/account')
     await page.getByRole('button', { name: 'Log out' }).click()
     await expect(page).toHaveURL('/login')
     await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()

--- a/app/src/features/account/lib/account-sections.test.ts
+++ b/app/src/features/account/lib/account-sections.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { AuthenticatedUser } from '@shared/api/auth'
+import { accountSections } from './account-sections'
+
+const TEAM = { id: 't1', name: 'Setpoint VT', slug: 'setpoint-vt' }
+const OTHER_TEAM = { id: 't2', name: 'Tovo Heren', slug: 'tovo-heren' }
+
+function user(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+  return {
+    id: 'u1',
+    email: 'alex@example.com',
+    displayName: 'Alex',
+    role: undefined,
+    teams: [],
+    activeTeam: undefined,
+    isPlatformAdmin: false,
+    actAs: undefined,
+    ...overrides,
+  }
+}
+
+describe('accountSections', () => {
+  // The invariant the whole ADR turns on: Log out is present no matter the context.
+  it.each([
+    ['teamless', user()],
+    ['single team', user({ teams: [TEAM], activeTeam: TEAM, role: 'MEMBER' })],
+    ['multi team, one active', user({ teams: [TEAM, OTHER_TEAM], activeTeam: TEAM, role: 'MEMBER' })],
+    ['multi team, none active', user({ teams: [TEAM, OTHER_TEAM] })],
+    ['platform admin', user({ isPlatformAdmin: true })],
+    ['act-as', user({ isPlatformAdmin: true, activeTeam: TEAM, role: 'ADMIN', actAs: { team: TEAM, expiresAt: 'x' } })],
+  ])('always includes log out (%s)', (_label, u) => {
+    expect(accountSections(u)).toContain('logout')
+  })
+
+  it('teamless: email, appearance, teams, log out — no name/position, no admin', () => {
+    expect(accountSections(user())).toEqual(['email', 'appearance', 'teams', 'logout'])
+  })
+
+  it('single team: adds display name + position', () => {
+    const sections = accountSections(user({ teams: [TEAM], activeTeam: TEAM, role: 'MEMBER' }))
+    expect(sections).toEqual(['email', 'displayName', 'position', 'appearance', 'teams', 'logout'])
+  })
+
+  it('multi team with one active is the same as single team (the switcher lives in Teams)', () => {
+    const sections = accountSections(user({ teams: [TEAM, OTHER_TEAM], activeTeam: TEAM, role: 'MEMBER' }))
+    expect(sections).toEqual(['email', 'displayName', 'position', 'appearance', 'teams', 'logout'])
+  })
+
+  it('multi team with none active hides name/position (no Active Team yet)', () => {
+    const sections = accountSections(user({ teams: [TEAM, OTHER_TEAM] }))
+    expect(sections).toEqual(['email', 'appearance', 'teams', 'logout'])
+  })
+
+  it('platform admin adds the platform-admin section', () => {
+    expect(accountSections(user({ isPlatformAdmin: true }))).toContain('platformAdmin')
+  })
+
+  // Act-as: an Active Team without a membership (teams empty). Name + position still show — they
+  // read the session tenant — and admin shows too. (ADR-0024 / ADR-0027 consequences.)
+  it('act-as: shows name/position (via the session tenant) and platform admin', () => {
+    const sections = accountSections(
+      user({ isPlatformAdmin: true, activeTeam: TEAM, role: 'ADMIN', actAs: { team: TEAM, expiresAt: 'x' } }),
+    )
+    expect(sections).toEqual([
+      'email',
+      'displayName',
+      'position',
+      'appearance',
+      'teams',
+      'platformAdmin',
+      'logout',
+    ])
+  })
+})

--- a/app/src/features/account/lib/account-sections.ts
+++ b/app/src/features/account/lib/account-sections.ts
@@ -1,0 +1,52 @@
+import type { AuthenticatedUser } from '@shared/api/auth'
+
+/**
+ * The rows the Account tab can show. What actually renders is a pure function of the authenticated
+ * user (ADR-0027 §2) — never of the URL, so it is identical on every in-shell screen.
+ */
+export type AccountSection =
+  | 'email'
+  | 'displayName'
+  | 'position'
+  | 'appearance'
+  | 'teams'
+  | 'platformAdmin'
+  | 'logout'
+
+// Canonical display order; the selector returns the present sections in this order.
+const ORDER: AccountSection[] = [
+  'email',
+  'displayName',
+  'position',
+  'appearance',
+  'teams',
+  'platformAdmin',
+  'logout',
+]
+
+/** The fields of the session this selector reads — a narrow view of {@link AuthenticatedUser}. */
+type AccountUser = Pick<
+  AuthenticatedUser,
+  'email' | 'activeTeam' | 'teams' | 'isPlatformAdmin' | 'actAs'
+>
+
+/**
+ * Which Account sections are visible for this session.
+ *
+ * - **Email / Appearance / Teams / Log out** — always. Log out is the whole point: it must be
+ *   reachable from every signed-in state.
+ * - **Display name / Position** — only with an Active Team, because member data is tenant-scoped
+ *   (ADR-0026). An Active Team can come from a membership *or* from act-as (ADR-0024): a Platform
+ *   Admin acting-as has `activeTeam` set with `teams` empty, and still gets the tenant's name +
+ *   position — so the gate is `activeTeam`, not "has a membership".
+ * - **Platform admin** — only for a Platform Admin.
+ */
+export function accountSections(user: AccountUser): AccountSection[] {
+  const present = new Set<AccountSection>(['email', 'appearance', 'teams', 'logout'])
+  if (user.activeTeam) {
+    present.add('displayName')
+    present.add('position')
+  }
+  if (user.isPlatformAdmin) present.add('platformAdmin')
+  return ORDER.filter((section) => present.has(section))
+}

--- a/app/src/features/account/ui/AccountView.stories.tsx
+++ b/app/src/features/account/ui/AccountView.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import type { Member } from '@shared/api/members'
+import type { Position } from '@shared/api/positions'
+import type { AccountSection } from '../lib/account-sections'
+import { AccountView } from './AccountView'
+
+// AccountView is the adaptive Account settings list behind the /account container (ADR-0027 §2).
+// It is prop-only and network-free, so every context — teamless / single / multi / admin — and both
+// profile shells (loading / error) render purely from props as a story. It renders TanStack Router
+// <Link>s (the platform-admin section), so it takes the shared withRouter decorator.
+//
+// The invariant under test in EVERY story: **Log out renders**. It is not gated on any section flag
+// and sits outside the profile loading/error shells, so a failed member fetch can never hide it —
+// which is the whole reason the ADR exists. LoggingOut additionally proves the click reaches
+// onLogout (a fn() spy), so the wiring survives a dependency bump.
+const POSITIONS: Position[] = [
+  { id: 'p1', label: 'Setter' },
+  { id: 'p2', label: 'Libero' },
+]
+
+const MEMBER: Member = {
+  userId: 'u1',
+  displayName: 'Alex',
+  role: 'MEMBER',
+  position: { id: 'p1', label: 'Setter' },
+  onboarded: true,
+}
+
+const WITH_TEAM: AccountSection[] = ['email', 'displayName', 'position', 'appearance', 'teams', 'logout']
+const TEAMLESS: AccountSection[] = ['email', 'appearance', 'teams', 'logout']
+
+const meta = {
+  title: 'features/account/AccountView',
+  component: AccountView,
+  decorators: [withRouter],
+  args: { email: 'alex@example.com', onLogout: fn(), onSubmitProfile: fn() },
+} satisfies Meta<typeof AccountView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Teamless: Story = {
+  args: { sections: TEAMLESS },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    // No profile form and no team named when teamless.
+    await expect(canvas.queryByLabelText('Display name')).not.toBeInTheDocument()
+    await expect(canvas.getByText('Join or create a team')).toBeInTheDocument()
+  },
+}
+
+export const SingleTeam: Story = {
+  args: { sections: WITH_TEAM, member: MEMBER, positions: POSITIONS, activeTeamName: 'Setpoint VT' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Display name')).toHaveValue('Alex')
+    await expect(canvas.getByText('Setpoint VT')).toBeInTheDocument()
+  },
+}
+
+// Multi-team with one active shows the same sections — the switcher is Slice 2, so the only visible
+// difference is that Teams names the active one. Log out still renders.
+export const MultiTeam: Story = {
+  args: { sections: WITH_TEAM, member: MEMBER, positions: POSITIONS, activeTeamName: 'Tovo Heren' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    await expect(canvas.getByText('Tovo Heren')).toBeInTheDocument()
+  },
+}
+
+export const Admin: Story = {
+  args: { sections: ['email', 'appearance', 'teams', 'platformAdmin', 'logout'] },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Teams' })).toHaveAttribute('href', '/admin/teams')
+    await expect(canvas.getByRole('link', { name: 'Creation codes' })).toHaveAttribute(
+      'href',
+      '/admin/creation-codes',
+    )
+  },
+}
+
+// The member-profile query is in flight: the profile section shows its loading shell, but Log out
+// (which acts on the session, not the profile) still renders.
+export const Loading: Story = {
+  args: { sections: WITH_TEAM, isMemberLoading: true, activeTeamName: 'Setpoint VT' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    await expect(canvas.getByText('Loading…')).toBeInTheDocument()
+    await expect(canvas.queryByLabelText('Display name')).not.toBeInTheDocument()
+  },
+}
+
+// The member-profile query failed: the profile section shows its error shell — Log out is still
+// reachable, so a broken member fetch never strands the user.
+export const ErrorState: Story = {
+  args: { sections: WITH_TEAM, isMemberError: true, activeTeamName: 'Setpoint VT' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    await expect(canvas.getByText("Couldn't load your profile. Please try again.")).toBeInTheDocument()
+    await expect(canvas.queryByLabelText('Display name')).not.toBeInTheDocument()
+  },
+}
+
+export const LoggingOut: Story = {
+  args: { sections: TEAMLESS },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Log out' }))
+    await expect(args.onLogout).toHaveBeenCalled()
+  },
+}

--- a/app/src/features/account/ui/AccountView.stories.tsx
+++ b/app/src/features/account/ui/AccountView.stories.tsx
@@ -75,7 +75,7 @@ export const Admin: Story = {
   args: { sections: ['email', 'appearance', 'teams', 'platformAdmin', 'logout'] },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
-    await expect(canvas.getByRole('link', { name: 'Teams' })).toHaveAttribute('href', '/admin/teams')
+    await expect(canvas.getByRole('link', { name: 'Teams console' })).toHaveAttribute('href', '/admin/teams')
     await expect(canvas.getByRole('link', { name: 'Creation codes' })).toHaveAttribute(
       'href',
       '/admin/creation-codes',

--- a/app/src/features/account/ui/AccountView.tsx
+++ b/app/src/features/account/ui/AccountView.tsx
@@ -1,0 +1,125 @@
+import { Link } from '@tanstack/react-router'
+import type { Member } from '@shared/api/members'
+import type { Position } from '@shared/api/positions'
+import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
+import { ThemeToggle } from '@features/theme-toggle/ui/ThemeToggle'
+import type { AccountSection } from '../lib/account-sections'
+
+interface AccountViewProps {
+  /** The visible sections for this session, from {@link accountSections}. Drives which rows render. */
+  sections: AccountSection[]
+  email: string
+  /** The Active Team's name, or null when there is none (teamless). */
+  activeTeamName?: string | null
+  /** The current member — only present (and only fetched) when there is an Active Team. */
+  member?: Member | null
+  /** The Active Team's position vocabulary; empty hides the position picker. */
+  positions?: Position[]
+  /** The member-profile query is in flight. Shows the profile shell — Log out stays rendered. */
+  isMemberLoading?: boolean
+  /** The member-profile query failed. Shows the error shell — Log out stays rendered. */
+  isMemberError?: boolean
+  isSaving?: boolean
+  /** Backend error discriminator from the update mutation (e.g. NAME_TAKEN), shown inline. */
+  memberErrorCode?: string
+  onSubmitProfile?: (name: string, positionId: string | null) => void
+  onLogout: () => void
+}
+
+/**
+ * The adaptive Account settings list (ADR-0027 §2) — prop-only and presentational. The container
+ * reads the session and the member profile; this renders the sections it is handed.
+ *
+ * **Log out is rendered unconditionally**, outside every other section including the profile
+ * loading/error shells: it acts on the session, not on any data that might still be loading, so a
+ * failed member fetch can never hide it. That invariant is the whole point of the ADR, and every
+ * story asserts it.
+ */
+export function AccountView({
+  sections,
+  email,
+  activeTeamName,
+  member,
+  positions = [],
+  isMemberLoading,
+  isMemberError,
+  isSaving,
+  memberErrorCode,
+  onSubmitProfile,
+  onLogout,
+}: AccountViewProps) {
+  const has = (section: AccountSection) => sections.includes(section)
+
+  return (
+    <div>
+      <h2 className="font-display text-2xl font-bold">Account</h2>
+
+      {has('email') && (
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold text-muted-foreground">Email</h3>
+          <p className="mt-1 text-sm">{email}</p>
+        </div>
+      )}
+
+      {/* Display name + position are one form (EditProfileForm covers both rows). Present only with
+          an Active Team; its loading/error shells are props-driven so they render with no network. */}
+      {has('displayName') && (
+        <div className="mt-8">
+          {isMemberLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {isMemberError && (
+            <p className="text-sm text-red">Couldn't load your profile. Please try again.</p>
+          )}
+          {!isMemberLoading && !isMemberError && member && (
+            <EditProfileForm
+              currentName={member.displayName}
+              positions={positions}
+              currentPositionId={member.position?.id ?? null}
+              isSaving={!!isSaving}
+              errorCode={memberErrorCode}
+              onSubmit={(name, positionId) => onSubmitProfile?.(name, positionId)}
+            />
+          )}
+        </div>
+      )}
+
+      {has('appearance') && (
+        <div className="mt-10 border-t border-border/40 pt-6">
+          <ThemeToggle />
+        </div>
+      )}
+
+      {/* A single entry naming the Active Team (Slice 2 opens it into the Teams view). Rendered as a
+          static row for now — no dead link — keeping Slice 1 focused on logout reachability. */}
+      {has('teams') && (
+        <div className="mt-10 border-t border-border/40 pt-6">
+          <h3 className="text-sm font-semibold text-muted-foreground">Teams</h3>
+          <p className="mt-1 text-sm">{activeTeamName ?? 'Join or create a team'}</p>
+        </div>
+      )}
+
+      {has('platformAdmin') && (
+        <div className="mt-10 border-t border-border/40 pt-6">
+          <h3 className="text-sm font-semibold text-muted-foreground">Platform admin</h3>
+          <div className="mt-2 flex flex-col gap-2">
+            <Link to="/admin/teams" className="text-sm font-semibold text-blue hover:underline">
+              Teams
+            </Link>
+            <Link to="/admin/creation-codes" className="text-sm font-semibold text-blue hover:underline">
+              Creation codes
+            </Link>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-10 border-t border-border/40 pt-6">
+        <button
+          type="button"
+          onClick={onLogout}
+          className="text-sm font-semibold text-muted-foreground hover:text-foreground"
+        >
+          Log out
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/src/features/account/ui/AccountView.tsx
+++ b/app/src/features/account/ui/AccountView.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
+import { ChevronRight, KeyRound, LogOut, Mail, ShieldCheck, Users } from 'lucide-react'
 import type { Member } from '@shared/api/members'
 import type { Position } from '@shared/api/positions'
 import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
@@ -26,14 +28,30 @@ interface AccountViewProps {
   onLogout: () => void
 }
 
+// A settings card: rows share the same warm surface, hairline dividers and soft lift as the
+// appearance control, so the whole tab reads as one grouped list (ADR-0027 §2, concept prototype).
+const CARD = 'overflow-hidden rounded-xl border border-border bg-card shadow-[var(--shadow-card)]'
+const ROW = 'flex items-center gap-3 px-4 py-3 text-sm'
+// Links / buttons get a hover wash and an inset focus ring so keyboard focus stays visible on a row.
+const ROW_INTERACTIVE =
+  `${ROW} w-full text-left transition-colors hover:bg-muted/60 ` +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50'
+const ICON = 'shrink-0 text-muted-foreground'
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return <h3 className="mb-2 px-1 text-sm font-semibold text-muted-foreground">{children}</h3>
+}
+
 /**
  * The adaptive Account settings list (ADR-0027 §2) — prop-only and presentational. The container
- * reads the session and the member profile; this renders the sections it is handed.
+ * reads the session and the member profile; this renders the sections it is handed as a grouped
+ * settings list of cards, following the concept prototype: iconed rows, right-aligned muted values,
+ * an Active badge on the team, and Log out as its own red row.
  *
- * **Log out is rendered unconditionally**, outside every other section including the profile
- * loading/error shells: it acts on the session, not on any data that might still be loading, so a
- * failed member fetch can never hide it. That invariant is the whole point of the ADR, and every
- * story asserts it.
+ * **Log out is rendered unconditionally**, in its own trailing card outside every other section —
+ * including the profile loading/error shells — because it acts on the session, not on any data that
+ * might still be loading. A failed member fetch can never hide it. That invariant is the whole point
+ * of the ADR, and every story asserts it.
  */
 export function AccountView({
   sections,
@@ -54,71 +72,107 @@ export function AccountView({
     <div>
       <h2 className="font-display text-2xl font-bold">Account</h2>
 
-      {has('email') && (
-        <div className="mt-4">
-          <h3 className="text-sm font-semibold text-muted-foreground">Email</h3>
-          <p className="mt-1 text-sm">{email}</p>
-        </div>
-      )}
+      <div className="mt-6 space-y-6">
+        {has('email') && (
+          <section>
+            <SectionLabel>Account</SectionLabel>
+            <div className={CARD}>
+              <div className={ROW}>
+                <Mail size={18} strokeWidth={1.9} className={ICON} aria-hidden="true" />
+                <span className="font-medium">Email</span>
+                <span className="ml-auto min-w-0 truncate text-muted-foreground" title={email}>
+                  {email}
+                </span>
+              </div>
+            </div>
+          </section>
+        )}
 
-      {/* Display name + position are one form (EditProfileForm covers both rows). Present only with
-          an Active Team; its loading/error shells are props-driven so they render with no network. */}
-      {has('displayName') && (
-        <div className="mt-8">
-          {isMemberLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
-          {isMemberError && (
-            <p className="text-sm text-red">Couldn't load your profile. Please try again.</p>
-          )}
-          {!isMemberLoading && !isMemberError && member && (
-            <EditProfileForm
-              currentName={member.displayName}
-              positions={positions}
-              currentPositionId={member.position?.id ?? null}
-              isSaving={!!isSaving}
-              errorCode={memberErrorCode}
-              onSubmit={(name, positionId) => onSubmitProfile?.(name, positionId)}
-            />
-          )}
-        </div>
-      )}
+        {/* Display name + position are one form (EditProfileForm covers both rows). Present only with
+            an Active Team; its loading/error shells are props-driven so they render with no network. */}
+        {has('displayName') && (
+          <section>
+            <SectionLabel>Profile</SectionLabel>
+            <div className={`${CARD} p-4`}>
+              {isMemberLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+              {isMemberError && (
+                <p className="text-sm text-red">Couldn't load your profile. Please try again.</p>
+              )}
+              {!isMemberLoading && !isMemberError && member && (
+                <EditProfileForm
+                  currentName={member.displayName}
+                  positions={positions}
+                  currentPositionId={member.position?.id ?? null}
+                  isSaving={!!isSaving}
+                  errorCode={memberErrorCode}
+                  onSubmit={(name, positionId) => onSubmitProfile?.(name, positionId)}
+                />
+              )}
+            </div>
+          </section>
+        )}
 
-      {has('appearance') && (
-        <div className="mt-10 border-t border-border/40 pt-6">
-          <ThemeToggle />
-        </div>
-      )}
+        {/* A single entry naming the Active Team (Slice 2 opens it into the Teams view). Rendered as a
+            static row for now — no dead link — keeping Slice 1 focused on logout reachability. */}
+        {has('teams') && (
+          <section>
+            <SectionLabel>Teams</SectionLabel>
+            <div className={CARD}>
+              <div className={ROW}>
+                <Users size={18} strokeWidth={1.9} className={ICON} aria-hidden="true" />
+                {activeTeamName ? (
+                  <>
+                    <span className="min-w-0 truncate font-medium">{activeTeamName}</span>
+                    <span className="ml-auto rounded-full bg-green/10 px-2 py-0.5 text-xs font-semibold text-green">
+                      Active
+                    </span>
+                  </>
+                ) : (
+                  <span className="font-medium text-muted-foreground">Join or create a team</span>
+                )}
+              </div>
+            </div>
+          </section>
+        )}
 
-      {/* A single entry naming the Active Team (Slice 2 opens it into the Teams view). Rendered as a
-          static row for now — no dead link — keeping Slice 1 focused on logout reachability. */}
-      {has('teams') && (
-        <div className="mt-10 border-t border-border/40 pt-6">
-          <h3 className="text-sm font-semibold text-muted-foreground">Teams</h3>
-          <p className="mt-1 text-sm">{activeTeamName ?? 'Join or create a team'}</p>
-        </div>
-      )}
+        {has('appearance') && (
+          <section>
+            {/* ThemeToggle carries its own "Appearance" heading + description and a bordered control,
+                so it needs no extra card or label — it already matches the settings-card treatment. */}
+            <ThemeToggle />
+          </section>
+        )}
 
-      {has('platformAdmin') && (
-        <div className="mt-10 border-t border-border/40 pt-6">
-          <h3 className="text-sm font-semibold text-muted-foreground">Platform admin</h3>
-          <div className="mt-2 flex flex-col gap-2">
-            <Link to="/admin/teams" className="text-sm font-semibold text-blue hover:underline">
-              Teams
-            </Link>
-            <Link to="/admin/creation-codes" className="text-sm font-semibold text-blue hover:underline">
-              Creation codes
-            </Link>
-          </div>
-        </div>
-      )}
+        {has('platformAdmin') && (
+          <section>
+            <SectionLabel>Platform admin</SectionLabel>
+            <div className={CARD}>
+              <div className="divide-y divide-border">
+                <Link to="/admin/teams" className={ROW_INTERACTIVE}>
+                  <ShieldCheck size={18} strokeWidth={1.9} className={ICON} aria-hidden="true" />
+                  <span className="font-medium">Teams console</span>
+                  <ChevronRight size={16} className="ml-auto shrink-0 text-muted-foreground/60" aria-hidden="true" />
+                </Link>
+                <Link to="/admin/creation-codes" className={ROW_INTERACTIVE}>
+                  <KeyRound size={18} strokeWidth={1.9} className={ICON} aria-hidden="true" />
+                  <span className="font-medium">Creation codes</span>
+                  <ChevronRight size={16} className="ml-auto shrink-0 text-muted-foreground/60" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+          </section>
+        )}
 
-      <div className="mt-10 border-t border-border/40 pt-6">
-        <button
-          type="button"
-          onClick={onLogout}
-          className="text-sm font-semibold text-muted-foreground hover:text-foreground"
-        >
-          Log out
-        </button>
+        <div className={CARD}>
+          <button
+            type="button"
+            onClick={onLogout}
+            className={`${ROW_INTERACTIVE} font-semibold text-red hover:bg-red/5`}
+          >
+            <LogOut size={18} strokeWidth={1.9} className="shrink-0 text-red" aria-hidden="true" />
+            Log out
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AccountRouteImport } from './routes/account'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as SelectTeamRouteImport } from './routes/select-team'
 import { Route as AdminCreationCodesRouteImport } from './routes/admin/creation-codes'
@@ -31,6 +32,11 @@ import { Route as TSlugTeamSettingsRouteImport } from './routes/t/$slug/team/set
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AccountRoute = AccountRouteImport.update({
+  id: '/account',
+  path: '/account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -121,6 +127,7 @@ const TSlugTeamSettingsRoute = TSlugTeamSettingsRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/select-team': typeof SelectTeamRoute
   '/t/$slug': typeof TSlugRouteRouteWithChildren
@@ -141,6 +148,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/select-team': typeof SelectTeamRoute
   '/admin/creation-codes': typeof AdminCreationCodesRoute
@@ -161,6 +169,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/select-team': typeof SelectTeamRoute
   '/t/$slug': typeof TSlugRouteRouteWithChildren
@@ -183,6 +192,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/account'
     | '/login'
     | '/select-team'
     | '/t/$slug'
@@ -203,6 +213,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/account'
     | '/login'
     | '/select-team'
     | '/admin/creation-codes'
@@ -222,6 +233,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/account'
     | '/login'
     | '/select-team'
     | '/t/$slug'
@@ -243,6 +255,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AccountRoute: typeof AccountRoute
   LoginRoute: typeof LoginRoute
   SelectTeamRoute: typeof SelectTeamRoute
   TSlugRouteRoute: typeof TSlugRouteRouteWithChildren
@@ -262,6 +275,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -412,6 +432,7 @@ const TSlugRouteRouteWithChildren = TSlugRouteRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AccountRoute: AccountRoute,
   LoginRoute: LoginRoute,
   SelectTeamRoute: SelectTeamRoute,
   TSlugRouteRoute: TSlugRouteRouteWithChildren,

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -28,7 +28,10 @@ function isTeamlessRoute(pathname: string): boolean {
     path === '/create-team' ||
     path === '/select-team' ||
     path === '/admin/creation-codes' ||
-    path === '/admin/teams'
+    path === '/admin/teams' ||
+    // The team-independent Account tab (ADR-0027 §1): a teamless caller reaches it instead of being
+    // parked on /onboarding, so Log out is reachable with no team.
+    path === '/account'
   )
 }
 

--- a/app/src/routes/account.tsx
+++ b/app/src/routes/account.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useAuthMe, useLogout } from '@shared/api/auth'
+import { clearSession } from '@shared/api/clear-session'
+import { MemberUpdateError, useCurrentMember, useUpdateMember } from '@shared/api/members'
+import { usePositions } from '@shared/api/positions'
+import { accountSections } from '@features/account/lib/account-sections'
+import { AccountView } from '@features/account/ui/AccountView'
+
+/**
+ * The team-independent Account tab (ADR-0027 §1). Because it is not under `/t/$slug`, it resolves on
+ * every in-shell screen regardless of slug — closing both the teamless and get-started logout gaps —
+ * and the root gate allow-lists it (`isTeamlessRoute`) so a teamless caller reaches it here rather
+ * than being bounced to onboarding.
+ */
+export const Route = createFileRoute('/account')({
+  component: AccountPage,
+})
+
+/**
+ * Thin container: reads the session, fetches the current member **only when an Active Team exists**,
+ * and wires ThemeToggle (inside AccountView), the member-update mutation, and logout. Pure wiring —
+ * the load/error/data shells live in the props-driven AccountView, so this seam is covered by e2e
+ * (Slice 4), not a story.
+ *
+ * Two guards, together, keep a teamless `/account` from tripping the forced-logout bounce: the
+ * member fetch is `enabled: !!activeTeam`, and `/account` is in `TENANT_RESOLVING_PATHS` so a stray
+ * 403 is read as "no tenant here yet", not "log out" (ADR-0027 consequences).
+ */
+function AccountPage() {
+  const { data: user } = useAuthMe()
+  const activeTeam = user?.activeTeam ?? null
+
+  const { data: member, isLoading: memberLoading, error: memberError } = useCurrentMember({
+    enabled: !!activeTeam,
+  })
+  const { data: positions } = usePositions({ enabled: !!activeTeam })
+  const updateMember = useUpdateMember()
+  const logout = useLogout()
+
+  const memberErrorCode =
+    updateMember.error instanceof MemberUpdateError ? updateMember.error.code : undefined
+
+  // The root gate confirms the session before this route renders, so `user` is present; guard
+  // defensively for the sliver of time before the cached /me resolves back.
+  if (!user) return null
+
+  return (
+    <AccountView
+      sections={accountSections(user)}
+      email={user.email}
+      activeTeamName={activeTeam?.name ?? null}
+      member={member ?? null}
+      positions={positions ?? []}
+      isMemberLoading={!!activeTeam && memberLoading}
+      isMemberError={!!memberError}
+      isSaving={updateMember.isPending}
+      memberErrorCode={memberErrorCode}
+      onSubmitProfile={(name, positionId) => {
+        if (!member) return
+        updateMember.mutate({ userId: member.userId, displayName: name, role: member.role, positionId })
+      }}
+      // In-shell logout: a clean server-side teardown first, then the shared client clear.
+      onLogout={() => logout.mutate(undefined, { onSuccess: () => clearSession() })}
+    />
+  )
+}

--- a/app/src/routes/t/$slug/profile/index.tsx
+++ b/app/src/routes/t/$slug/profile/index.tsx
@@ -1,108 +1,13 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { useQueryClient } from '@tanstack/react-query'
-import { useCurrentMember, useUpdateMember, MemberUpdateError } from '@shared/api/members'
-import { usePositions } from '@shared/api/positions'
-import { useLogout } from '@shared/api/auth'
-import { useUserStore } from '@shared/stores/user-store'
-import { EditProfileForm } from '@features/edit-profile/ui/EditProfileForm'
-import { ThemeToggle } from '@features/theme-toggle/ui/ThemeToggle'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
+/**
+ * The merged Account surface moved off this team-scoped path to the team-independent `/account`
+ * (ADR-0027 §1). This stays as a thin redirect so existing links and bookmarks keep working, with
+ * `/account` as the single source of truth. The old `LogoutButton` logic now lives in `AccountView`.
+ */
 export const Route = createFileRoute('/t/$slug/profile/')({
-  component: ProfilePage,
+  beforeLoad: () => {
+    throw redirect({ to: '/account' })
+  },
+  component: () => null,
 })
-
-/**
- * Log out lives on the Profile page now that the header carries no nav (the tab bar is the primary
- * nav). Same logic as before: clear the session, drop the cached /me, and route to /login.
- */
-function LogoutButton() {
-  const userId = useUserStore((s) => s.userId)
-  const setCurrentUser = useUserStore((s) => s.setCurrentUser)
-  const logout = useLogout()
-  const queryClient = useQueryClient()
-  const navigate = useNavigate()
-
-  if (!userId) return null
-
-  const handleLogout = () => {
-    logout.mutate(undefined, {
-      onSuccess: () => {
-        setCurrentUser(null)
-        queryClient.setQueryData(['auth', 'me'], null)
-        navigate({ to: '/login' })
-      },
-    })
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleLogout}
-      className="text-sm font-semibold text-muted-foreground hover:text-foreground"
-    >
-      Log out
-    </button>
-  )
-}
-
-/**
- * Container for the profile screen: wires the current-member query and the update mutation to the
- * presentational EditProfileForm. Handles the loading/error shells; the form itself is network-free.
- */
-function ProfilePage() {
-  const { data: member, isLoading, error } = useCurrentMember()
-  const { data: positions } = usePositions()
-  const updateMember = useUpdateMember()
-  const isPlatformAdmin = useUserStore((s) => s.isPlatformAdmin)
-
-  const errorCode = updateMember.error instanceof MemberUpdateError ? updateMember.error.code : undefined
-
-  return (
-    <div>
-      <h2 className="font-display text-2xl font-bold">Profile</h2>
-
-      {isLoading && <p className="mt-4 text-sm text-muted-foreground">Loading…</p>}
-      {error && <p className="mt-4 text-sm text-red">Couldn't load your profile. Please try again.</p>}
-
-      {member && (
-        <div className="mt-4">
-          <EditProfileForm
-            currentName={member.displayName}
-            positions={positions ?? []}
-            currentPositionId={member.position?.id ?? null}
-            isSaving={updateMember.isPending}
-            errorCode={errorCode}
-            onSubmit={(name, positionId) =>
-              updateMember.mutate({ userId: member.userId, displayName: name, role: member.role, positionId })
-            }
-          />
-        </div>
-      )}
-
-      {/* Appearance is a personal setting, so it sits on Profile rather than /team/settings (which
-          is team-scoped) — same reasoning that put Log out here (F11, #159). Above the admin and
-          log-out sections: it applies to every user, they do not. */}
-      <div className="mt-10 border-t border-border/40 pt-6">
-        <ThemeToggle />
-      </div>
-
-      {isPlatformAdmin && (
-        <div className="mt-10 border-t border-border/40 pt-6">
-          <h3 className="text-sm font-semibold text-muted-foreground">Platform admin</h3>
-          <div className="mt-2 flex flex-col gap-2">
-            <Link to="/admin/teams" className="text-sm font-semibold text-blue hover:underline">
-              Teams
-            </Link>
-            <Link to="/admin/creation-codes" className="text-sm font-semibold text-blue hover:underline">
-              Creation codes
-            </Link>
-          </div>
-        </div>
-      )}
-
-      <div className="mt-10 border-t border-border/40 pt-6">
-        <LogoutButton />
-      </div>
-    </div>
-  )
-}

--- a/app/src/shared/api/auth-redirect.test.ts
+++ b/app/src/shared/api/auth-redirect.test.ts
@@ -27,7 +27,7 @@ describe('shouldRedirectToLogin', () => {
 
   // This 403 no longer means "teamless" alone — a Member of several Teams gets it before one is
   // Active — so picking a Team must not log you out on the way to picking it.
-  it.each(['/select-team', '/select-team/', '/onboarding', '/create-team'])(
+  it.each(['/select-team', '/select-team/', '/onboarding', '/create-team', '/account', '/account/'])(
     'does NOT redirect from %s, which owns the no-Active-Team question itself',
     (currentPath) => {
       expect(shouldRedirectToLogin({ status: 403, code: NO_TEAM_MEMBERSHIP_CODE, currentPath })).toBe(false)

--- a/app/src/shared/api/auth-redirect.ts
+++ b/app/src/shared/api/auth-redirect.ts
@@ -8,7 +8,10 @@ export const NO_TEAM_MEMBERSHIP_CODE = 'NO_TEAM_MEMBERSHIP'
  * "teamless" — a Member of several Teams gets it before choosing — so bouncing these to login would
  * log out a perfectly authenticated person.
  */
-const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team']
+// `/account` is team-independent (ADR-0027): a teamless caller reaches it, and its member-profile
+// fetch would 403 NO_TEAM_MEMBERSHIP — so, like the other no-Active-Team screens, a stray 403 here
+// means "no tenant yet", not "log out". Paired with the container's `enabled: !!activeTeam` guard.
+const TENANT_RESOLVING_PATHS = ['/select-team', '/onboarding', '/create-team', '/account']
 
 /**
  * Whether an API response means we should bounce the user to the login screen. Kept pure (no

--- a/app/src/shared/api/clear-session.test.ts
+++ b/app/src/shared/api/clear-session.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AuthenticatedUser } from './auth'
+import { authMeQueryOptions } from './auth'
+import { clearSession } from './clear-session'
+import { queryClient } from './query-client'
+import { useUserStore } from '@shared/stores/user-store'
+
+const USER: AuthenticatedUser = {
+  id: 'u1',
+  email: 'alex@example.com',
+  displayName: 'Alex',
+  role: undefined,
+  teams: [],
+  activeTeam: undefined,
+  isPlatformAdmin: false,
+  actAs: undefined,
+}
+
+describe('clearSession', () => {
+  const originalLocation = window.location
+  let assign: ReturnType<typeof vi.fn>
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // jsdom's real location.assign is non-configurable and throws "Not implemented", so swap the
+    // whole location object for a stub carrying a spy — restored in afterEach.
+    assign = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign },
+    })
+    // A real fetch would prove a network call slipped in; there is no api client on this path.
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null))
+    // Start from a signed-in state so the clear is observable.
+    useUserStore.getState().setCurrentUser(USER)
+    queryClient.setQueryData(authMeQueryOptions.queryKey, USER)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    vi.restoreAllMocks()
+    queryClient.clear()
+  })
+
+  it('nulls the user store', () => {
+    clearSession()
+    expect(useUserStore.getState().userId).toBeNull()
+  })
+
+  it('nulls the cached /auth/me', () => {
+    clearSession()
+    expect(queryClient.getQueryData(authMeQueryOptions.queryKey)).toBeNull()
+  })
+
+  it('hard-redirects to /login', () => {
+    clearSession()
+    expect(assign).toHaveBeenCalledWith('/login')
+  })
+
+  it('makes no network call', () => {
+    clearSession()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/shared/api/clear-session.ts
+++ b/app/src/shared/api/clear-session.ts
@@ -1,0 +1,21 @@
+import { useUserStore } from '@shared/stores/user-store'
+import { authMeQueryOptions } from './auth'
+import { LOGIN_PATH } from './auth-redirect'
+import { queryClient } from './query-client'
+
+/**
+ * Client-only session teardown (ADR-0027 §3): drop the user store, null the cached `/auth/me`, and
+ * hard-redirect to `/login` — with **no** `api.Logout()` round-trip, so it still works when the
+ * backend is the thing that is down.
+ *
+ * The in-shell logout calls `api.Logout()` first (a clean server-side teardown) and **then** this;
+ * the out-of-shell escape hatch (later slice) calls this alone. Because it touches only the store,
+ * the cache, and the location, it makes zero network calls — the unit test pins that.
+ */
+export function clearSession() {
+  useUserStore.getState().setCurrentUser(null)
+  queryClient.setQueryData(authMeQueryOptions.queryKey, null)
+  // A hard nav, not a router push: it fully resets in-memory state and works from the out-of-shell
+  // states that render without the router's shell.
+  window.location.assign(LOGIN_PATH)
+}

--- a/app/src/shared/api/members.ts
+++ b/app/src/shared/api/members.ts
@@ -25,8 +25,11 @@ export const currentMemberQueryOptions = queryOptions({
   },
 })
 
-export function useCurrentMember() {
-  return useQuery(currentMemberQueryOptions)
+// `enabled` lets a caller hold the fetch off when there is no tenant to resolve it against — the
+// Account container passes `enabled: !!activeTeam`, because a teamless member-profile fetch 403s
+// NO_TEAM_MEMBERSHIP, which the fetch handler turns into a forced logout (ADR-0027 consequences).
+export function useCurrentMember(options?: { enabled?: boolean }) {
+  return useQuery({ ...currentMemberQueryOptions, enabled: options?.enabled })
 }
 
 // The admin roster. Keyed ['members'] so a member mutation invalidating that prefix refreshes both

--- a/app/src/shared/api/positions.ts
+++ b/app/src/shared/api/positions.ts
@@ -15,7 +15,9 @@ export class PositionError extends Error {
 
 // The per-team position vocabulary. Readable by any member (GET has no 403). Keyed ['positions'] so
 // a create/rename/delete mutation invalidating that prefix refreshes every picker.
-export function usePositions() {
+// `enabled` lets a caller hold the fetch off when there is no tenant to resolve it against — the
+// Account container passes `enabled: !!activeTeam`, since positions are a per-team vocabulary.
+export function usePositions(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['positions'],
     queryFn: async () => {
@@ -23,6 +25,7 @@ export function usePositions() {
       // A 401 is handled globally (redirect to login) by the fetch handler; fall back to empty here.
       return res.body?.positions ?? []
     },
+    enabled: options?.enabled,
   })
 }
 

--- a/app/src/shared/lib/team-routes.test.ts
+++ b/app/src/shared/lib/team-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { teamRoutes, teamSlugFromPath } from './team-routes'
+import { ACCOUNT_PATH, teamRoutes, teamSlugFromPath } from './team-routes'
 
 describe('teamSlugFromPath', () => {
   it('reads the slug from a team-scoped path', () => {
@@ -37,7 +37,6 @@ describe('teamRoutes', () => {
     expect(routes.team).toBe('/t/setpoint-vt/team')
     expect(routes.teamSettings).toBe('/t/setpoint-vt/team/settings')
     expect(routes.money).toBe('/t/setpoint-vt/money')
-    expect(routes.profile).toBe('/t/setpoint-vt/profile')
     expect(routes.getStarted).toBe('/t/setpoint-vt/get-started')
   })
 
@@ -53,5 +52,20 @@ describe('teamRoutes', () => {
 
   it('round-trips through teamSlugFromPath', () => {
     expect(teamSlugFromPath(teamRoutes('setpoint-vt').teamSettings)).toBe('setpoint-vt')
+  })
+
+  // Profile is no longer a team-scoped destination — it moved to the team-independent /account
+  // (ADR-0027 §1), so teamRoutes must not name it any more.
+  it('no longer names a team-scoped profile destination', () => {
+    expect('profile' in teamRoutes('setpoint-vt')).toBe(false)
+  })
+})
+
+describe('ACCOUNT_PATH', () => {
+  // The Account tab is a constant, team-independent route (ADR-0027 §1) — never built from a slug —
+  // so the BottomNav Profile tab and the /account route can both reference the same literal.
+  it('is the team-independent /account route', () => {
+    expect(ACCOUNT_PATH).toBe('/account')
+    expect(teamSlugFromPath(ACCOUNT_PATH)).toBeNull()
   })
 })

--- a/app/src/shared/lib/team-routes.ts
+++ b/app/src/shared/lib/team-routes.ts
@@ -7,6 +7,12 @@ import { useRouterState } from '@tanstack/react-router'
  */
 const TEAM_PREFIX = '/t/'
 
+/**
+ * The Account tab is team-independent (ADR-0027 §1): a single constant, never built from a slug, so
+ * it resolves on every in-shell screen and the BottomNav Profile tab points here unconditionally.
+ */
+export const ACCOUNT_PATH = '/account'
+
 /** Null for a path that is not team-scoped. Strict: the segment right after `/t/` and nothing else. */
 export function teamSlugFromPath(pathname: string): string | null {
   if (!pathname.startsWith(TEAM_PREFIX)) return null
@@ -22,7 +28,6 @@ export interface TeamRoutes {
   teamSettings: string
   /** The shared-money pool — a coming-soon placeholder for now (Bunq integration to follow). */
   money: string
-  profile: string
   getStarted: string
 }
 
@@ -32,7 +37,7 @@ export interface TeamRoutes {
  */
 export function teamRoutes(slug: string | null): TeamRoutes {
   if (slug === null) {
-    return { events: '/', event: () => '/', team: '/', teamSettings: '/', money: '/', profile: '/', getStarted: '/' }
+    return { events: '/', event: () => '/', team: '/', teamSettings: '/', money: '/', getStarted: '/' }
   }
   const base = `${TEAM_PREFIX}${encodeURIComponent(slug)}`
   return {
@@ -41,7 +46,6 @@ export function teamRoutes(slug: string | null): TeamRoutes {
     team: `${base}/team`,
     teamSettings: `${base}/team/settings`,
     money: `${base}/money`,
-    profile: `${base}/profile`,
     getStarted: `${base}/get-started`,
   }
 }

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -25,7 +25,8 @@ async function expectTabTargets(canvas: Parameters<NonNullable<Story['play']>>[0
   await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('href', '/t/setpoint-vt')
   await expect(canvas.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/t/setpoint-vt/team')
   await expect(canvas.getByRole('link', { name: 'Money' })).toHaveAttribute('href', '/t/setpoint-vt/money')
-  await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/t/setpoint-vt/profile')
+  // Profile is the team-independent /account (ADR-0027 §1), not a slug-built destination.
+  await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/account')
   // No dead tabs: nothing is disabled/non-interactive. The Money tab is a live link to its
   // (coming-soon) placeholder page, not a greyed-out stub.
   await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('pointer-events-none')
@@ -80,14 +81,19 @@ export const TeamSettingsActive: Story = {
   },
 }
 
+// Profile is the team-independent /account (ADR-0027 §1), so it is active there regardless of slug.
+// /account carries no slug, so the other tabs collapse to the dispatcher `/` — the accepted
+// teamless-bar behaviour (ADR-0027 consequences) — while Profile still points at its constant.
 export const ProfileActive: Story = {
-  parameters: { router: { initialEntries: ['/t/setpoint-vt/profile'] } },
+  parameters: { router: { initialEntries: ['/account'] } },
   play: async ({ canvas }) => {
-    await expectTabTargets(canvas)
+    await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/account')
     await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveClass('text-blue')
     await expect(canvas.getByRole('link', { name: 'Profile' })).toHaveAttribute('aria-current', 'page')
     await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')
     await expect(canvas.getByRole('link', { name: 'Team' })).not.toHaveClass('text-blue')
     await expect(canvas.getByRole('link', { name: 'Money' })).not.toHaveClass('text-blue')
+    // With no slug in scope the non-Profile tabs point at the dispatcher.
+    await expect(canvas.getByRole('link', { name: 'Events' })).toHaveAttribute('href', '/')
   },
 }

--- a/app/src/shared/ui/BottomNav.tsx
+++ b/app/src/shared/ui/BottomNav.tsx
@@ -1,6 +1,6 @@
 import { Link, useRouterState } from '@tanstack/react-router'
 import { Calendar, Users, PiggyBank, User, type LucideIcon } from 'lucide-react'
-import { teamRoutes, teamSlugFromPath, type TeamRoutes } from '@shared/lib/team-routes'
+import { ACCOUNT_PATH, teamRoutes, teamSlugFromPath, type TeamRoutes } from '@shared/lib/team-routes'
 
 interface TabConfig {
   icon: LucideIcon
@@ -20,7 +20,10 @@ function tabsFor(routes: TeamRoutes): TabConfig[] {
     { icon: Calendar, label: 'Events', to: routes.events, isActive: exact(routes.events) },
     { icon: Users, label: 'Team', to: routes.team, isActive: prefix(routes.team) },
     { icon: PiggyBank, label: 'Money', to: routes.money, isActive: prefix(routes.money) },
-    { icon: User, label: 'Profile', to: routes.profile, isActive: prefix(routes.profile) },
+    // Profile points at the team-independent /account (ADR-0027 §1) — a constant, not a slug-built
+    // destination — so it resolves and logout stays reachable on every in-shell screen, teamless
+    // and mid-onboarding included.
+    { icon: User, label: 'Profile', to: ACCOUNT_PATH, isActive: prefix(ACCOUNT_PATH) },
   ]
 }
 


### PR DESCRIPTION
Implements **Slice 0** and **Slice 1** of [ADR-0027](https://github.com/ZzAve/teambalance-app/blob/main/docs/adr/0027-logout-reachable-everywhere-account-tab.md) — the first, independently shippable step that lands the biggest win: **Log out is now reachable from the teamless and mid-onboarding states**. Tracker: #261.

Frontend-only: no Wirespec, no backend, no DB.

## Slice 0 — `clearSession()` primitive
- New client-only `shared/api/clear-session.ts`: drops the user store, nulls the `['auth','me']` cache, and hard-redirects to `/login` with **no** `api.Logout()` round-trip — so it works when the backend is the thing that is down.
- In-shell logout becomes `api.Logout()` → `clearSession()`; the out-of-shell escape hatch (Slice 3) will call `clearSession()` alone.

## Slice 1 — team-independent `/account` route
- `features/account/lib/account-sections.ts`: pure `accountSections(user)` selector. Email / Appearance / Teams / Log out always; Display name + Position only with an Active Team (membership **or** act-as); Platform admin for admins.
- `features/account/ui/AccountView.tsx`: prop-only, presentational. **Log out renders in every branch**, outside the profile loading/error shells — a failed member fetch can never hide it.
- `routes/account.tsx`: thin container. Reads `/auth/me`; fetches the current member **only when an Active Team exists** (`enabled: !!activeTeam`); wires `ThemeToggle`, the member-update mutation, and logout.
- BottomNav Profile tab repointed to the constant `/account` (dropped its `teamRoutes(...)` dependence); `isActive` updated.
- `/account` allow-listed in the root gate's `isTeamlessRoute`, and added to `TENANT_RESOLVING_PATHS` in `auth-redirect.ts`.
- `/t/$slug/profile` → thin redirect to `/account`; old `LogoutButton` logic moved into `AccountView`; unused `teamRoutes.profile` pruned; `ACCOUNT_PATH` added.

## Two traps guarded (both from the ADR / #261 risk table)
1. **Teamless `/account` → forced-logout bounce.** A teamless member fetch 403s `NO_TEAM_MEMBERSHIP`, which `auth-redirect.ts` turns into a hard `/login` redirect. Guarded by **both** `enabled: !!activeTeam` **and** the `TENANT_RESOLVING_PATHS` entry.
2. **Get-started trap.** `/account` lives **outside** the `/t/$slug` tree, so the per-team onboarding guard never touches it — closed by construction, not a new exception.

## Tests (lowest layer that proves each)
- **Vitest (pure):** `clearSession` (nulls store + cache, targets `/login`, **zero** network calls); `accountSections` across teamless / single / multi / admin / act-as; extended `team-routes` (new `ACCOUNT_PATH`, `profile` gone) and `auth-redirect` (`/account` allow-listed) units.
- **Storybook `AccountView.stories`** with `fn()` spies: teamless / single-team / multi-team / admin / loading / error — every story asserts **Log out renders**; `LoggingOut` asserts `onLogout` fires in `play`. Props only, no MSW.
- The container is thin wiring — covered later by the Slice 4 e2e, so no RTL render test for it.

`make test-app` (632 tests), `make lint` (detekt + ESLint), typecheck, and a production build are all green.

## Verification note
The full-stack teamless sign-in → tap Profile → Log out click-through is **Slice 4's e2e** per the ADR (it introduces an auth seam the login/attendance flows never exercise). Docker/Postgres aren't available in this environment, so that flow isn't manually run here; behaviour is proved at the layers above (the AccountView interaction stories render Log out in the teamless/loading/error states and assert it fires, and the route/gate units prove `/account` is allow-listed and never bounced).

Closes nothing yet — this is Slice 0 + 1 of #261; Slices 2–4 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkRTnaVmcZd12TySDLDTxr)_