### PR TITLE
test(app): roll out snapshot policy — disableSnapshot + dark modes (ADR-0027)

### DIFF
--- a/app/.storybook/modes.ts
+++ b/app/.storybook/modes.ts
@@ -1,0 +1,12 @@
+// Chromatic modes for the theme axis (ADR-0027 §3).
+// Theme is a preview *global* (see preview.ts — the `theme` toolbar + `.dark` decorator), so a
+// second-theme baseline belongs in a mode, not a hand-written `*Dark` twin story. A mode re-renders
+// a story with a global flipped: same args, same `play`, one extra snapshot with its own baseline.
+// Apply these at the meta level on the token-sensitive components (attendance colours, the hero, the
+// money surfaces, event-type chits, the bottom nav) so every state inherits both a light and a dark
+// picture. This mirrors the exemplar `features/theme-toggle/ThemeToggleView` `Dark` story, which
+// opts into the dark layer via `globals: { theme: 'dark' }`.
+export const allModes = {
+  light: { theme: 'light' },
+  dark: { theme: 'dark' },
+} as const

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
 import { makeEvent, makeRoster } from '@shared/testing/event-fixtures'
+import { allModes } from '../../../../.storybook/modes'
 import { EventCard } from './EventCard'
 
 // EventCard renders a TanStack Router <Link to="/events/$eventId">, which needs a router in context.
@@ -12,11 +13,14 @@ import { EventCard } from './EventCard'
 const NOW = new Date(2026, 7, 10, 9, 0) // Monday 10 August 2026, 09:00 local
 const on = (day: number, hour = 20, minute = 0) => new Date(2026, 7, day, hour, minute).toISOString()
 
+// Token-sensitive component (ADR-0027 §3): the event-type colour chits on the card surface, so
+// modes at the meta level give every state a light *and* a dark baseline.
 const meta = {
   title: 'entities/event/EventCard',
   component: EventCard,
   decorators: [withRouter],
   args: { now: NOW },
+  parameters: { chromatic: { modes: { light: allModes.light, dark: allModes.dark } } },
 } satisfies Meta<typeof EventCard>
 
 export default meta

--- a/app/src/entities/event/ui/ReferenceRowsEditor.stories.tsx
+++ b/app/src/entities/event/ui/ReferenceRowsEditor.stories.tsx
@@ -65,6 +65,9 @@ export const Prefilled: Story = {
 // The stateful stories above assert the resulting DOM; this asserts the wiring — that the add and
 // update paths call onChange with the expected array, which a getByLabelText check can't prove.
 export const ReportsEdits: Story = {
+  // Behavioural twin of AddAndRemove — the onChange spy's final frame is AddAndRemove's added-row
+  // state (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Add link/ }))
     await expect(args.onChange).toHaveBeenCalledWith([{ title: '', url: '' }])

--- a/app/src/entities/position/ui/PositionPicker.stories.tsx
+++ b/app/src/entities/position/ui/PositionPicker.stories.tsx
@@ -32,6 +32,9 @@ export const NoPositions: Story = {
 
 // Positions available: opening the picker lists them and choosing one emits its id.
 export const HasPositions: Story = {
+  // Behavioural twin of NoPositions — the controlled select closes, settling to the placeholder
+  // trigger picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('combobox'))
     const listbox = within(document.body)

--- a/app/src/features/act-as/ui/ActAsBannerView.stories.tsx
+++ b/app/src/features/act-as/ui/ActAsBannerView.stories.tsx
@@ -22,6 +22,8 @@ export const NamesTheTeam: Story = {
 }
 
 export const ExitIsOneClick: Story = {
+  // Behavioural twin of NamesTheTeam — onExit fires; the banner picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Exit' }))
     await expect(args.onExit).toHaveBeenCalled()

--- a/app/src/features/act-as/ui/ActAsRecordsView.stories.tsx
+++ b/app/src/features/act-as/ui/ActAsRecordsView.stories.tsx
@@ -114,6 +114,9 @@ export const ReasoningIsReachable: Story = {
 // The reasoning belongs to the record it was opened from: collapsing that record takes it with it,
 // so re-opening a different one never starts mid-explanation.
 export const ReasoningClosesWithItsRecord: Story = {
+  // Behavioural twin of RecordExpandsToItsDetail — the final frame is the expanded-record detail
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: /worked here 2 times/ }))
     const records = canvas.getAllByRole('button', { name: /worked in your team/ })

--- a/app/src/features/act-as/ui/PlatformTeamsView.stories.tsx
+++ b/app/src/features/act-as/ui/PlatformTeamsView.stories.tsx
@@ -59,6 +59,8 @@ export const EveryTeam: Story = {
 }
 
 export const EnterATeam: Story = {
+  // Behavioural twin of EveryTeam — onEnter fires; the team-list picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Enter' })[1])
     await expect(args.onEnter).toHaveBeenCalledWith(TEAMS[1])

--- a/app/src/features/attendance-toggle/ui/AttendanceToggle.stories.tsx
+++ b/app/src/features/attendance-toggle/ui/AttendanceToggle.stories.tsx
@@ -1,14 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
+import { allModes } from '../../../../.storybook/modes'
 import { AttendanceToggle } from './AttendanceToggle'
 
 // AttendanceToggle is presentational (value/onToggle/disabled). Each response state is a render arg;
 // the aria-pressed button is the observable contract. The mutation lives in the page container, so
 // there is nothing to mock — every state is a plain story.
+//
+// Token-sensitive component (ADR-0027 §3): the pressed states carry the semantic attendance colours
+// (green/gold/red), which a token or Tailwind bump can break in dark while light stays green. Modes
+// at the meta level give every state a light *and* a dark baseline.
 const meta = {
   title: 'features/attendance-toggle/AttendanceToggle',
   component: AttendanceToggle,
   args: { onToggle: fn() },
+  parameters: { chromatic: { modes: { light: allModes.light, dark: allModes.dark } } },
 } satisfies Meta<typeof AttendanceToggle>
 
 export default meta

--- a/app/src/features/bulk-attend/ui/BulkAttendBarView.stories.tsx
+++ b/app/src/features/bulk-attend/ui/BulkAttendBarView.stories.tsx
@@ -78,6 +78,9 @@ export const OneTypePending: Story = {
 
 // Prop-contract spy: the tap must reach onAttend with the type it named, not merely render.
 export const TapReportsItsType: Story = {
+  // Behavioural twin of PerType — onAttend fires with its type; the per-type bar is unchanged
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, args, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Attend 3 matches' }))
     await expect(args.onAttend).toHaveBeenCalledWith('et-match')

--- a/app/src/features/bulk-attend/ui/BulkAttendButtonView.stories.tsx
+++ b/app/src/features/bulk-attend/ui/BulkAttendButtonView.stories.tsx
@@ -55,6 +55,8 @@ export const Pending: Story = {
 
 // Prop-contract spy: proves the tap actually reaches onAttend, not merely that the label renders.
 export const TapFiresOnAttend: Story = {
+  // Behavioural twin of WithCount — onAttend fires; the button picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, args, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Attend 3 events/ }))
     await expect(args.onAttend).toHaveBeenCalled()

--- a/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
+++ b/app/src/features/create-team/ui/CreateTeamForm.stories.tsx
@@ -96,6 +96,8 @@ export const GenericFailure: Story = {
 }
 
 export const GenericError: Story = {
+  // Behavioural twin of GenericFailure — a literal duplicate render (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     error: new CreateTeamError('GENERIC', 'Something went wrong creating your team. Please try again.'),
   },

--- a/app/src/features/edit-event/ui/DeleteEventDialogView.stories.tsx
+++ b/app/src/features/edit-event/ui/DeleteEventDialogView.stories.tsx
@@ -37,6 +37,8 @@ export const Standalone: Story = {
 }
 
 export const Cancel: Story = {
+  // Behavioural twin of Standalone — onCancel fires; the confirm picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Cancel' }))
     await expect(args.onCancel).toHaveBeenCalled()

--- a/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
+++ b/app/src/features/edit-event/ui/EditEventDialogView.stories.tsx
@@ -75,6 +75,9 @@ export const Series: Story = {
 // carry it: renaming an event must not silently erase its lineup. A prop-contract spy is the only
 // layer that can catch the omission — a getByText would not see it.
 export const CarriesRosterOverrideThroughAnUnrelatedEdit: Story = {
+  // Behavioural twin of Standalone — the roster-override carry is a callback assertion; the filled
+  // edit-form picture ≈ Standalone (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     event: {
       ...EVENT,
@@ -106,6 +109,9 @@ export const CarriesRosterOverrideThroughAnUnrelatedEdit: Story = {
 
 // The mirror case: an inheriting event stays inheriting, rather than acquiring an override.
 export const KeepsAnInheritingEventInheriting: Story = {
+  // Behavioural twin of Standalone — asserts onSave gets `rosterOverride: undefined`; the picture
+  // settles back to Standalone (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Save changes' }))
 

--- a/app/src/features/edit-profile/ui/EditProfileForm.stories.tsx
+++ b/app/src/features/edit-profile/ui/EditProfileForm.stories.tsx
@@ -37,6 +37,9 @@ export const Default: Story = {
 }
 
 export const Editing: Story = {
+  // Behavioural twin of Default — typing a name leaves the form structurally identical to Default
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent }) => {
     const input = canvas.getByLabelText('Display name')
     await userEvent.clear(input)
@@ -63,6 +66,9 @@ export const NameTakenError: Story = {
 }
 
 export const SavedSuccess: Story = {
+  // Behavioural twin of Default — onSubmit fires; the post-play frame is the Default layout
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     const input = canvas.getByLabelText('Display name')
     await userEvent.clear(input)

--- a/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
@@ -59,6 +59,9 @@ export const Open: Story = {
 // Prop-contract spy: a chip tap must report the tapped type id up to the route, which owns the
 // isolate-first selection rule (toggleTypeSelection).
 export const TogglesType: Story = {
+  // Behavioural twin of Open — the open popover is the same picture; only onToggleType fires
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
     await userEvent.click(canvas.getByRole('button', { name: 'Match' }))
@@ -69,6 +72,9 @@ export const TogglesType: Story = {
 // Prop-contract spy: the switch reports the value it is moving *to*, which is what drives
 // useEvents(showPast).
 export const TogglesShowPast: Story = {
+  // Behavioural twin of Open — the open popover is the same picture; only onToggleShowPast fires
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
     await userEvent.click(canvas.getByRole('switch', { name: 'Show past events' }))
@@ -92,6 +98,8 @@ export const ShowingPast: Story = {
 }
 
 export const ClosesOnEscape: Story = {
+  // Behavioural twin of Closed — Escape settles back to the shut popover (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
     await expect(canvas.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument()

--- a/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
+++ b/app/src/features/generate-invite/ui/GenerateInviteContent.stories.tsx
@@ -83,6 +83,9 @@ export const Copied: Story = {
 }
 
 export const RotateLink: Story = {
+  // Behavioural twin of ActiveLink — onRotate fires while the active-link picture is unchanged
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { link: LINK },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Rotate link' }))
@@ -91,6 +94,9 @@ export const RotateLink: Story = {
 }
 
 export const RevokeLink: Story = {
+  // Behavioural twin of ActiveLink — onExpire fires while the active-link picture is unchanged
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { link: LINK },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Revoke link' }))

--- a/app/src/features/join-team/ui/JoinTeamView.stories.tsx
+++ b/app/src/features/join-team/ui/JoinTeamView.stories.tsx
@@ -26,6 +26,9 @@ export const Default: Story = {
 }
 
 export const TypingUpdatesTheContainer: Story = {
+  // Behavioural twin of Default — the field is controlled at `''`, so typing reports to onChange
+  // without changing the picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.type(canvas.getByLabelText('Invite link'), 'abc')
     await expect(args.onChange).toHaveBeenCalled()

--- a/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.stories.tsx
+++ b/app/src/features/manage-creation-codes/ui/ManageCreationCodesView.stories.tsx
@@ -69,6 +69,9 @@ export const WithItems: Story = {
 }
 
 export const GenerateCode: Story = {
+  // Behavioural twin of Empty — onCreate fires with `codes: []`, so the picture stays the Empty
+  // state (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { codes: [] },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Generate code' }))
@@ -77,6 +80,9 @@ export const GenerateCode: Story = {
 }
 
 export const RevokeConfirm: Story = {
+  // Behavioural twin of WithItems — the confirm dialog closes on confirm and settles back to the
+  // items picture; the open-dialog frame is an untracked gap (#263, ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     // Open the confirm dialog from the first (active) code's Revoke button.
     await userEvent.click(canvas.getAllByRole('button', { name: 'Revoke' })[0])

--- a/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
@@ -71,6 +71,9 @@ export const Default: Story = {
 }
 
 export const ChangePosition: Story = {
+  // Behavioural twin of Default — the controlled select closes back to the roster picture
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByLabelText('Position for Grace Hopper'))
     const listbox = within(document.body)
@@ -113,6 +116,9 @@ export const RenameMember: Story = {
 // Prop-contract: promoting/demoting reuses the update mutation — the first "Make member" (the first
 // admin, Ada) fires onToggleRole with that member.
 export const ToggleRole: Story = {
+  // Behavioural twin of Default — onToggleRole fires while the roster picture is unchanged
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Make member' })[0])
     await expect(args.onToggleRole).toHaveBeenCalledWith(MEMBERS[0])
@@ -123,6 +129,9 @@ export const ToggleRole: Story = {
 // with the member. The row buttons go aria-hidden while the modal is open, so the dialog's Remove is
 // unambiguous.
 export const RemoveMember: Story = {
+  // Behavioural twin of Default — the confirm dialog closes on confirm and settles back to the
+  // roster picture; RemoveConfirmOpen holds the open-dialog baseline (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Remove' })[0])
     const dialog = within(document.body)

--- a/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
+++ b/app/src/features/manage-positions/ui/ManagePositionsView.stories.tsx
@@ -65,6 +65,9 @@ export const WithItems: Story = {
 }
 
 export const CreatePosition: Story = {
+  // Behavioural twin of Empty — the field clears with `positions: []`, settling to the Empty picture
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { positions: [] },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.type(canvas.getByLabelText('New position label'), 'Middle Blocker')
@@ -85,6 +88,9 @@ export const RenamePosition: Story = {
 }
 
 export const DeleteConfirm: Story = {
+  // Behavioural twin of WithItems — the confirm dialog closes on confirm and settles back to the
+  // items picture; the open-dialog frame is an untracked gap (#263, ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getAllByRole('button', { name: 'Delete' })[0])
     const dialog = within(document.body)

--- a/app/src/features/onboarding-hub/ui/OnboardingHubView.stories.tsx
+++ b/app/src/features/onboarding-hub/ui/OnboardingHubView.stories.tsx
@@ -23,6 +23,8 @@ export const Default: Story = {
 }
 
 export const ChooseJoin: Story = {
+  // Behavioural twin of Default — onChooseJoin fires; the fork picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     // The accessible name includes the helper text, so match by substring rather than exact.
     await userEvent.click(canvas.getByRole('button', { name: /^I have an invite/ }))
@@ -31,6 +33,8 @@ export const ChooseJoin: Story = {
 }
 
 export const ChooseCreate: Story = {
+  // Behavioural twin of Default — onChooseCreate fires; the fork picture is unchanged (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /^Create a team/ }))
     await expect(args.onChooseCreate).toHaveBeenCalled()

--- a/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
+++ b/app/src/features/switch-team/ui/SelectTeamView.stories.tsx
@@ -44,6 +44,9 @@ export const ManyTeams: Story = {
 
 // The container turns this slug into a /t/:slug navigation, which is what performs the switch.
 export const ChoosingHandsUpTheSlug: Story = {
+  // Behavioural twin of TwoTeams — onSelect fires with the slug; the two-team list is unchanged
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByText('Tovo Heren 5'))
     await expect(args.onSelect).toHaveBeenCalledWith('tovo-heren-5')

--- a/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
+++ b/app/src/features/switch-team/ui/TeamSwitcherView.stories.tsx
@@ -45,6 +45,9 @@ export const MenuOpen: Story = {
 
 // The slug, not the id: it is what the team-scoped URL carries, and opening that URL is the switch.
 export const SwitchesToTheOtherTeam: Story = {
+  // Behavioural twin of SeveralTeams — the menu closes after the pick, settling to the trigger-closed
+  // picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
     await userEvent.click(canvas.getByRole('option', { name: /Tovo Heren 5/ }))
@@ -54,6 +57,9 @@ export const SwitchesToTheOtherTeam: Story = {
 
 // Re-picking the current Team is not a switch, and must not fire one.
 export const PickingTheActiveTeamDoesNothing: Story = {
+  // Behavioural twin of SeveralTeams — the menu closes with no switch, settling to the trigger-closed
+  // picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Current team: Setpoint VT/ }))
     await userEvent.click(canvas.getByRole('option', { name: /Setpoint VT/ }))

--- a/app/src/features/theme-toggle/ui/ThemeToggleView.stories.tsx
+++ b/app/src/features/theme-toggle/ui/ThemeToggleView.stories.tsx
@@ -42,6 +42,9 @@ export const DarkSelected: Story = {
 }
 
 export const ChoosingDark: Story = {
+  // Behavioural twin of SystemSelected — the control is controlled, so the click reports to onChange
+  // without moving the checked radio; the picture stays SystemSelected (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('radio', { name: 'Dark' }))
     await expect(args.onChange).toHaveBeenCalledWith('dark')
@@ -49,6 +52,9 @@ export const ChoosingDark: Story = {
 }
 
 export const ReturningToSystem: Story = {
+  // Behavioural twin of DarkSelected — controlled click, so the picture stays DarkSelected
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { value: 'dark' },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('radio', { name: 'System' }))

--- a/app/src/shared/ui/BottomNav.stories.tsx
+++ b/app/src/shared/ui/BottomNav.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
+import { allModes } from '../../../.storybook/modes'
 import { BottomNav } from './BottomNav'
 
 // BottomNav renders TanStack Router <Link>s, so it needs a router in context — supplied by the
@@ -10,10 +11,13 @@ import { BottomNav } from './BottomNav'
 //
 // The tab targets are built from the slug in the path the bar is rendered on (ADR-0023 §2), which is
 // why starting the router at a path is enough to drive them — there is no store to prime.
+// Token-sensitive component (ADR-0027 §3): persistent nav chrome plus the active-tab blue, so modes
+// at the meta level give every state a light *and* a dark baseline.
 const meta = {
   title: 'shared/ui/BottomNav',
   component: BottomNav,
   decorators: [withRouter],
+  parameters: { chromatic: { modes: { light: allModes.light, dark: allModes.dark } } },
 } satisfies Meta<typeof BottomNav>
 
 export default meta
@@ -73,7 +77,12 @@ export const MoneyActive: Story = {
 
 // The Team tab stays active on nested team routes (e.g. the admin settings sub-page).
 export const TeamSettingsActive: Story = {
-  parameters: { router: { initialEntries: ['/t/setpoint-vt/team/settings'] } },
+  // Behavioural twin of TeamActive — a nested route that keeps the Team tab active renders the same
+  // picture (ADR-0027 §2).
+  parameters: {
+    router: { initialEntries: ['/t/setpoint-vt/team/settings'] },
+    chromatic: { disableSnapshot: true },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('link', { name: 'Team' })).toHaveClass('text-blue')
     await expect(canvas.getByRole('link', { name: 'Events' })).not.toHaveClass('text-blue')

--- a/app/src/widgets/money-teaser/ui/MoneyTeaserView.stories.tsx
+++ b/app/src/widgets/money-teaser/ui/MoneyTeaserView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
+import { allModes } from '../../../../.storybook/modes'
 import { MoneyTeaserView } from './MoneyTeaserView'
 
 // MoneyTeaserView is the prop-only teaser behind the MoneyTeaser container: the vote's on/off state,
@@ -7,10 +8,13 @@ import { MoneyTeaserView } from './MoneyTeaserView'
 // (ADR-0017). There is no loading/error shell — the page shows no server data (the money feature has
 // no backend yet), so its only states are "haven't voted" and "voted". The count is fake theatre the
 // container computes from the clock; here it is just pinned to a fixed number per story.
+// Token-sensitive component (ADR-0027 §3): the money surface and its gradients, so modes at the
+// meta level give every state a light *and* a dark baseline.
 const meta = {
   title: 'widgets/money-teaser/MoneyTeaserView',
   component: MoneyTeaserView,
   args: { hasVoted: false, count: 142, onVote: fn() },
+  parameters: { chromatic: { modes: { light: allModes.light, dark: allModes.dark } } },
 } satisfies Meta<typeof MoneyTeaserView>
 
 export default meta
@@ -55,6 +59,9 @@ export const Voted: Story = {
 
 // Prop-contract spy: the vote is the whole interaction, so prove the button actually calls onVote.
 export const Voting: Story = {
+  // Behavioural twin of NotVoted — controlled `hasVoted: false`, so the tap reports to onVote
+  // without changing the picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'I want this' }))
     await expect(args.onVote).toHaveBeenCalledTimes(1)
@@ -63,6 +70,9 @@ export const Voting: Story = {
 
 // The other half of the contract: once voted, the button is held, so a second tap can't double-fire.
 export const AlreadyVotedIsHeld: Story = {
+  // Behavioural twin of Voted — the held button doesn't fire, and nothing visible changes
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   args: { hasVoted: true },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: "You're in!" }))

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
 import { makeEvent } from '@shared/testing/event-fixtures'
+import { allModes } from '../../../../.storybook/modes'
 import { NextEventHeroView } from './NextEventHeroView'
 
 // NextEventHeroView is the prop-only Next Up hero behind the NextEventHero container: the event,
@@ -21,11 +22,14 @@ const EVENT = makeEvent({
   attendanceSummary: { attending: 10, maybe: 1, absent: 0, notResponded: 4, roleBreakdown: [] },
 })
 
+// Token-sensitive component (ADR-0027 §3): the largest themed surface plus the RSVP colouring, so
+// modes at the meta level give every state a light *and* a dark baseline.
 const meta = {
   title: 'widgets/next-event-hero/NextEventHeroView',
   component: NextEventHeroView,
   decorators: [withRouter],
   args: { event: EVENT, now: NOW, myState: 'NOT_RESPONDED', onRespond: fn() },
+  parameters: { chromatic: { modes: { light: allModes.light, dark: allModes.dark } } },
 } satisfies Meta<typeof NextEventHeroView>
 
 /**
@@ -56,6 +60,8 @@ export const HasNext: Story = {
 }
 
 export const HaventReplied: Story = {
+  // Behavioural twin of HasNext — default args render the identical picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas }) => {
     await expect(canvas.getByText(/10 going · you haven't replied/)).toBeInTheDocument()
     // Neither answer is pressed yet — "I'm in" is solid because it is the invitation.
@@ -112,6 +118,9 @@ export const Maybe: Story = {
 // Prop-contract spies: the inline RSVP is the whole point of the hero, so prove both buttons
 // actually call onRespond with the right state — not merely that they render.
 export const RsvpIn: Story = {
+  // Behavioural twin of HasNext — the View is controlled, so a click reports to onRespond without
+  // re-rendering; the post-play picture is HasNext's (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /I'm in/ }))
     await expect(args.onRespond).toHaveBeenCalledWith('ATTENDING')
@@ -119,6 +128,8 @@ export const RsvpIn: Story = {
 }
 
 export const RsvpOut: Story = {
+  // Behavioural twin of HasNext — controlled click, picture unchanged from HasNext (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: /Can't make it/ }))
     await expect(args.onRespond).toHaveBeenCalledWith('ABSENT')
@@ -140,6 +151,9 @@ export const Saving: Story = {
 // carries a stretched-link overlay, so the passive rows (countdown, date, headcount, padding) all
 // hit that link instead of dead text — the same pattern EventCard already uses in the list below.
 export const WholeCardIsClickable: Story = {
+  // Behavioural twin of HasNext — a hit-test that changes nothing visible; picture = HasNext
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, canvasElement }) => {
     const cardLink = canvas.getByRole('link', { name: EVENT.title })
     const hero = canvasElement.querySelector('section')!
@@ -164,6 +178,9 @@ export const WholeCardIsClickable: Story = {
 // A stretched overlay covering the RSVP buttons would make the hero's whole point unreachable, and
 // `userEvent` alone would not notice — it dispatches at the button either way.
 export const ControlsStayAboveTheOverlay: Story = {
+  // Behavioural twin of HasNext — a hit-test that changes nothing visible; picture = HasNext
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas, canvasElement }) => {
     for (const name of [/I'm in/, /Can't make it/]) {
       const button = canvas.getByRole('button', { name })

--- a/app/src/widgets/page-header/ui/PageHeader.stories.tsx
+++ b/app/src/widgets/page-header/ui/PageHeader.stories.tsx
@@ -49,6 +49,9 @@ export const TitleOnly: Story = {
 // end-to-end — a plain class assertion would still pass if the offset were re-hardcoded to today's
 // header height.
 export const StickyOffsetFollowsHeaderHeight: Story = {
+  // Behavioural twin of TitleOnly — the computed sticky offset is not visible; the picture = TitleOnly
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
   decorators: [
     (Story) => (
       <div style={{ '--header-height': '80px' } as React.CSSProperties}>


### PR DESCRIPTION
Rollout of **ADR-0027**'s Storybook/Chromatic snapshot policy across the story catalogue. Closes #259.

No `play`, spy, or assertion is deleted, weakened, or merged — this only **adds** `parameters.chromatic` and one shared modes file. Every one of the catalogue's stories still runs headless under `make test-app`.

## What changed

### Task 1 — shared modes definition
- Added `app/.storybook/modes.ts` exporting `allModes = { light: { theme: 'light' }, dark: { theme: 'dark' } }`, mirroring the `theme` global the `ThemeToggleView.Dark` exemplar already uses (`.dark` on the preview root, the same mechanism the app and toolbar drive).

### Task 2 — `disableSnapshot` the 42 behavioural-only pictures
- Set `parameters.chromatic.disableSnapshot: true` on the 42 stories whose post-`play` render is pixel-identical to a sibling baseline (controlled-component clicks that only fire a callback, menu/dialog closes that settle back, hit-tests that change nothing visible).
- Each carries an inline comment naming the sibling baseline it visually duplicates, per ADR-0027 §2/§4. The behavioural test (the `play` + spies) is untouched.

### Task 3 — dark `modes` on the 5 token-sensitive components
- Applied `parameters.chromatic.modes: { light, dark }` at the **meta** level of `AttendanceToggle`, `NextEventHeroView`, `MoneyTeaserView`, `EventCard`, and `BottomNav`, so every state inherits both a light and a dark baseline (ADR-0027 §3).

## Net baseline change (please read — differs from the issue's projection)

The issue projected **247 − 42 + 11 = 216 (net −31)**. On the **current** tree the real numbers are different, for two reasons:

1. **Meta-level modes give a dark twin to *every* keep-baseline state in the 5 files, not only the flagship states.** ADR-0027 §3 and Task 3 both mandate meta-level application ("so every state inherits both baselines"). The issue's `+11` counted only the states tagged "· modes" in the classification table, but applying at the meta level (as instructed) adds a dark baseline to all **26** keep-baseline stories across those 5 files:

   | Component | keep-baseline stories → dark twins |
   |-----------|-----------------------------------:|
   | AttendanceToggle | 5 |
   | NextEventHeroView | 6 |
   | MoneyTeaserView | 2 |
   | EventCard | 9 |
   | BottomNav | 4 |
   | **Total dark twins** | **+26** |

2. **The catalogue grew since the issue was written** (247 → 262 exports) — e.g. `EventCard.WithRosterChip` (roster disclosure, #227) is new.

So the actual net picture change is **−42 (disableSnapshot) + 26 (dark twins) = −16 pictures** on the current tree, versus the issue's projected −31. If you'd rather cap the dark twins at the flagged flagship states, that means dropping modes to per-story rather than meta level — which contradicts ADR-0027 §3's "at the meta level so every state inherits both baselines", so I left it at meta level as written. Happy to narrow it if you prefer.

## Out of scope (untouched)

- The two open-dialog coverage gaps (`ManageCreationCodesView.RevokeConfirm`, `ManagePositionsView.DeleteConfirm`) — tracked in #263. Their `disableSnapshot` comments point there.
- `ThemeToggleView` keeps its existing hand-written `Dark` baseline (the exemplar); it is **not** in Task 3's meta-modes list, so only its 2 `disableSnapshot`s were added.

## Verification

- `make test-app` — **93 test files / 605 tests pass** headless (Storybook browser project included; every disabled-snapshot story's `play` still runs).
- `make lint` — clean (ESLint incl. `eslint-plugin-boundaries`; the `.storybook/modes` import resolves without a boundary violation).
- `npm run typecheck` (`tsc -b`) — clean; `modes.ts` typechecks and its `allModes` import resolves from every story depth.

No new e2e: this change introduces no new auth path, cross-tenant write, or external integration seam (per the PR gate in CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZfhiUjjCKF7pFwFANz1cw)_