### PR TITLE
feat: memberless team creation + Admin-granting invite link (the club rollout)

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -25,6 +25,11 @@ import java.util.UUID
  */
 data class GeneratedInvitation(val token: InviteToken, val expiresAt: Instant)
 
+// One cohesive owner of every invite-link operation — generate / current / rotate / revoke for both
+// the shareable USER link and the single-use ADMIN handover link, plus accept. The two link kinds are
+// exact parallels sharing the same mint/reveal/hash machinery, so keeping them in one class is what
+// avoids duplicating that machinery; that pushes the method count just over detekt's default.
+@Suppress("TooManyFunctions")
 class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val teamMemberRepository: TeamMemberRepository,
@@ -116,6 +121,46 @@ class InvitationService(
     }
 
     /**
+     * The team's current unspent ADMIN handover link, or null if it has none — the read that lets the
+     * link survive a page refresh, exactly as [activeInviteLink] does for the shareable USER link
+     * (ADR-0025). Scoped to a live, *unconsumed* ADMIN link: once one is accepted it is spent, so it is
+     * no longer offered back and the admin is shown the option to mint a fresh one.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the acting-in Platform Admin's Virtual
+     * Member, ADR-0024 §2).
+     */
+    fun activeAdminInviteLink(callerId: UserId, teamId: TeamId): GeneratedInvitation? {
+        authorizationService.requireAdmin(callerId, teamId)
+        return invitationRepository.findActiveAdminByTeam(teamId, clock.instant())?.let(::reveal)
+    }
+
+    /**
+     * Revoke-and-reissue for the ADMIN handover link: expires the team's active ADMIN link and mints a
+     * fresh one in its place, atomically (the guarantee lives in [InvitationRepository.rotate]). Used
+     * when a handover link may have leaked before it reached the right person. The USER shareable link
+     * is untouched — rotate is role-scoped by the replacement's role.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
+     */
+    fun rotateAdminInviteLink(callerId: UserId, teamId: TeamId): GeneratedInvitation {
+        authorizationService.requireAdmin(callerId, teamId)
+        val now = clock.instant()
+        val token = generateToken()
+        invitationRepository.rotate(teamId, mint(token, callerId, teamId, now, Role.ADMIN), now)
+        return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
+    }
+
+    /**
+     * Revokes the team's active ADMIN handover link without a replacement — the "I don't want to hand
+     * over right now after all" path. Scoped to [Role.ADMIN], so the shareable USER link keeps working.
+     * Admin-only: [callerId] must be an admin of [teamId] (the server-resolved tenant).
+     */
+    fun expireAdminInviteLinks(callerId: UserId, teamId: TeamId) {
+        authorizationService.requireAdmin(callerId, teamId)
+        invitationRepository.expireActive(teamId, Role.ADMIN, Instant.now(clock))
+    }
+
+    /**
      * Joins the presenting user to the invitation's team and makes it their Active Team, so a joiner
      * who was already a Member elsewhere lands where they just accepted (ADR-0023 §4).
      *
@@ -150,7 +195,7 @@ class InvitationService(
      */
     fun expireActiveInvitations(callerId: UserId, teamId: TeamId) {
         authorizationService.requireAdmin(callerId, teamId)
-        invitationRepository.expireActive(teamId, Instant.now(clock))
+        invitationRepository.expireActive(teamId, Role.USER, Instant.now(clock))
     }
 
     /**

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -94,6 +94,14 @@ class InvitationService(
      * rather than minting a second, so a team holds at most one live ADMIN credential. Once the previous
      * was accepted (consumed) or expired, this mints a fresh one.
      *
+     * The one-live-link property is held here, not in the schema — the same service-held invariant
+     * ADR-0025 chose for the USER link (a partial unique index can't bite on the time-based
+     * active-ness). So two near-simultaneous mints could each pass the find and leave two live ADMIN
+     * links. That is an anti-accumulation weakening, **not** a single-use hole: single-use is enforced
+     * at accept by the conditional [InvitationRepository.consume], so every link is still spent at most
+     * once. The extra-credential window is the accepted ADR-0025 trade-off, and the UI disables the
+     * button while the mint is in flight; the operator, not an accident, decides what to hand out.
+     *
      * Admin-only: [callerId] must be an admin of [teamId] — which, for the memberless handover, is the
      * acting-in Platform Admin's Virtual Member (ADR-0024 §2).
      */

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/InvitationService.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.application
 import com.github.zzave.teambalance.api.domain.model.EncryptedToken
 import com.github.zzave.teambalance.api.domain.model.Invitation
 import com.github.zzave.teambalance.api.domain.model.InviteToken
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.model.UserId
@@ -79,7 +80,30 @@ class InvitationService(
         invitationRepository.findActiveByTeam(teamId, now)?.let(::reveal)?.let { return it }
 
         val token = generateToken()
-        invitationRepository.save(mint(token, callerId, teamId, now))
+        invitationRepository.save(mint(token, callerId, teamId, now, Role.USER))
+        return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
+    }
+
+    /**
+     * The single-use, **ADMIN**-granting handover link (ADR-0024 §5) — how a memberless team gets its
+     * first Admin. Distinct from [generateInviteLink]: that mints the shareable USER link ("one link,
+     * many joiners", ADR-0025), whereas an ADMIN grant with those semantics would hand Admin to
+     * everyone the recipient forwards it to, so this link is spent on first accept.
+     *
+     * Idempotent while unspent: with a live, unconsumed ADMIN link already present it returns that one
+     * rather than minting a second, so a team holds at most one live ADMIN credential. Once the previous
+     * was accepted (consumed) or expired, this mints a fresh one.
+     *
+     * Admin-only: [callerId] must be an admin of [teamId] — which, for the memberless handover, is the
+     * acting-in Platform Admin's Virtual Member (ADR-0024 §2).
+     */
+    fun generateAdminInviteLink(callerId: UserId, teamId: TeamId): GeneratedInvitation {
+        authorizationService.requireAdmin(callerId, teamId)
+        val now = clock.instant()
+        invitationRepository.findActiveAdminByTeam(teamId, now)?.let(::reveal)?.let { return it }
+
+        val token = generateToken()
+        invitationRepository.save(mint(token, callerId, teamId, now, Role.ADMIN))
         return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
     }
 
@@ -93,11 +117,24 @@ class InvitationService(
         val now = Instant.now(clock)
         val invitation = invitationRepository.findByTokenHash(hashToken(token))
             ?.takeIf { it.expiresAt.isAfter(now) }
+            ?.takeIf { claim(it, now) }
             ?: return null
-        teamMemberRepository.addMember(invitation.teamId, userId)
+
+        teamMemberRepository.addMember(invitation.teamId, userId, invitation.role)
         activeTeamService.activate(userId, invitation.teamId)
         return invitation.teamId
     }
+
+    /**
+     * Claims the invitation for the caller who is about to accept it, returning whether it may proceed.
+     *
+     * A single-use ADMIN link is consumed conditionally *before* it grants anything (ADR-0024 §5), so
+     * at most one accept ever passes: consume-first is the fail-safe order — a lost race or an
+     * already-spent link returns false and joins nobody, rather than risking two admins from one link.
+     * A USER link is reusable, always claimable, and never consumed.
+     */
+    private fun claim(invitation: Invitation, now: Instant): Boolean =
+        invitation.role != Role.ADMIN || invitationRepository.consume(invitation.id, now)
 
     /**
      * Invalidates every currently-active invite link for the team; already-expired ones are untouched.
@@ -120,13 +157,15 @@ class InvitationService(
         authorizationService.requireAdmin(callerId, teamId)
         val now = clock.instant()
         val token = generateToken()
-        invitationRepository.rotate(teamId, mint(token, callerId, teamId, now), now)
+        invitationRepository.rotate(teamId, mint(token, callerId, teamId, now, Role.USER), now)
         return GeneratedInvitation(token = token, expiresAt = now.plus(INVITE_TTL))
     }
 
-    private fun mint(token: InviteToken, callerId: UserId, teamId: TeamId, now: Instant) = Invitation(
+    private fun mint(token: InviteToken, callerId: UserId, teamId: TeamId, now: Instant, role: Role) = Invitation(
         id = UUID.randomUUID(),
         teamId = teamId,
+        role = role,
+        consumedAt = null,
         tokenHash = hashToken(token.value),
         encryptedToken = tokenCipher.encrypt(token),
         createdBy = callerId,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/TeamService.kt
@@ -8,6 +8,7 @@ import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TeamName
 import com.github.zzave.teambalance.api.domain.model.TeamNaming
 import com.github.zzave.teambalance.api.domain.model.UserId
+import com.github.zzave.teambalance.api.domain.port.PlatformAdminGateway
 import com.github.zzave.teambalance.api.domain.port.TeamCreationCodeRepository
 import com.github.zzave.teambalance.api.domain.port.TeamNotificationGateway
 import com.github.zzave.teambalance.api.domain.port.TeamRegistrationGateway
@@ -47,6 +48,7 @@ class TeamService(
     private val userRepository: UserRepository,
     private val teamNotificationGateway: TeamNotificationGateway,
     private val activeTeamService: ActiveTeamService,
+    private val platformAdminGateway: PlatformAdminGateway,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(TeamService::class.java)
@@ -75,6 +77,41 @@ class TeamService(
         activeTeamService.activate(founderId, teamId)
 
         notifyBestEffort(founderId, names.name, names.slug)
+
+        return CreatedTeam(id = teamId, name = names.name, slug = names.slug)
+    }
+
+    /**
+     * Memberless team creation by a Platform Admin (ADR-0024 §5, issue #240): provision the tenant
+     * schema and insert the `teams` row with **no `team_members` rows at all**. The admin does not
+     * become a member or a founder — the platform account is structurally teamless (ADR-0024 §3) — and
+     * the new team is deliberately **not** made their Active Team: they enter it via act-as, prepare it,
+     * and hand it over with an ADMIN invite link.
+     *
+     * Gated by the platform-admin allowlist, the same gate the rest of `/admin` carries — a stronger
+     * gate than a creation code, so no code is required here. [adminId] is recorded as the team's
+     * creator for provenance (who created which team, when).
+     *
+     * Provision-first, mirroring [createTeam]: a failed insert leaves at worst a harmless empty orphan
+     * schema, self-healed by the startup runner. Notifications are best-effort and never fail creation.
+     */
+    fun createMemberlessTeam(adminId: UserId, rawName: String, rawSlug: String): CreatedTeam {
+        platformAdminGateway.requirePlatformAdmin(adminId.value)
+
+        val names = TeamNaming.validate(rawName, rawSlug)
+        requireSlugAvailable(names.slug)
+
+        tenantProvisioningGateway.provisionTenant(names.schemaName)
+
+        val teamId = teamRegistrationGateway.registerMemberless(
+            createdBy = adminId.value,
+            name = names.name,
+            slug = names.slug,
+            schemaName = names.schemaName,
+            now = clock.instant(),
+        )
+
+        notifyCreatedBestEffort(adminId, names.name, names.slug)
 
         return CreatedTeam(id = teamId, name = names.name, slug = names.slug)
     }
@@ -108,6 +145,21 @@ class TeamService(
             teamNotificationGateway.creationCodeConsumed(teamName.value, teamSlug.value, founderEmail.value)
         } catch (e: Exception) {
             log.warn("Post-create notifications failed for team '{}' (creation succeeded)", teamSlug, e)
+        }
+    }
+
+    /**
+     * The memberless creator confirmation — just "the team is created", no code-consumed audit (no
+     * code was spent). Best-effort for the same reason as [notifyBestEffort]: the team is committed, so
+     * a failure to resolve the admin's email or send mail must never turn a success into a 500.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun notifyCreatedBestEffort(creatorId: UserId, teamName: TeamName, teamSlug: Slug) {
+        try {
+            val creatorEmail = userRepository.findById(creatorId)?.email ?: return
+            teamNotificationGateway.teamCreated(creatorEmail.value, teamName.value, teamSlug.value)
+        } catch (e: Exception) {
+            log.warn("Post-create notification failed for team '{}' (creation succeeded)", teamSlug, e)
         }
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/Invitation.kt
@@ -6,6 +6,18 @@ import java.util.UUID
 data class Invitation(
     val id: UUID,
     val teamId: TeamId,
+    /**
+     * The permission role this link grants on acceptance (ADR-0024 §5). [Role.USER] is the ordinary
+     * shareable link ("one link, many joiners", ADR-0025); [Role.ADMIN] is the single-use handover
+     * link that gives a memberless team its first Admin.
+     */
+    val role: Role,
+    /**
+     * When this link was spent, or null while unspent. Only ever set for an [Role.ADMIN] link, which is
+     * single-use: the one accept that wins the conditional consume stamps it, and a later accept of the
+     * same token finds it non-null and is refused. A [Role.USER] link never sets it — it stays reusable.
+     */
+    val consumedAt: Instant?,
     val tokenHash: TokenHash,
     /**
      * The recoverable copy of the token, so an admin can be shown this link again (ADR-0025).

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -35,7 +35,11 @@ interface InvitationRepository {
      */
     fun consume(invitationId: UUID, now: Instant): Boolean
 
-    /** Marks every currently-active (unexpired) invitation for the team as expired as of [now]. */
+    /**
+     * Marks the team's active (unexpired) **shareable USER link(s)** as expired as of [now]. Scoped to
+     * [Role.USER] so revoking or rotating the player link never collaterally kills a live single-use
+     * ADMIN handover link, which is an independent credential (ADR-0024 §5).
+     */
     fun expireActive(teamId: TeamId, now: Instant)
 
     /**

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -36,15 +36,17 @@ interface InvitationRepository {
     fun consume(invitationId: UUID, now: Instant): Boolean
 
     /**
-     * Marks the team's active (unexpired) **shareable USER link(s)** as expired as of [now]. Scoped to
-     * [Role.USER] so revoking or rotating the player link never collaterally kills a live single-use
-     * ADMIN handover link, which is an independent credential (ADR-0024 §5).
+     * Marks the team's active (unexpired) links **of [role]** as expired as of [now]. Scoped by role so
+     * revoking the shareable USER link never collaterally kills a live single-use ADMIN handover link,
+     * and vice-versa — they are independent credentials (ADR-0024 §5), each revoked on its own path.
      */
-    fun expireActive(teamId: TeamId, now: Instant)
+    fun expireActive(teamId: TeamId, role: Role, now: Instant)
 
     /**
-     * Expires the team's active invitations and mints [replacement] in their place, as ONE unit: if
-     * the mint fails the expiry is rolled back, so a team is never left without a usable link.
+     * Expires the team's active invitations **of [replacement]'s role** and mints [replacement] in
+     * their place, as ONE unit: if the mint fails the expiry is rolled back, so a team is never left
+     * without a usable link. The role scoping keeps a USER rotate off the ADMIN handover link (and
+     * vice-versa) — the replacement's role decides which link is being reissued.
      *
      * Expire-then-mint is the only operation in the codebase whose atomicity spans two distinct
      * writes, so it is expressed as a single port call — the application states the intent and the

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/InvitationRepository.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.domain.port
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import java.time.Instant
@@ -11,11 +12,28 @@ interface InvitationRepository {
     fun findByTokenHash(tokenHash: TokenHash): Invitation?
 
     /**
-     * The team's current invite link, or null if it has none. At most one is active at a time — the
-     * invariant [InvitationRepository] callers maintain by minting through
-     * `InvitationService.generateInviteLink` (idempotent) or [rotate] (expire-and-replace).
+     * The team's current shareable (USER) invite link, or null if it has none. At most one is active at
+     * a time — the invariant [InvitationRepository] callers maintain by minting through
+     * `InvitationService.generateInviteLink` (idempotent) or [rotate] (expire-and-replace). Scoped to
+     * [Role.USER] so a live ADMIN handover link is never mistaken for the shareable one, and never
+     * re-shown by the admin's "current link" read.
      */
     fun findActiveByTeam(teamId: TeamId, now: Instant): Invitation?
+
+    /**
+     * The team's current unspent ADMIN handover link, or null if it has none — active at [now],
+     * [Role.ADMIN], and not yet consumed. Backs the idempotent mint of the handover link, so a team
+     * holds at most one live ADMIN credential at a time (ADR-0024 §5).
+     */
+    fun findActiveAdminByTeam(teamId: TeamId, now: Instant): Invitation?
+
+    /**
+     * Marks the invitation [invitationId] consumed as of [now], but only if it was still unspent —
+     * `UPDATE … SET consumed_at = :now WHERE id = :id AND consumed_at IS NULL`. Returns true iff one
+     * row changed, so a second accept of a single-use ADMIN link (or a lost race) gets false and joins
+     * nobody. Consume-first ordering makes the failure mode fail-safe: at most one caller ever passes.
+     */
+    fun consume(invitationId: UUID, now: Instant): Boolean
 
     /** Marks every currently-active (unexpired) invitation for the team as expired as of [now]. */
     fun expireActive(teamId: TeamId, now: Instant)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamMemberRepository.kt
@@ -31,10 +31,15 @@ interface TeamMemberRepository {
     fun findSoleTenantRouting(userId: UserId): TenantRouting?
 
     /**
-     * Joins the user to the team as a USER, whether or not they were a member before. No-op if they
-     * already are one. A previously removed member comes back as a USER, never at their old role.
+     * Joins the user to the team at [role], whether or not they were a member before. A previously
+     * removed member comes back at [role], never at their old one. If they are already an active member
+     * the call promotes them to [role] when it is higher (an ADMIN handover link makes an existing USER
+     * an ADMIN) and is otherwise a no-op.
+     *
+     * The ordinary accept path passes [Role.USER]; the single-use ADMIN handover link (ADR-0024 §5)
+     * passes [Role.ADMIN], which is how a memberless team gets its first Admin.
      */
-    fun addMember(teamId: TeamId, userId: UserId)
+    fun addMember(teamId: TeamId, userId: UserId, role: Role = Role.USER)
 
     /** Sets the permission [role] for an active member. */
     fun updateRole(teamId: TeamId, userId: UserId, role: Role)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRegistrationGateway.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/TeamRegistrationGateway.kt
@@ -34,4 +34,24 @@ interface TeamRegistrationGateway {
         schemaName: SchemaName,
         now: Instant,
     ): TeamId
+
+    /**
+     * Inserts the team ([name]/[slug]/[schemaName]) with **no `team_members` row and no creation code**
+     * — the memberless creation of ADR-0024 §5. [createdBy] is the Platform Admin, recorded as the
+     * team's creator for provenance ([now] as `created_at`); it is deliberately *not* made a member,
+     * because the platform account is structurally teamless (ADR-0024 §3). Returns the new team id.
+     *
+     * Kept a separate method rather than a nullable founder on [register]: "insert no member" must not
+     * be reachable from the ordinary self-service path, where the founder always becomes the admin.
+     *
+     * @throws com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
+     *   if the slug / schema name collides with an existing team.
+     */
+    fun registerMemberless(
+        createdBy: UUID,
+        name: TeamName,
+        slug: Slug,
+        schemaName: SchemaName,
+        now: Instant,
+    ): TeamId
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/config/TeamCompositionRoot.kt
@@ -32,6 +32,7 @@ class TeamCompositionRoot {
         userRepository: UserRepository,
         teamNotificationGateway: TeamNotificationGateway,
         activeTeamService: ActiveTeamService,
+        platformAdminGateway: PlatformAdminGateway,
         clock: Clock,
     ) = TeamService(
         teamRepository = teamRepository,
@@ -41,6 +42,7 @@ class TeamCompositionRoot {
         userRepository = userRepository,
         teamNotificationGateway = teamNotificationGateway,
         activeTeamService = activeTeamService,
+        platformAdminGateway = platformAdminGateway,
         clock = clock,
     )
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRegistrationAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JdbcTeamRegistrationAdapter.kt
@@ -61,7 +61,7 @@ class JdbcTeamRegistrationAdapter(
             throw InvalidCreationCodeException()
         }
 
-        val teamId = insertTeam(name, slug, schemaName)
+        val teamId = insertTeam(name, slug, schemaName, createdBy = founderId)
 
         // Link the consumed code to the team it produced (same transaction), so the codes-admin
         // surface can show which team a code was redeemed into. The binds below are `vararg Any?`, so
@@ -84,19 +84,36 @@ class JdbcTeamRegistrationAdapter(
         return teamId
     }
 
+    /**
+     * Memberless creation (ADR-0024 §5): the team row and nothing else. No creation code is consumed
+     * and — deliberately — no `team_members` row is written, so the platform account never holds a
+     * membership (ADR-0024 §3). [createdBy] is recorded only as the team's creator, for provenance.
+     * `@Transactional` is a formality for a single insert, kept for symmetry with [register].
+     */
+    @Transactional
+    override fun registerMemberless(
+        createdBy: UUID,
+        name: TeamName,
+        slug: Slug,
+        schemaName: SchemaName,
+        now: Instant,
+    ): TeamId = insertTeam(name, slug, schemaName, createdBy = createdBy)
+
     // The DuplicateKeyException is intentionally translated (not chained) into a clean domain 409:
     // the slug / schema_name UNIQUE constraint tripped because a team was created under this name in
     // the window after the pre-check. The driver-level cause carries no caller-actionable detail.
     @Suppress("SwallowedException")
-    private fun insertTeam(name: TeamName, slug: Slug, schemaName: SchemaName): TeamId =
+    private fun insertTeam(name: TeamName, slug: Slug, schemaName: SchemaName, createdBy: UUID): TeamId =
         try {
             TeamId(
                 jdbcTemplate.queryForObject(
-                    "INSERT INTO public.teams (name, slug, schema_name) VALUES (?, ?, ?) RETURNING id",
+                    "INSERT INTO public.teams (name, slug, schema_name, created_by) " +
+                        "VALUES (?, ?, ?, ?) RETURNING id",
                     UUID::class.java,
                     name.value,
                     slug.value,
                     schemaName.value,
+                    createdBy,
                 )!!,
             )
         } catch (e: DuplicateKeyException) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -38,13 +38,15 @@ class JpaInvitationRepositoryAdapter(
         jpaRepository.consume(invitationId, now) == 1
 
     @Transactional
-    override fun expireActive(teamId: TeamId, now: Instant) {
-        jpaRepository.expireActive(teamId.value, now)
+    override fun expireActive(teamId: TeamId, role: Role, now: Instant) {
+        jpaRepository.expireActiveByRole(teamId.value, role.name, now)
     }
 
     @Transactional
     override fun rotate(teamId: TeamId, replacement: Invitation, now: Instant): Invitation {
-        jpaRepository.expireActive(teamId.value, now)
+        // Expire only the links of the same role we are about to reissue, so a USER rotate leaves a
+        // live ADMIN handover link untouched (and vice-versa).
+        jpaRepository.expireActiveByRole(teamId.value, replacement.role.name, now)
         return jpaRepository.save(replacement.externalize()).internalize()
     }
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaInvitationRepositoryAdapter.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.port.InvitationRepository
@@ -23,7 +24,18 @@ class JpaInvitationRepositoryAdapter(
         jpaRepository.findByTokenHash(tokenHash.value)?.internalize()
 
     override fun findActiveByTeam(teamId: TeamId, now: Instant): Invitation? =
-        jpaRepository.findFirstByTeamIdAndExpiresAtAfter(teamId.value, now)?.internalize()
+        jpaRepository.findFirstByTeamIdAndRoleAndExpiresAtAfter(teamId.value, Role.USER.name, now)?.internalize()
+
+    override fun findActiveAdminByTeam(teamId: TeamId, now: Instant): Invitation? =
+        jpaRepository.findFirstByTeamIdAndRoleAndConsumedAtIsNullAndExpiresAtAfter(
+            teamId.value,
+            Role.ADMIN.name,
+            now,
+        )?.internalize()
+
+    @Transactional
+    override fun consume(invitationId: UUID, now: Instant): Boolean =
+        jpaRepository.consume(invitationId, now) == 1
 
     @Transactional
     override fun expireActive(teamId: TeamId, now: Instant) {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaTeamMemberRepositoryAdapter.kt
@@ -138,13 +138,21 @@ class JpaTeamMemberRepositoryAdapter(
     override fun countAdmins(teamId: TeamId): Int = jpaRepository.countActiveAdmins(teamId.value)
 
     @Transactional
-    override fun addMember(teamId: TeamId, userId: UserId) {
-        if (jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId.value, userId.value) != null) return
+    override fun addMember(teamId: TeamId, userId: UserId, role: Role) {
+        val existing = jpaRepository.findByTeamIdAndUserIdAndActiveTrue(teamId.value, userId.value)
+        if (existing != null) {
+            // Already a member. An ADMIN handover link promotes a plain member; anything else is a
+            // no-op. Never demote — a USER link must not strip an existing admin's rights.
+            if (role == Role.ADMIN && existing.role != Role.ADMIN.name) {
+                jpaRepository.updateRole(teamId.value, userId.value, Role.ADMIN.name)
+            }
+            return
+        }
         // (team_id, user_id) is UNIQUE, so an insert cannot re-join a member whose row is inactive.
-        if (jpaRepository.reactivateAsUser(teamId.value, userId.value) > 0) return
+        if (jpaRepository.reactivateWithRole(teamId.value, userId.value, role.name) > 0) return
         try {
             jpaRepository.save(
-                TeamMemberJpaEntity(teamId = teamId.value, userId = userId.value, role = Role.USER.name),
+                TeamMemberJpaEntity(teamId = teamId.value, userId = userId.value, role = role.name),
             )
         } catch (e: DataIntegrityViolationException) {
             // Lost a race with a concurrent accept — the other one made them a member, which is the

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -10,7 +10,13 @@ import java.util.UUID
 interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UUID> {
     fun findByTokenHash(tokenHash: String): InvitationJpaEntity?
 
-    fun findFirstByTeamIdAndExpiresAtAfter(teamId: UUID, now: Instant): InvitationJpaEntity?
+    fun findFirstByTeamIdAndRoleAndExpiresAtAfter(teamId: UUID, role: String, now: Instant): InvitationJpaEntity?
+
+    fun findFirstByTeamIdAndRoleAndConsumedAtIsNullAndExpiresAtAfter(
+        teamId: UUID,
+        role: String,
+        now: Instant,
+    ): InvitationJpaEntity?
 
     @Modifying(clearAutomatically = true)
     @Query(
@@ -18,4 +24,13 @@ interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UU
             "WHERE i.teamId = :teamId AND i.expiresAt > :now",
     )
     fun expireActive(teamId: UUID, now: Instant)
+
+    // Conditional single-use consume: stamps consumed_at only while still unspent, so exactly one
+    // accept of an ADMIN handover link can win. Returns the number of rows changed (0 or 1).
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "UPDATE InvitationJpaEntity i SET i.consumedAt = :now " +
+            "WHERE i.id = :id AND i.consumedAt IS NULL",
+    )
+    fun consume(id: UUID, now: Instant): Int
 }

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -18,10 +18,13 @@ interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UU
         now: Instant,
     ): InvitationJpaEntity?
 
+    // Scoped to the shareable USER link: rotate and revoke act on that link only, so a live single-use
+    // ADMIN handover link (an independent credential, ADR-0024 §5) is never collaterally expired by a
+    // player-link rotate/revoke. The ADMIN link is governed by its own consumption and TTL.
     @Modifying(clearAutomatically = true)
     @Query(
         "UPDATE InvitationJpaEntity i SET i.expiresAt = :now " +
-            "WHERE i.teamId = :teamId AND i.expiresAt > :now",
+            "WHERE i.teamId = :teamId AND i.role = 'USER' AND i.expiresAt > :now",
     )
     fun expireActive(teamId: UUID, now: Instant)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataInvitationRepository.kt
@@ -18,15 +18,15 @@ interface SpringDataInvitationRepository : JpaRepository<InvitationJpaEntity, UU
         now: Instant,
     ): InvitationJpaEntity?
 
-    // Scoped to the shareable USER link: rotate and revoke act on that link only, so a live single-use
-    // ADMIN handover link (an independent credential, ADR-0024 §5) is never collaterally expired by a
-    // player-link rotate/revoke. The ADMIN link is governed by its own consumption and TTL.
+    // Scoped by role, so revoke/rotate of the shareable USER link never touches a live ADMIN handover
+    // link and vice-versa — the two are independent credentials (ADR-0024 §5), each rotated/revoked on
+    // its own path.
     @Modifying(clearAutomatically = true)
     @Query(
         "UPDATE InvitationJpaEntity i SET i.expiresAt = :now " +
-            "WHERE i.teamId = :teamId AND i.role = 'USER' AND i.expiresAt > :now",
+            "WHERE i.teamId = :teamId AND i.role = :role AND i.expiresAt > :now",
     )
-    fun expireActive(teamId: UUID, now: Instant)
+    fun expireActiveByRole(teamId: UUID, role: String, now: Instant)
 
     // Conditional single-use consume: stamps consumed_at only while still unspent, so exactly one
     // accept of an ADMIN handover link can win. Returns the number of rows changed (0 or 1).

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataTeamMemberRepository.kt
@@ -41,15 +41,20 @@ interface SpringDataTeamMemberRepository : JpaRepository<TeamMemberJpaEntity, UU
     )
     fun deactivate(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): Int
 
-    // Re-joining after removal. The role resets to USER: a removed admin walking back in through a
-    // shared invite link must not arrive holding their old rights.
+    // Re-joining after removal. The role is set from the accepted link, never inherited: a removed
+    // admin walking back in through a shared USER link arrives as USER, and a single-use ADMIN handover
+    // link re-admits at ADMIN. The invitation's role — not the old row — decides.
     @Modifying
     @Query(
-        "UPDATE public.team_members SET active = true, role = 'USER' " +
+        "UPDATE public.team_members SET active = true, role = :role " +
             "WHERE team_id = :teamId AND user_id = :userId AND active = false",
         nativeQuery = true,
     )
-    fun reactivateAsUser(@Param("teamId") teamId: UUID, @Param("userId") userId: UUID): Int
+    fun reactivateWithRole(
+        @Param("teamId") teamId: UUID,
+        @Param("userId") userId: UUID,
+        @Param("role") role: String,
+    ): Int
 
     @Query(
         "SELECT COUNT(*) FROM public.team_members " +

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/entity/InvitationJpaEntity.kt
@@ -18,6 +18,10 @@ class InvitationJpaEntity(
     val tokenHash: String = "",
     @Column(name = "token_encrypted")
     val encryptedToken: String? = null,
+    @Column(name = "role", nullable = false)
+    val role: String = "USER",
+    @Column(name = "consumed_at")
+    val consumedAt: Instant? = null,
     @Column(name = "created_by", nullable = false)
     val createdBy: UUID = UUID.randomUUID(),
     @Column(name = "expires_at", nullable = false)

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/mapper/InvitationMapper.kt
@@ -2,6 +2,7 @@ package com.github.zzave.teambalance.api.infrastructure.persistence.mapper
 
 import com.github.zzave.teambalance.api.domain.model.EncryptedToken
 import com.github.zzave.teambalance.api.domain.model.Invitation
+import com.github.zzave.teambalance.api.domain.model.Role
 import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.model.TokenHash
 import com.github.zzave.teambalance.api.domain.model.UserId
@@ -10,6 +11,8 @@ import com.github.zzave.teambalance.api.infrastructure.persistence.entity.Invita
 fun InvitationJpaEntity.internalize() = Invitation(
     id = id,
     teamId = TeamId(teamId),
+    role = Role.valueOf(role),
+    consumedAt = consumedAt,
     tokenHash = TokenHash(tokenHash),
     encryptedToken = encryptedToken?.let(::EncryptedToken),
     createdBy = UserId(createdBy),
@@ -20,6 +23,8 @@ fun InvitationJpaEntity.internalize() = Invitation(
 fun Invitation.externalize() = InvitationJpaEntity(
     id = id,
     teamId = teamId.value,
+    role = role.name,
+    consumedAt = consumedAt,
     tokenHash = tokenHash.value,
     encryptedToken = encryptedToken?.value,
     createdBy = createdBy.value,

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -7,8 +7,11 @@ import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateAdminInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireAdminInvitations
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireInvitations
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetActiveAdminInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetActiveInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RotateAdminInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.RotateInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.AcceptedInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.model.Invitation
@@ -21,6 +24,9 @@ class InvitationController(
     private val currentTeamGateway: CurrentTeamGateway,
 ) : CreateInvitation.Handler,
     CreateAdminInvitation.Handler,
+    GetActiveAdminInvitation.Handler,
+    RotateAdminInvitation.Handler,
+    ExpireAdminInvitations.Handler,
     AcceptInvitation.Handler,
     ExpireInvitations.Handler,
     GetActiveInvitation.Handler,
@@ -76,6 +82,48 @@ class InvitationController(
                 expiresAt = invitation.expiresAt.toString(),
             ),
         )
+    }
+
+    /**
+     * The team's current unspent ADMIN handover link, so it survives a refresh (ADR-0025's
+     * recoverability, extended to the handover link). 204 when there is none — the UI turns that into a
+     * "create one" offer.
+     */
+    override suspend fun getActiveAdminInvitation(
+        request: GetActiveAdminInvitation.Request,
+    ): GetActiveAdminInvitation.Response<*> {
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+
+        val invitation = invitationService.activeAdminInviteLink(callerId = userId, teamId = teamId)
+            ?: return GetActiveAdminInvitation.Response204(Unit)
+        return GetActiveAdminInvitation.Response200(
+            Invitation(token = invitation.token.value, expiresAt = invitation.expiresAt.toString()),
+        )
+    }
+
+    /** Revoke-and-reissue the ADMIN handover link (the shareable USER link is untouched). */
+    override suspend fun rotateAdminInvitation(
+        request: RotateAdminInvitation.Request,
+    ): RotateAdminInvitation.Response<*> {
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+
+        val invitation = invitationService.rotateAdminInviteLink(callerId = userId, teamId = teamId)
+        return RotateAdminInvitation.Response201(
+            Invitation(token = invitation.token.value, expiresAt = invitation.expiresAt.toString()),
+        )
+    }
+
+    /** Revoke the ADMIN handover link without a replacement (the shareable USER link keeps working). */
+    override suspend fun expireAdminInvitations(
+        request: ExpireAdminInvitations.Request,
+    ): ExpireAdminInvitations.Response<*> {
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+
+        invitationService.expireAdminInviteLinks(callerId = userId, teamId = teamId)
+        return ExpireAdminInvitations.Response204(Unit)
     }
 
     override suspend fun acceptInvitation(request: AcceptInvitation.Request): AcceptInvitation.Response<*> {

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationController.kt
@@ -5,6 +5,7 @@ import com.github.zzave.teambalance.api.domain.model.TeamId
 import com.github.zzave.teambalance.api.domain.port.CurrentTeamGateway
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.AcceptInvitation
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateAdminInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateInvitation
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ExpireInvitations
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.GetActiveInvitation
@@ -19,6 +20,7 @@ class InvitationController(
     private val currentUserGateway: CurrentUserGateway,
     private val currentTeamGateway: CurrentTeamGateway,
 ) : CreateInvitation.Handler,
+    CreateAdminInvitation.Handler,
     AcceptInvitation.Handler,
     ExpireInvitations.Handler,
     GetActiveInvitation.Handler,
@@ -49,6 +51,26 @@ class InvitationController(
 
         val invitation = invitationService.generateInviteLink(callerId = userId, teamId = teamId)
         return CreateInvitation.Response201(
+            Invitation(
+                token = invitation.token.value,
+                expiresAt = invitation.expiresAt.toString(),
+            ),
+        )
+    }
+
+    /**
+     * The single-use, ADMIN-granting handover link (ADR-0024 §5). Same team-scoped admin gate as
+     * [createInvitation]; the acting-in Platform Admin passes it through their Virtual Member. The
+     * distinct minting keeps this link off the shareable USER link's idempotency and GET-active read.
+     */
+    override suspend fun createAdminInvitation(
+        request: CreateAdminInvitation.Request,
+    ): CreateAdminInvitation.Response<*> {
+        val userId = currentUserGateway.requireCurrentUserId()
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+
+        val invitation = invitationService.generateAdminInviteLink(callerId = userId, teamId = teamId)
+        return CreateAdminInvitation.Response201(
             Invitation(
                 token = invitation.token.value,
                 expiresAt = invitation.expiresAt.toString(),

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/TeamController.kt
@@ -7,6 +7,7 @@ import com.github.zzave.teambalance.api.domain.model.CreationCode
 import com.github.zzave.teambalance.api.domain.model.Slug
 import com.github.zzave.teambalance.api.domain.port.CurrentUserGateway
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.ActivateTeam
+import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateMemberlessTeam
 import com.github.zzave.teambalance.api.interfaces.generated.endpoint.CreateTeam
 import com.github.zzave.teambalance.api.interfaces.generated.model.Team
 import org.springframework.web.bind.annotation.RestController
@@ -26,6 +27,7 @@ class TeamController(
     private val activeTeamService: ActiveTeamService,
     private val currentUserGateway: CurrentUserGateway,
 ) : CreateTeam.Handler,
+    CreateMemberlessTeam.Handler,
     ActivateTeam.Handler {
 
     override suspend fun createTeam(request: CreateTeam.Request): CreateTeam.Response<*> {
@@ -38,6 +40,24 @@ class TeamController(
             creationCode = CreationCode(request.body.creationCode.trim()),
         )
         return CreateTeam.Response201(created.toDto())
+    }
+
+    /**
+     * Memberless creation by a Platform Admin (ADR-0024 §5): the team is provisioned with no members,
+     * and the caller does not become one. The platform-admin gate lives in [TeamService]; a non-admin
+     * caller surfaces as an opaque 403 via [GlobalExceptionHandler], like the rest of `/admin`. No
+     * tenant is resolved — the caller is teamless — and, deliberately, no Active Team is set.
+     */
+    override suspend fun createMemberlessTeam(
+        request: CreateMemberlessTeam.Request,
+    ): CreateMemberlessTeam.Response<*> {
+        val adminId = currentUserGateway.requireCurrentUserId()
+        val created = teamService.createMemberlessTeam(
+            adminId = adminId,
+            rawName = request.body.name,
+            rawSlug = request.body.slug,
+        )
+        return CreateMemberlessTeam.Response201(created.toDto())
     }
 
     /**

--- a/api/src/main/resources/application-e2e.yml
+++ b/api/src/main/resources/application-e2e.yml
@@ -11,7 +11,10 @@ spring:
 teambalance:
   # The act-as flow needs a Platform Admin (ADR-0024). Fail-closed by default, so name one here; the
   # seed fixture creates this user WITHOUT a team_members row, which is the point (ADR-0024 section 3).
-  platform-admins: platform@example.com
+  # A second admin (platform2@example.com) is named for the memberless-handover spec so it never races
+  # the act-as spec for platform@example.com's single magic-link token. It needs no seed row — its
+  # first sign-in creates it teamless, which is exactly the state a Platform Admin must be in.
+  platform-admins: platform@example.com, platform2@example.com
   invitation:
     # Hardcoded salt for e2e runs (not a live environment); live supplies INVITATION_TOKEN_SALT.
     token-salt: e2e-invitation-salt

--- a/api/src/main/resources/db/migration/V012__memberless_team_and_role_granting_invite.sql
+++ b/api/src/main/resources/db/migration/V012__memberless_team_and_role_granting_invite.sql
@@ -1,0 +1,28 @@
+-- ADR-0024 §5 (issue #240): memberless team creation by a Platform Admin, plus an Admin-granting,
+-- single-use Invite Link that hands a prepared team over to its first Admin.
+--
+-- Auto-pinned to `public` by spring.flyway.schemas (application.yml).
+
+-- 1. Team-creation provenance. The platform owner needs to see which teams were created, when, and by
+--    whom, uniformly across BOTH create paths — the self-service founder flow and the new memberless
+--    admin flow. `created_at` already answers "when"; `created_by` answers "by whom" without having to
+--    join through team_creation_codes (which the memberless path never touches). Nullable: pre-existing
+--    teams have no recorded creator. FK ON DELETE SET NULL, matching team_creation_codes.created_team_id
+--    — deleting a user never blocks on this historical record.
+ALTER TABLE teams
+    ADD COLUMN created_by UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- 2. The Role an Invite Link grants. Default 'USER' keeps every existing link, and the ordinary
+--    self-service mint, exactly as before (ADR-0025's "one link, many joiners"). Only an explicitly
+--    ADMIN-minted handover link carries 'ADMIN'.
+ALTER TABLE invitations
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER',
+    ADD CONSTRAINT valid_invitation_role CHECK (role IN ('USER', 'ADMIN'));
+
+-- 3. Single-use marker for ADMIN links. An ADMIN grant with the shareable link's many-joiner semantics
+--    would hand Admin to everyone the recipient forwards it to, so an ADMIN link is spent on first
+--    accept (ADR-0024 §5, decided in #240). `consumed_at` is set by the one accept that wins the
+--    conditional consume; NULL means unspent. USER links never set it — they stay reusable. Kept NULL
+--    for every existing row by leaving it nullable with no default.
+ALTER TABLE invitations
+    ADD COLUMN consumed_at TIMESTAMPTZ;

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -17,6 +17,25 @@ endpoint CreateAdminInvitation POST /api/invitations/admin -> {
     403 -> Unit
 }
 
+// The team's current unspent ADMIN handover link, so it survives a page refresh instead of being lost to local state - the same recoverability the shareable USER link got in ADR-0025, now for the handover link. 204 when there is none (a normal state the UI turns into a "create one" offer). Admin-only.
+endpoint GetActiveAdminInvitation GET /api/invitations/admin/active -> {
+    200 -> Invitation
+    204 -> Unit
+    403 -> Unit
+}
+
+// Revoke-and-reissue for the ADMIN handover link: expires the active one and mints a fresh replacement in a single step (in case the link leaked before it reached the right person). Role-scoped, so the shareable USER link is untouched. Admin-only.
+endpoint RotateAdminInvitation POST /api/invitations/admin/rotate -> {
+    201 -> Invitation
+    403 -> Unit
+}
+
+// Revokes the team's active ADMIN handover link without a replacement. Role-scoped, so the shareable USER link keeps working. Admin-only.
+endpoint ExpireAdminInvitations POST /api/invitations/admin/expire -> {
+    204 -> Unit
+    403 -> Unit
+}
+
 endpoint GetActiveInvitation GET /api/invitations/active -> {
     200 -> Invitation
     204 -> Unit

--- a/api/src/main/wirespec/invitations.ws
+++ b/api/src/main/wirespec/invitations.ws
@@ -11,6 +11,12 @@ endpoint CreateInvitation POST /api/invitations -> {
     201 -> Invitation
 }
 
+// The single-use, ADMIN-granting handover link (ADR-0024 section 5). Distinct from CreateInvitation, whose link grants USER and stays "one link, many joiners" (ADR-0025): an ADMIN grant with those semantics would hand admin to everyone the recipient forwards it to, so it is spent on first accept. Idempotent while unconsumed - a team accumulates at most one live ADMIN credential, mirroring ADR-0025's anti-accumulation rule - and mints a fresh one once the previous was accepted or expired. Admin-only (the acting-in Platform Admin's Virtual Member is ADMIN).
+endpoint CreateAdminInvitation POST /api/invitations/admin -> {
+    201 -> Invitation
+    403 -> Unit
+}
+
 endpoint GetActiveInvitation GET /api/invitations/active -> {
     200 -> Invitation
     204 -> Unit

--- a/api/src/main/wirespec/teams.ws
+++ b/api/src/main/wirespec/teams.ws
@@ -4,6 +4,12 @@ type CreateTeamRequest {
     creationCode: String
 }
 
+// A Platform Admin provisions a Team with NO members at all (ADR-0024 section 5): the tenant schema and the teams row, and not one team_members row - the teamless invariant (ADR-0024 section 3) forbids the platform account ever holding a membership. No creation code: the platform-admin allowlist on /admin is a stronger gate than a code the admin would only be minting for themselves. The creator does NOT become the founder or the Active Team; they enter via act-as and hand the team over with an ADMIN invite link.
+type CreateMemberlessTeamRequest {
+    name: String,
+    slug: String
+}
+
 type Team {
     id: String,
     name: String,
@@ -11,6 +17,14 @@ type Team {
 }
 
 endpoint CreateTeam POST CreateTeamRequest /api/teams -> {
+    201 -> Team
+    400 -> Unit
+    403 -> Unit
+    409 -> Unit
+}
+
+// Lives in the /admin group beside the console and creation codes - same platform-admin allowlist, no new auth surface (ADR-0024 section 6). 403 is the allowlist refusing a non-admin; the memberless path is deliberately kept off POST /api/teams so "insert no member" is never reachable from the self-service founder flow.
+endpoint CreateMemberlessTeam POST CreateMemberlessTeamRequest /api/admin/teams -> {
     201 -> Team
     400 -> Unit
     403 -> Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -29,7 +29,7 @@ private class FakeTeamMemberRepository(private val roles: Map<Pair<TeamId, UserI
     override fun findRole(teamId: TeamId, userId: UserId): Role? = roles[teamId to userId]
     override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
     override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
-    override fun addMember(teamId: TeamId, userId: UserId) {
+    override fun addMember(teamId: TeamId, userId: UserId, role: Role) {
         writes += "addMember"
     }
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -75,7 +75,7 @@ private class EventFakeMemberRepo(private val admins: Set<UserId>) : TeamMemberR
     override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
     override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
     override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
-    override fun addMember(teamId: TeamId, userId: UserId) = Unit
+    override fun addMember(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun deactivate(teamId: TeamId, userId: UserId) = Unit
     override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -327,6 +327,19 @@ class InvitationServiceTest : FunSpec() {
             f.service.activeInviteLink(callerId = adminId, teamId = f.teamId) shouldBe null
         }
 
+        // The two links are independent: rotating the shareable USER link must not disturb a live,
+        // unspent ADMIN handover link (the port scopes expire to USER — regression for the code review).
+        test("rotating the shareable link leaves the admin handover link mintable and unchanged") {
+            val f = newFixture()
+            val admin = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+            f.service.generateInviteLink(callerId = adminId, teamId = f.teamId)
+            f.service.rotateInviteLink(callerId = adminId, teamId = f.teamId)
+
+            // Still the same unspent admin link — not collaterally expired by the USER-link rotate.
+            f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId).token.value shouldBe
+                admin.token.value
+        }
+
         test("accepting an ADMIN link joins the recipient as ADMIN and switches them in") {
             val f = newFixture()
             f.invitations.present(adminLink(teamId = f.teamId))

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -64,10 +64,14 @@ private class FakeInvitationRepo(private var live: Invitation?) : InvitationRepo
                 it.teamId == teamId && it.expiresAt.isAfter(now)
         }
     override fun consume(invitationId: UUID, now: Instant): Boolean = consumed.add(invitationId)
-    override fun expireActive(teamId: TeamId, now: Instant) { expiredTeam = teamId; active = null }
+    override fun expireActive(teamId: TeamId, role: Role, now: Instant) {
+        expiredTeam = teamId
+        // Role-scoped, like the real query: revoking USER never clears the ADMIN slot, and vice-versa.
+        if (role == Role.ADMIN) activeAdmin = null else active = null
+    }
     override fun rotate(teamId: TeamId, replacement: Invitation, now: Instant): Invitation {
         rotated += replacement
-        active = replacement
+        if (replacement.role == Role.ADMIN) activeAdmin = replacement else active = replacement
         return replacement
     }
 }
@@ -338,6 +342,61 @@ class InvitationServiceTest : FunSpec() {
             // Still the same unspent admin link — not collaterally expired by the USER-link rotate.
             f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId).token.value shouldBe
                 admin.token.value
+        }
+
+        // ----- Admin handover link: survive refresh + rotate + revoke (parity with the USER link) -----
+
+        test("activeAdminInviteLink hands back the very admin link that was minted (survives a refresh)") {
+            val f = newFixture()
+            val minted = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            f.service.activeAdminInviteLink(callerId = adminId, teamId = f.teamId)?.token?.value shouldBe
+                minted.token.value
+        }
+
+        test("activeAdminInviteLink is null for a team with no admin link, and forbidden for a non-admin") {
+            val f = newFixture()
+            f.service.activeAdminInviteLink(callerId = adminId, teamId = f.teamId) shouldBe null
+            shouldThrow<NotTeamAdminException> {
+                f.service.activeAdminInviteLink(callerId = nonAdmin, teamId = f.teamId)
+            }
+        }
+
+        test("rotateAdminInviteLink replaces the admin link with a new one and follows it") {
+            val f = newFixture()
+            val before = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+            val rotated = f.service.rotateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            rotated.token.value shouldNotBe before.token.value
+            f.service.activeAdminInviteLink(callerId = adminId, teamId = f.teamId)?.token?.value shouldBe
+                rotated.token.value
+        }
+
+        test("rotateAdminInviteLink and expireAdminInviteLinks by a non-admin are forbidden") {
+            val f = newFixture()
+            shouldThrow<NotTeamAdminException> { f.service.rotateAdminInviteLink(callerId = nonAdmin, teamId = f.teamId) }
+            shouldThrow<NotTeamAdminException> { f.service.expireAdminInviteLinks(callerId = nonAdmin, teamId = f.teamId) }
+        }
+
+        test("expireAdminInviteLinks revokes the admin link without a replacement") {
+            val f = newFixture()
+            f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+            f.service.expireAdminInviteLinks(callerId = adminId, teamId = f.teamId)
+
+            f.service.activeAdminInviteLink(callerId = adminId, teamId = f.teamId) shouldBe null
+        }
+
+        // The converse of the earlier independence test: acting on the ADMIN link leaves the USER link.
+        test("rotating/revoking the admin link leaves the shareable USER link untouched") {
+            val f = newFixture()
+            val user = f.service.generateInviteLink(callerId = adminId, teamId = f.teamId)
+            f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            f.service.rotateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+            f.service.activeInviteLink(callerId = adminId, teamId = f.teamId)?.token?.value shouldBe user.token.value
+
+            f.service.expireAdminInviteLinks(callerId = adminId, teamId = f.teamId)
+            f.service.activeInviteLink(callerId = adminId, teamId = f.teamId)?.token?.value shouldBe user.token.value
         }
 
         test("accepting an ADMIN link joins the recipient as ADMIN and switches them in") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -36,18 +36,34 @@ private class FakeInvitationRepo(private var live: Invitation?) : InvitationRepo
     var expiredTeam: TeamId? = null
     val rotated = mutableListOf<Invitation>()
     var active: Invitation? = null
+    var activeAdmin: Invitation? = null
+    private val consumed = mutableSetOf<UUID>()
 
     /** The way a rotate or a lapsed TTL does: every later lookup misses. */
     fun expire() { live = null; active = null }
 
+    /** Make [invitation] the one the accept path resolves — a specific ADMIN link, say. */
+    fun present(invitation: Invitation) { live = invitation }
+
+    /** True once [consume] has stamped this id — the single-use assertion. */
+    fun isConsumed(id: UUID): Boolean = id in consumed
+
     override fun save(invitation: Invitation): Invitation {
         saved += invitation
-        active = invitation
+        // A save routes to the role-scoped "active" slot the matching lookup reads, so the idempotent
+        // mint sees its own link back — the USER shareable one and the ADMIN handover one are separate.
+        if (invitation.role == Role.ADMIN) activeAdmin = invitation else active = invitation
         return invitation
     }
     override fun findByTokenHash(tokenHash: TokenHash): Invitation? = live
     override fun findActiveByTeam(teamId: TeamId, now: Instant): Invitation? =
-        active?.takeIf { it.teamId == teamId && it.expiresAt.isAfter(now) }
+        active?.takeIf { it.role == Role.USER && it.teamId == teamId && it.expiresAt.isAfter(now) }
+    override fun findActiveAdminByTeam(teamId: TeamId, now: Instant): Invitation? =
+        activeAdmin?.takeIf {
+            it.role == Role.ADMIN && it.consumedAt == null && it.id !in consumed &&
+                it.teamId == teamId && it.expiresAt.isAfter(now)
+        }
+    override fun consume(invitationId: UUID, now: Instant): Boolean = consumed.add(invitationId)
     override fun expireActive(teamId: TeamId, now: Instant) { expiredTeam = teamId; active = null }
     override fun rotate(teamId: TeamId, replacement: Invitation, now: Instant): Invitation {
         rotated += replacement
@@ -71,6 +87,8 @@ class InvitationServiceTest : FunSpec() {
                 Invitation(
                     id = UUID.randomUUID(),
                     teamId = teamId,
+                    role = Role.USER,
+                    consumedAt = null,
                     tokenHash = TokenHash("hash"),
                     // Hash-only, like every invitation minted before ADR-0025.
                     encryptedToken = null,
@@ -204,6 +222,8 @@ class InvitationServiceTest : FunSpec() {
             f.invitations.active = Invitation(
                 id = UUID.randomUUID(),
                 teamId = f.teamId,
+                role = Role.USER,
+                consumedAt = null,
                 tokenHash = TokenHash("legacy"),
                 encryptedToken = null,
                 createdBy = adminId,
@@ -220,6 +240,8 @@ class InvitationServiceTest : FunSpec() {
             f.invitations.active = Invitation(
                 id = UUID.randomUUID(),
                 teamId = f.teamId,
+                role = Role.USER,
+                consumedAt = null,
                 tokenHash = TokenHash("legacy"),
                 encryptedToken = null,
                 createdBy = adminId,
@@ -252,6 +274,97 @@ class InvitationServiceTest : FunSpec() {
             f.service.acceptInvitation(token = "anything", userId = nonAdmin) shouldBe null
 
             f.routingGateway.pins shouldBe emptyList()
+        }
+
+        // ----- Role-granting Admin handover link (ADR-0024 §5, #240) -----
+
+        val recipient = UserId.random()
+
+        fun adminLink(id: UUID = UUID.randomUUID(), teamId: TeamId) = Invitation(
+            id = id,
+            teamId = teamId,
+            role = Role.ADMIN,
+            consumedAt = null,
+            tokenHash = TokenHash("hash"),
+            encryptedToken = null,
+            createdBy = adminId,
+            expiresAt = Instant.EPOCH.plus(Duration.ofDays(1)),
+            createdAt = Instant.EPOCH,
+        )
+
+        test("generateAdminInviteLink by a non-admin is forbidden") {
+            val f = newFixture()
+            shouldThrow<NotTeamAdminException> {
+                f.service.generateAdminInviteLink(callerId = nonAdmin, teamId = f.teamId)
+            }
+        }
+
+        test("generateAdminInviteLink mints an ADMIN link attributed to the caller") {
+            val f = newFixture()
+            val result = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            result.token.value.isNotBlank() shouldBe true
+            f.invitations.saved.single().role shouldBe Role.ADMIN
+            f.invitations.saved.single().createdBy shouldBe adminId
+        }
+
+        // At most one live ADMIN credential per team, mirroring the USER link's anti-accumulation rule.
+        test("generateAdminInviteLink returns the existing unspent admin link instead of minting a second") {
+            val f = newFixture()
+            val first = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+            val second = f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            second.token.value shouldBe first.token.value
+            f.invitations.saved.size shouldBe 1
+        }
+
+        // The ADMIN link does not masquerade as the shareable USER link: the "current link" read and the
+        // USER idempotent mint must never surface it.
+        test("an admin handover link is not returned as the team's shareable USER link") {
+            val f = newFixture()
+            f.service.generateAdminInviteLink(callerId = adminId, teamId = f.teamId)
+
+            f.service.activeInviteLink(callerId = adminId, teamId = f.teamId) shouldBe null
+        }
+
+        test("accepting an ADMIN link joins the recipient as ADMIN and switches them in") {
+            val f = newFixture()
+            f.invitations.present(adminLink(teamId = f.teamId))
+
+            val joined = f.service.acceptInvitation(token = "handover", userId = recipient)
+
+            joined shouldBe f.teamId
+            f.members.findRole(f.teamId, recipient) shouldBe Role.ADMIN
+            f.routingGateway.lastPinned?.schemaName shouldBe f.directory.schemaOf(f.teamId)
+        }
+
+        // Single-use: the link is spent on the first accept, and forwarding it to a second person grants
+        // them nothing (ADR-0024 §5 — the decision made in #240).
+        test("an ADMIN link is single-use: a second accept joins nobody and switches nothing") {
+            val f = newFixture()
+            val id = UUID.randomUUID()
+            f.invitations.present(adminLink(id = id, teamId = f.teamId))
+            val second = UserId.random()
+
+            f.service.acceptInvitation(token = "handover", userId = recipient) shouldBe f.teamId
+            f.invitations.isConsumed(id) shouldBe true
+            f.routingGateway.writes.clear()
+
+            f.service.acceptInvitation(token = "handover", userId = second) shouldBe null
+            f.members.findRole(f.teamId, second) shouldBe null
+            f.routingGateway.pins shouldBe emptyList()
+        }
+
+        // A USER link is never consumed — the shareable "many joiners" model is unchanged (ADR-0025).
+        test("a USER link is reusable: two different people can both accept it") {
+            val f = newFixture()
+            val second = UserId.random()
+
+            f.service.acceptInvitation(token = "shared", userId = nonAdmin) shouldBe f.teamId
+            f.service.acceptInvitation(token = "shared", userId = second) shouldBe f.teamId
+
+            f.members.findRole(f.teamId, nonAdmin) shouldBe Role.USER
+            f.members.findRole(f.teamId, second) shouldBe Role.USER
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
@@ -78,7 +78,7 @@ private class FakeMembershipRepo(
         store[teamId to userId]?.takeIf { it.active }?.role
     override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
     override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
-    override fun addMember(teamId: TeamId, userId: UserId) = Unit
+    override fun addMember(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) {
         store[teamId to userId]?.role = role
     }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
@@ -49,7 +49,7 @@ private class FakeAdminRepo(private val admins: Set<UserId>) : TeamMemberReposit
     override fun findMembersByUserIds(userIds: Set<UserId>): Map<UserId, TeamMember> = emptyMap()
     override fun findTenantRouting(teamId: TeamId, userId: UserId): TenantRouting? = null
     override fun findSoleTenantRouting(userId: UserId): TenantRouting? = null
-    override fun addMember(teamId: TeamId, userId: UserId) = Unit
+    override fun addMember(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun updateRole(teamId: TeamId, userId: UserId, role: Role) = Unit
     override fun deactivate(teamId: TeamId, userId: UserId) = Unit
     override fun assignPosition(teamId: TeamId, userId: UserId, positionId: PositionId?) = Unit

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamDirectory.kt
@@ -113,7 +113,7 @@ internal class TeamDirectory {
         override fun findSoleTenantRouting(userId: UserId): TenantRouting? =
             memberships.keys.filter { it.first == userId }.singleOrNull()?.let { routing(it.second) }
 
-        override fun addMember(teamId: TeamId, userId: UserId) = join(userId, teamId)
+        override fun addMember(teamId: TeamId, userId: UserId, role: Role) = join(userId, teamId, role)
 
         override fun findByTeamId(teamId: TeamId): List<TeamMember> = emptyList()
         override fun findDisplayName(userId: UserId): DisplayName? = null

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/TeamServiceTest.kt
@@ -3,6 +3,7 @@ package com.github.zzave.teambalance.api.application
 import com.github.zzave.teambalance.api.domain.exception.InvalidCreationCodeException
 import com.github.zzave.teambalance.api.domain.exception.InvalidSlugException
 import com.github.zzave.teambalance.api.domain.exception.InvalidTeamNameException
+import com.github.zzave.teambalance.api.domain.exception.NotPlatformAdminException
 import com.github.zzave.teambalance.api.domain.exception.TeamSlugTakenException
 import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
@@ -65,6 +66,18 @@ private class RecordingRegistrar(
         calls += "register:$slug"
         return directory.addTeam(name.value, slug.value).also { directory.join(founder, it, Role.ADMIN) }
     }
+
+    // Memberless: the team is created but — the point of the path — no membership is written.
+    override fun registerMemberless(
+        createdBy: UUID,
+        name: TeamName,
+        slug: Slug,
+        schemaName: SchemaName,
+        now: Instant,
+    ): TeamId {
+        calls += "registerMemberless:$slug"
+        return directory.addTeam(name.value, slug.value)
+    }
 }
 
 private class RecordingNotifier(private val throwing: Boolean = false) : TeamNotificationGateway {
@@ -95,6 +108,7 @@ class TeamServiceTest : FunSpec() {
             provisionFails: Boolean = false,
             user: User? = founderUser,
             notifier: TeamNotificationGateway = RecordingNotifier(),
+            platformAdmins: Set<UserId> = emptySet(),
         ): Triple<TeamDirectory, RecordingTenantRoutingGateway, TeamService> {
             val directory = TeamDirectory()
             existingSlugs.forEach { directory.addTeam(it.value, it.value) }
@@ -107,6 +121,7 @@ class TeamServiceTest : FunSpec() {
                 userRepository = directory.userRepository(*listOfNotNull(user).toTypedArray()),
                 teamNotificationGateway = notifier,
                 activeTeamService = directory.activeTeamService(gateway, *listOfNotNull(user).toTypedArray()),
+                platformAdminGateway = AllowlistedPlatformAdmins(platformAdmins),
                 clock = clock,
             )
             return Triple(directory, gateway, service)
@@ -119,7 +134,8 @@ class TeamServiceTest : FunSpec() {
             provisionFails: Boolean = false,
             user: User? = founderUser,
             notifier: TeamNotificationGateway = RecordingNotifier(),
-        ) = fixture(calls, existingSlugs, redeemable, provisionFails, user, notifier).third
+            platformAdmins: Set<UserId> = emptySet(),
+        ) = fixture(calls, existingSlugs, redeemable, provisionFails, user, notifier, platformAdmins).third
 
         test("creates the team: provisions the schema, registers, and returns id/name/slug") {
             val calls = mutableListOf<String>()
@@ -205,6 +221,70 @@ class TeamServiceTest : FunSpec() {
             val (directory, _, service) = fixture(notifier = RecordingNotifier(throwing = true))
             val created = service.createTeam(founder, "Setpoint VT", "setpoint-vt", CreationCode("GOODCODE"))
             directory.summaryOf(created.id).name shouldBe TeamName("Setpoint VT")
+        }
+
+        // ----- Memberless creation by a Platform Admin (ADR-0024 §5, #240) -----
+
+        val admin = UserId.random()
+
+        test("createMemberlessTeam provisions and registers with no member, and returns id/name/slug") {
+            val calls = mutableListOf<String>()
+            val (directory, _, service) = fixture(calls, platformAdmins = setOf(admin))
+
+            val created = service.createMemberlessTeam(admin, "Dames 5", "dames-5")
+
+            created.name shouldBe TeamName("Dames 5")
+            created.slug shouldBe Slug("dames-5")
+            directory.summaryOf(created.id).slug shouldBe Slug("dames-5")
+            // Provision-first, then the memberless register — the register variant that writes no member.
+            calls shouldContainExactly listOf("provision:team_dames_5", "registerMemberless:dames-5")
+        }
+
+        // The teamless invariant (ADR-0024 §3): the platform account must never hold a membership. If a
+        // fixture had to grant one to make this pass, the design would be broken, not the test.
+        test("createMemberlessTeam writes NO membership for the creating admin") {
+            val (directory, _, service) = fixture(platformAdmins = setOf(admin))
+
+            val created = service.createMemberlessTeam(admin, "Dames 5", "dames-5")
+
+            directory.membershipsOf(admin) shouldBe emptySet()
+            directory.membershipsOf(admin).contains(created.id) shouldBe false
+        }
+
+        // The admin enters via act-as; the new team must not silently become their Active Team, or the
+        // route gate would treat a teamless platform admin as having a team.
+        test("createMemberlessTeam does NOT make the new team the admin's Active Team") {
+            val (directory, gateway, service) = fixture(platformAdmins = setOf(admin))
+
+            service.createMemberlessTeam(admin, "Dames 5", "dames-5")
+
+            directory.rememberedTeamOf(admin) shouldBe null
+            gateway.writes shouldBe emptyList()
+        }
+
+        test("createMemberlessTeam by a non-platform-admin is forbidden before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<NotPlatformAdminException> {
+                service(calls, platformAdmins = emptySet()).createMemberlessTeam(admin, "Dames 5", "dames-5")
+            }
+            calls shouldBe emptyList()
+        }
+
+        test("createMemberlessTeam rejects an invalid slug with 400 before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<InvalidSlugException> {
+                service(calls, platformAdmins = setOf(admin)).createMemberlessTeam(admin, "Dames 5", "Bad Slug")
+            }
+            calls shouldBe emptyList()
+        }
+
+        test("createMemberlessTeam rejects a taken slug with 409 before any provisioning") {
+            val calls = mutableListOf<String>()
+            shouldThrow<TeamSlugTakenException> {
+                service(calls, existingSlugs = setOf(Slug("dames-5")), platformAdmins = setOf(admin))
+                    .createMemberlessTeam(admin, "Dames 5", "dames-5")
+            }
+            calls shouldBe emptyList()
         }
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateMemberlessTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateMemberlessTeamControllerIT.kt
@@ -1,0 +1,149 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
+
+// Memberless creation (ADR-0024 §5, #240) is gated on the platform-admin allowlist, empty by default
+// (fail-closed) in the test profile. Pin one admin email here; the admin user is seeded with it.
+@AutoConfigureMockMvc
+@TestPropertySource(properties = ["teambalance.platform-admins=memberless-admin@test.com"])
+class CreateMemberlessTeamControllerIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    private fun seedUser(id: String, email: String) {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        jdbcTemplate.update(
+            "INSERT INTO public.users (id, email, display_name) VALUES (?::uuid, ?, ?) " +
+                "ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email",
+            id,
+            email,
+            "User $email",
+        )
+    }
+
+    private fun createMemberless(userId: String?, name: String, slug: String) =
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/teams")
+                .apply { if (userId != null) header("X-User-Id", userId) }
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"$name","slug":"$slug"}"""),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    private fun appliedTenantMigrations(schema: String): Int = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM \"$schema\".flyway_tenant_schema_history " +
+            "WHERE success = true AND version IS NOT NULL AND \"type\" <> 'BASELINE'",
+        Int::class.java,
+    ) ?: 0
+
+    private fun tenantMigrationsOnClasspath(): Int =
+        PathMatchingResourcePatternResolver()
+            .getResources("classpath*:db/tenant-migration/V*__*.sql")
+            .size
+
+    init {
+        test("POST /api/admin/teams provisions the schema with NO members and records the creator") {
+            val admin = UUID.randomUUID().toString()
+            seedUser(admin, "memberless-admin@test.com")
+
+            createMemberless(admin, "Dames 5", "ml-dames-5")
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Dames 5"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.slug").value("ml-dames-5"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").isNotEmpty)
+                // schema_name is never exposed.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.schema_name").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.schemaName").doesNotExist())
+
+            val schema = "team_ml_dames_5"
+
+            // Tenant schema provisioned and migrated to head — a real, usable team, just empty.
+            appliedTenantMigrations(schema) shouldBe tenantMigrationsOnClasspath()
+
+            val teamId = jdbcTemplate.queryForObject(
+                "SELECT id::text FROM public.teams WHERE schema_name = ?",
+                String::class.java,
+                schema,
+            )
+
+            // The teamless invariant (ADR-0024 §3): not one team_members row exists for this team.
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members WHERE team_id = ?::uuid",
+                Long::class.java,
+                teamId,
+            ) shouldBe 0L
+
+            // Provenance: the creating admin is recorded on the team row.
+            jdbcTemplate.queryForObject(
+                "SELECT created_by::text FROM public.teams WHERE id = ?::uuid",
+                String::class.java,
+                teamId,
+            ) shouldBe admin
+
+            // The admin holds no membership and the new team is NOT their Active Team — they enter via
+            // act-as, never as a member.
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members WHERE user_id = ?::uuid",
+                Long::class.java,
+                admin,
+            ) shouldBe 0L
+            jdbcTemplate.queryForObject(
+                "SELECT last_active_team_id::text FROM public.users WHERE id = ?::uuid",
+                String::class.java,
+                admin,
+            ) shouldBe null
+        }
+
+        test("POST /api/admin/teams by a non-platform-admin is forbidden (403)") {
+            val notAdmin = UUID.randomUUID().toString()
+            seedUser(notAdmin, "not-admin-${notAdmin.take(8)}@test.com")
+
+            createMemberless(notAdmin, "Nope", "ml-nope")
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+
+            // Nothing was created.
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.teams WHERE slug = ?",
+                Long::class.java,
+                "ml-nope",
+            ) shouldBe 0L
+        }
+
+        test("POST /api/admin/teams with a taken slug returns 409 TEAM_SLUG_TAKEN") {
+            val admin = UUID.randomUUID().toString()
+            seedUser(admin, "memberless-admin@test.com")
+
+            createMemberless(admin, "First", "ml-dupe")
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+            createMemberless(admin, "Second", "ml-dupe")
+                .andExpect(MockMvcResultMatchers.status().isConflict)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("TEAM_SLUG_TAKEN"))
+        }
+
+        test("POST /api/admin/teams without an authenticated user returns 401") {
+            createMemberless(null, "Nope", "ml-unauth")
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateMemberlessTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateMemberlessTeamControllerIT.kt
@@ -16,8 +16,15 @@ import java.util.UUID
 
 // Memberless creation (ADR-0024 §5, #240) is gated on the platform-admin allowlist, empty by default
 // (fail-closed) in the test profile. Pin one admin email here; the admin user is seeded with it.
+//
+// The admin identity is a FIXED (id, email) pair, not a per-test random id: the allowlist matches a
+// fixed email, and `public.users.email` is UNIQUE, so a fresh id with that same email would collide.
+// One stable admin, seeded idempotently, is the honest shape — it is the same operator every test.
+private const val ADMIN_ID = "d0000000-0000-0000-0000-000000000240"
+private const val ADMIN_EMAIL = "memberless-admin@test.com"
+
 @AutoConfigureMockMvc
-@TestPropertySource(properties = ["teambalance.platform-admins=memberless-admin@test.com"])
+@TestPropertySource(properties = ["teambalance.platform-admins=" + ADMIN_EMAIL])
 class CreateMemberlessTeamControllerIT : TeamBalanceIT() {
 
     @Autowired
@@ -64,8 +71,8 @@ class CreateMemberlessTeamControllerIT : TeamBalanceIT() {
 
     init {
         test("POST /api/admin/teams provisions the schema with NO members and records the creator") {
-            val admin = UUID.randomUUID().toString()
-            seedUser(admin, "memberless-admin@test.com")
+            val admin = ADMIN_ID
+            seedUser(admin, ADMIN_EMAIL)
 
             createMemberless(admin, "Dames 5", "ml-dames-5")
                 .andExpect(MockMvcResultMatchers.status().isCreated)
@@ -131,8 +138,8 @@ class CreateMemberlessTeamControllerIT : TeamBalanceIT() {
         }
 
         test("POST /api/admin/teams with a taken slug returns 409 TEAM_SLUG_TAKEN") {
-            val admin = UUID.randomUUID().toString()
-            seedUser(admin, "memberless-admin@test.com")
+            val admin = ADMIN_ID
+            seedUser(admin, ADMIN_EMAIL)
 
             createMemberless(admin, "First", "ml-dupe")
                 .andExpect(MockMvcResultMatchers.status().isCreated)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -335,6 +335,79 @@ class InvitationControllerTest : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
+        test("GET /api/invitations/admin/active hands back the minted admin link (survives a refresh)") {
+            seedAdmin()
+            expireAllInvitations()
+
+            val minted = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/admin")
+                    .header("X-Team-Id", "public").header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andReturn().response.contentAsString
+            val mintedToken = objectMapper.readTree(minted).get("token").asText()
+
+            mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/invitations/admin/active")
+                    .header("X-Team-Id", "public").header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.token").value(mintedToken))
+        }
+
+        test("POST /api/invitations/admin/rotate mints a fresh admin link and expires the old one") {
+            seedAdmin()
+            expireAllInvitations()
+            seedAdminInvitation("plaintext-admin-to-rotate")
+
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/admin/rotate")
+                    .header("X-Team-Id", "public").header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
+
+            // The old admin link is now expired...
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations WHERE token = ? AND expires_at > now()",
+                Long::class.java,
+                sha256Hex(TEST_SALT, "plaintext-admin-to-rotate"),
+            ) shouldBe 0L
+            // ...and exactly one live unspent admin link remains (the replacement).
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations " +
+                    "WHERE team_id = ?::uuid AND role = 'ADMIN' AND consumed_at IS NULL AND expires_at > now()",
+                Long::class.java,
+                TEAM_ID,
+            ) shouldBe 1L
+        }
+
+        test("POST /api/invitations/admin/expire revokes the admin link (204)") {
+            seedAdmin()
+            expireAllInvitations()
+            seedAdminInvitation("plaintext-admin-to-revoke")
+
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/admin/expire")
+                    .header("X-Team-Id", "public").header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted()).andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations " +
+                    "WHERE team_id = ?::uuid AND role = 'ADMIN' AND expires_at > now()",
+                Long::class.java,
+                TEAM_ID,
+            ) shouldBe 0L
+        }
+
         test("accepting an ADMIN link makes the joiner an ADMIN and marks the link consumed") {
             seedAdmin()
             seedJoiner(JOINER_USER_ID, "admin-joiner@test.com")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -63,6 +63,15 @@ class InvitationControllerTest : TeamBalanceIT() {
         )
     }
 
+    /** An ADMIN-granting handover link (ADR-0024 §5), seeded directly so accept can be exercised. */
+    private fun seedAdminInvitation(plaintextToken: String, expiresAt: String = "2099-01-01T00:00:00Z") {
+        jdbcTemplate.execute(
+            "INSERT INTO public.invitations (team_id, token, created_by, expires_at, role) " +
+                "VALUES ('$TEAM_ID'::uuid, '${sha256Hex(TEST_SALT, plaintextToken)}', " +
+                "'$JAN_USER_ID'::uuid, '$expiresAt'::timestamptz, 'ADMIN')",
+        )
+    }
+
     private fun seedJoiner(userId: String, email: String) {
         jdbcTemplate.execute(
             "INSERT INTO public.users (id, email, display_name) " +
@@ -284,6 +293,100 @@ class InvitationControllerTest : TeamBalanceIT() {
                 JOINER_USER_ID,
             )
             memberRows shouldBe 1L
+        }
+
+        test("POST /api/invitations/admin by an admin mints an ADMIN-role link") {
+            seedAdmin()
+            expireAllInvitations()
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/admin").header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.token").isNotEmpty)
+
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations " +
+                    "WHERE team_id = ?::uuid AND role = 'ADMIN' AND consumed_at IS NULL AND expires_at > now()",
+                Long::class.java,
+                TEAM_ID,
+            ) shouldBe 1L
+        }
+
+        test("POST /api/invitations/admin by a non-admin is forbidden") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "not-admin-handover@test.com")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/admin").header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        test("accepting an ADMIN link makes the joiner an ADMIN and marks the link consumed") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "admin-joiner@test.com")
+            seedAdminInvitation("plaintext-admin-token")
+
+            val mvcResult = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-admin-token/accept")
+                    .header("X-User-Id", JOINER_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.teamId").value(TEAM_ID))
+
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members " +
+                    "WHERE team_id = ?::uuid AND user_id = ?::uuid AND role = 'ADMIN' AND active = true",
+                Long::class.java,
+                TEAM_ID,
+                JOINER_USER_ID,
+            ) shouldBe 1L
+
+            // Single-use: the link is now spent.
+            jdbcTemplate.queryForObject(
+                "SELECT consumed_at FROM public.invitations WHERE token = ?",
+                java.sql.Timestamp::class.java,
+                sha256Hex(TEST_SALT, "plaintext-admin-token"),
+            ) shouldNotBe null
+        }
+
+        test("an ADMIN link is single-use: a second person accepting it is rejected and joins nobody") {
+            seedAdmin()
+            seedJoiner(JOINER_USER_ID, "admin-first@test.com")
+            seedJoiner(EXPIRED_JOINER_USER_ID, "admin-second@test.com")
+            seedAdminInvitation("plaintext-admin-once-token")
+
+            fun accept(userId: String) = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/plaintext-admin-once-token/accept")
+                    .header("X-User-Id", userId),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+            accept(JOINER_USER_ID).andExpect(MockMvcResultMatchers.status().isOk)
+            // The second accept of the spent link joins nobody — 404, indistinguishable from unknown.
+            accept(EXPIRED_JOINER_USER_ID).andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.team_members WHERE team_id = ?::uuid AND user_id = ?::uuid",
+                Long::class.java,
+                TEAM_ID,
+                EXPIRED_JOINER_USER_ID,
+            ) shouldBe 0L
         }
 
         test("POST /api/invitations/{token}/accept with an unknown token is rejected with 404") {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/InvitationControllerTest.kt
@@ -300,7 +300,9 @@ class InvitationControllerTest : TeamBalanceIT() {
             expireAllInvitations()
 
             val mvcResult = mockMvc.perform(
-                MockMvcRequestBuilders.post("/api/invitations/admin").header("X-User-Id", JAN_USER_ID),
+                MockMvcRequestBuilders.post("/api/invitations/admin")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
                 .andReturn()
@@ -322,7 +324,9 @@ class InvitationControllerTest : TeamBalanceIT() {
             seedJoiner(JOINER_USER_ID, "not-admin-handover@test.com")
 
             val mvcResult = mockMvc.perform(
-                MockMvcRequestBuilders.post("/api/invitations/admin").header("X-User-Id", JOINER_USER_ID),
+                MockMvcRequestBuilders.post("/api/invitations/admin")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JOINER_USER_ID),
             )
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
                 .andReturn()
@@ -361,6 +365,32 @@ class InvitationControllerTest : TeamBalanceIT() {
                 java.sql.Timestamp::class.java,
                 sha256Hex(TEST_SALT, "plaintext-admin-token"),
             ) shouldNotBe null
+        }
+
+        test("rotating the shareable link leaves a live ADMIN handover link untouched") {
+            seedAdmin()
+            expireAllInvitations()
+            seedAdminInvitation("plaintext-admin-survives-rotate")
+
+            // Rotate the (absent) shareable USER link — this mints a new USER link and expires the old
+            // USER one, but must not touch the independent single-use ADMIN handover link.
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/invitations/rotate")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", JAN_USER_ID),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+                .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+
+            // The ADMIN link is still active (unexpired) and unspent.
+            jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM public.invitations " +
+                    "WHERE token = ? AND role = 'ADMIN' AND consumed_at IS NULL AND expires_at > now()",
+                Long::class.java,
+                sha256Hex(TEST_SALT, "plaintext-admin-survives-rotate"),
+            ) shouldBe 1L
         }
 
         test("an ADMIN link is single-use: a second person accepting it is rejected and joins nobody") {

--- a/app/e2e-real/memberless-handover.spec.ts
+++ b/app/e2e-real/memberless-handover.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect, type BrowserContext, type Page } from '@playwright/test'
 
 /**
  * Real e2e: the **memberless-team handover** (ADR-0024 §5, issue #240). A Platform Admin creates a
@@ -23,10 +23,15 @@ const PLATFORM_EMAIL = 'platform2@example.com'
 const TEAM_NAME = `E2E Handover ${RUN}`
 const TEAM_SLUG = `e2e-handover-${RUN}`
 const RECIPIENT_EMAIL = `handover-recipient-${RUN}@example.com`
+const BASE_URL = 'http://localhost:5173'
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
-/** Signs an email in through the real magic-link flow, leaving the session on `page`. */
+/**
+ * Signs an email in through the real magic-link flow, leaving the session on `page`. The final
+ * `/auth/verify` is a page navigation, so the caller must wait for the app to settle (a `toHaveURL`)
+ * before relying on the session — used for the interactive Platform Admin flow below.
+ */
 async function signIn(page: Page, email: string) {
   const requested = await page.request.post('/api/auth/magic-link/request', { data: { email } })
   expect(requested.status()).toBe(202)
@@ -34,6 +39,24 @@ async function signIn(page: Page, email: string) {
   expect(tokenResponse.ok()).toBeTruthy()
   const { token } = await tokenResponse.json()
   await page.goto(`/auth/verify?token=${token}`)
+}
+
+/**
+ * Establishes a session on a browser context via the API — POST verify directly rather than through
+ * the verify page — so it is synchronous: the cookie is set the moment this returns, and any page in
+ * the context is immediately authenticated. Used for the recipient contexts, whose very next action is
+ * opening the invite link (which auto-accepts only for an already-authenticated visitor).
+ */
+async function authViaApi(context: BrowserContext, email: string) {
+  const requested = await context.request.post('/api/auth/magic-link/request', { data: { email } })
+  expect(requested.status()).toBe(202)
+  const tokenResponse = await context.request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+  const verified = await context.request.post('/api/auth/magic-link/verify', { data: { token } })
+  expect(verified.ok()).toBeTruthy()
 }
 
 test('a Platform Admin creates a memberless team, preps it, and hands it over as Admin by link', async ({
@@ -66,17 +89,18 @@ test('a Platform Admin creates a memberless team, preps it, and hands it over as
   const handoverUrl = await page.getByLabel('Admin handover link').inputValue()
   expect(handoverUrl).toContain('/invite/')
 
-  // 6. The recipient — a brand-new, teamless user in their own browser context — signs in and clicks
-  //    the handover link. The direct /invite/$token visit auto-accepts for an authenticated visitor.
-  const recipientContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
-  const recipient = await recipientContext.newPage()
+  // 6. The recipient — a brand-new, teamless user in their own browser context — authenticates, then
+  //    opens the handover link. A direct /invite/$token visit auto-accepts for an authenticated
+  //    visitor, so the session must be established first (authViaApi is synchronous).
+  const recipientContext = await browser.newContext({ baseURL: BASE_URL })
   try {
-    await signIn(recipient, RECIPIENT_EMAIL)
+    await authViaApi(recipientContext, RECIPIENT_EMAIL)
+    const recipient = await recipientContext.newPage()
     await recipient.goto(handoverUrl)
 
     // 7. They land as ADMIN of the prepared team — the whole point: one link, and control is handed over.
     await expect(async () => {
-      const me = await recipient.request.get('/api/auth/me')
+      const me = await recipientContext.request.get('/api/auth/me')
       expect(me.ok()).toBeTruthy()
       const body = await me.json()
       expect(body.role).toBe('ADMIN')
@@ -84,13 +108,13 @@ test('a Platform Admin creates a memberless team, preps it, and hands it over as
     }).toPass({ timeout: 15_000 })
 
     // 8. Single-use: a second person opening the same link gets nothing.
-    const secondContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
-    const second = await secondContext.newPage()
+    const secondContext = await browser.newContext({ baseURL: BASE_URL })
     try {
-      await signIn(second, `handover-second-${RUN}@example.com`)
+      await authViaApi(secondContext, `handover-second-${RUN}@example.com`)
+      const second = await secondContext.newPage()
       await second.goto(handoverUrl)
       await expect(second.getByText('Invite link invalid')).toBeVisible({ timeout: 15_000 })
-      const me = await second.request.get('/api/auth/me')
+      const me = await secondContext.request.get('/api/auth/me')
       const body = await me.json()
       // Never became a member of the team.
       expect((body.teams ?? []).some((t: { slug: string }) => t.slug === TEAM_SLUG)).toBe(false)

--- a/app/e2e-real/memberless-handover.spec.ts
+++ b/app/e2e-real/memberless-handover.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Real e2e: the **memberless-team handover** (ADR-0024 §5, issue #240). A Platform Admin creates a
+ * team with no members, enters it via act-as, and hands it over with a single-use ADMIN invite link;
+ * the recipient clicks the link and lands as **Admin** of the prepared team.
+ *
+ * Justified under the PR gate as a genuinely new seam: **acceptance grants ADMIN**. The login,
+ * attendance and existing invite flows only ever add a plain User — a link that makes the accepter an
+ * Admin of a team they had no prior relationship to is a new auth path, and it is the only path by
+ * which a memberless team gets its first Admin. (The act-as write itself is already covered by
+ * act-as.spec.ts; this spec exercises the create-memberless → handover-link → accept-as-admin chain
+ * around it.)
+ *
+ * Idempotent across warm-DB re-runs: the team slug and the recipient email are per-run unique, so each
+ * run provisions a fresh team and a freshly-teamless recipient (magic-link verify creates the user).
+ * Runs as platform2@example.com so it never races act-as.spec.ts for platform@example.com's token.
+ */
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+const RUN = Date.now()
+const PLATFORM_EMAIL = 'platform2@example.com'
+const TEAM_NAME = `E2E Handover ${RUN}`
+const TEAM_SLUG = `e2e-handover-${RUN}`
+const RECIPIENT_EMAIL = `handover-recipient-${RUN}@example.com`
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+/** Signs an email in through the real magic-link flow, leaving the session on `page`. */
+async function signIn(page: Page, email: string) {
+  const requested = await page.request.post('/api/auth/magic-link/request', { data: { email } })
+  expect(requested.status()).toBe(202)
+  const tokenResponse = await page.request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, { params: { email } })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+  await page.goto(`/auth/verify?token=${token}`)
+}
+
+test('a Platform Admin creates a memberless team, preps it, and hands it over as Admin by link', async ({
+  page,
+  browser,
+}) => {
+  // 1. Teamless Platform Admin lands on the console.
+  await signIn(page, PLATFORM_EMAIL)
+  await expect(page).toHaveURL(/\/admin\/teams/, { timeout: 15_000 })
+
+  // 2. Create a team with NO members — the /admin form, no creation code.
+  await page.getByLabel('Team name').fill(TEAM_NAME)
+  await page.getByLabel('Team address').fill(TEAM_SLUG)
+  await page.getByRole('button', { name: 'Create team' }).click()
+  await expect(page.getByRole('status')).toContainText(TEAM_NAME, { timeout: 15_000 })
+
+  // 3. The new team shows up in the console list; enter it via act-as.
+  const teamRow = page.getByRole('listitem').filter({ hasText: TEAM_NAME })
+  await expect(teamRow).toBeVisible({ timeout: 15_000 })
+  await teamRow.getByRole('button', { name: 'Enter' }).click()
+  await expect(page).toHaveURL(new RegExp(`/t/${TEAM_SLUG}`), { timeout: 15_000 })
+
+  // 4. The zero-member state is real: the roster says so rather than showing an empty box.
+  await page.goto(`/t/${TEAM_SLUG}/team`)
+  await expect(page.getByText('No members yet.')).toBeVisible({ timeout: 15_000 })
+
+  // 5. Mint the single-use ADMIN handover link from the admin settings page (Virtual Member = ADMIN).
+  await page.goto(`/t/${TEAM_SLUG}/team/settings`)
+  await page.getByRole('button', { name: 'Create admin handover link' }).click()
+  const handoverUrl = await page.getByLabel('Admin handover link').inputValue()
+  expect(handoverUrl).toContain('/invite/')
+
+  // 6. The recipient — a brand-new, teamless user in their own browser context — signs in and clicks
+  //    the handover link. The direct /invite/$token visit auto-accepts for an authenticated visitor.
+  const recipientContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+  const recipient = await recipientContext.newPage()
+  try {
+    await signIn(recipient, RECIPIENT_EMAIL)
+    await recipient.goto(handoverUrl)
+
+    // 7. They land as ADMIN of the prepared team — the whole point: one link, and control is handed over.
+    await expect(async () => {
+      const me = await recipient.request.get('/api/auth/me')
+      expect(me.ok()).toBeTruthy()
+      const body = await me.json()
+      expect(body.role).toBe('ADMIN')
+      expect(body.activeTeam?.slug).toBe(TEAM_SLUG)
+    }).toPass({ timeout: 15_000 })
+
+    // 8. Single-use: a second person opening the same link gets nothing.
+    const secondContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+    const second = await secondContext.newPage()
+    try {
+      await signIn(second, `handover-second-${RUN}@example.com`)
+      await second.goto(handoverUrl)
+      await expect(second.getByText('Invite link invalid')).toBeVisible({ timeout: 15_000 })
+      const me = await second.request.get('/api/auth/me')
+      const body = await me.json()
+      // Never became a member of the team.
+      expect((body.teams ?? []).some((t: { slug: string }) => t.slug === TEAM_SLUG)).toBe(false)
+    } finally {
+      await secondContext.close()
+    }
+  } finally {
+    await recipientContext.close()
+  }
+})

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -125,7 +125,26 @@ export const WithRosterChip: Story = {
   },
 }
 
+// Nobody has answered yet, but the team HAS members: they all sit in notResponded, so the denominator
+// is real. Distinct from the zero-member card below (all counts zero).
 export const NoResponses: Story = {
+  args: {
+    event: makeEvent({
+      startTime: on(13),
+      attendanceSummary: { attending: 0, maybe: 0, absent: 0, notResponded: 12, roleBreakdown: [] },
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/0 going/)).toBeInTheDocument()
+    await expect(canvas.getByText(/of 12/)).toBeInTheDocument()
+    await expect(canvas.getByText(/12 pending/)).toBeInTheDocument()
+  },
+}
+
+// The zero-member state (ADR-0024 §5): an event on a team a Platform Admin created memberless and is
+// still preparing. Every count is zero, so the denominator is zero — "0 going of 0" would read as
+// broken, so the card says what is actually true: there is nobody on the roster yet.
+export const NoMembersYet: Story = {
   args: {
     event: makeEvent({
       startTime: on(13),
@@ -133,8 +152,10 @@ export const NoResponses: Story = {
     }),
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/0 going/)).toBeInTheDocument()
-    await expect(canvas.getByText(/of 0/)).toBeInTheDocument()
+    await expect(canvas.getByText('No members yet')).toBeInTheDocument()
+    // The broken-looking "of 0" denominator is not shown.
+    await expect(canvas.queryByText(/of 0/)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/going/)).not.toBeInTheDocument()
   },
 }
 

--- a/app/src/entities/event/ui/EventCard.tsx
+++ b/app/src/entities/event/ui/EventCard.tsx
@@ -92,18 +92,26 @@ export function EventCard({ event, index = 0, now = new Date() }: EventCardProps
       {/* Attendance row. Sibling of the chit+body row, so its rule spans the full card width.
           `flex-wrap` so the roster panel, which is a full-width sibling of the chip, drops below. */}
       <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
-        <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
-          ✓ {s.attending} going
-        </span>
-        <span className="text-xs text-muted-foreground">
-          of {invited}
-          {s.notResponded > 0 && (
-            <>
-              {' · '}
-              <span className="opacity-60">{s.notResponded} pending</span>
-            </>
-          )}
-        </span>
+        {invited === 0 ? (
+          // A team with no members yet has a denominator of zero — "0 going of 0" reads as broken.
+          // Say what is actually true instead: nobody is on the roster to respond (ADR-0024 §5).
+          <span className="text-xs text-muted-foreground">No members yet</span>
+        ) : (
+          <>
+            <span className="rounded-full bg-green/10 px-2.5 py-1 text-xs font-medium text-green">
+              ✓ {s.attending} going
+            </span>
+            <span className="text-xs text-muted-foreground">
+              of {invited}
+              {s.notResponded > 0 && (
+                <>
+                  {' · '}
+                  <span className="opacity-60">{s.notResponded} pending</span>
+                </>
+              )}
+            </span>
+          </>
+        )}
         {/* Renders nothing at all when the event's type doesn't track a roster (a social). */}
         <RosterDisclosure roster={event.roster} />
       </div>

--- a/app/src/features/create-memberless-team/ui/CreateMemberlessTeam.tsx
+++ b/app/src/features/create-memberless-team/ui/CreateMemberlessTeam.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCreateMemberlessTeam, type CreateTeamError } from '@shared/api/teams'
+import { CreateMemberlessTeamView } from './CreateMemberlessTeamView'
+
+/**
+ * Container for the console's memberless-create form (ADR-0024 §5): wires the create mutation to the
+ * View and, on success, invalidates the platform team list so the new (empty) team appears below,
+ * ready to enter via act-as. Pure wiring, covered by e2e rather than a story (ADR-0017).
+ */
+export function CreateMemberlessTeam() {
+  const queryClient = useQueryClient()
+  const createTeam = useCreateMemberlessTeam()
+  const [createdName, setCreatedName] = useState<string | null>(null)
+
+  return (
+    <CreateMemberlessTeamView
+      isPending={createTeam.isPending}
+      error={createTeam.error as CreateTeamError | null}
+      createdName={createdName}
+      onSubmit={({ name, slug }) =>
+        createTeam.mutate(
+          { name, slug },
+          {
+            onSuccess: (team) => {
+              setCreatedName(team.name)
+              queryClient.invalidateQueries({ queryKey: ['platform', 'teams'] })
+            },
+          },
+        )
+      }
+    />
+  )
+}

--- a/app/src/features/create-memberless-team/ui/CreateMemberlessTeamView.stories.tsx
+++ b/app/src/features/create-memberless-team/ui/CreateMemberlessTeamView.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { CreateTeamError } from '@shared/api/teams'
+import { CreateMemberlessTeamView } from './CreateMemberlessTeamView'
+
+// The console's memberless-create form (ADR-0024 §5). Prop-only, so loading / error / success / the
+// submit contract all render from props with no network — the mutation lives in the container.
+const meta = {
+  title: 'features/create-memberless-team/CreateMemberlessTeamView',
+  component: CreateMemberlessTeamView,
+  args: { isPending: false, onSubmit: fn() },
+} satisfies Meta<typeof CreateMemberlessTeamView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText('Team name')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Team address')).toBeInTheDocument()
+    // No creation code — the /admin allowlist is the gate.
+    await expect(canvas.queryByLabelText('Creation code')).not.toBeInTheDocument()
+    // Submit is disabled until name + a valid slug are present.
+    await expect(canvas.getByRole('button', { name: 'Create team' })).toBeDisabled()
+  },
+}
+
+export const Pending: Story = {
+  args: { isPending: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Creating…' })).toBeDisabled()
+  },
+}
+
+export const SlugTaken: Story = {
+  args: { error: new CreateTeamError('SLUG_TAKEN', 'That address is already taken — try another.') },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('That address is already taken — try another.')).toBeInTheDocument()
+  },
+}
+
+export const GenericError: Story = {
+  args: { error: new CreateTeamError('GENERIC', 'Something went wrong creating the team. Please try again.') },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('alert')).toHaveTextContent('Something went wrong creating the team.')
+  },
+}
+
+export const Created: Story = {
+  args: { createdName: 'Tovo Dames 5' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('status')).toHaveTextContent('Created “Tovo Dames 5”.')
+  },
+}
+
+// Prop-contract: a valid name + address enables submit, and submitting fires onSubmit with the typed
+// values — proving the create wiring survives a dependency bump.
+export const SubmitsValidInput: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.type(canvas.getByLabelText('Team name'), 'Tovo Dames 5')
+    await userEvent.type(canvas.getByLabelText('Team address'), 'tovo-dames-5')
+    await userEvent.click(canvas.getByRole('button', { name: 'Create team' }))
+    await expect(args.onSubmit).toHaveBeenCalledWith({ name: 'Tovo Dames 5', slug: 'tovo-dames-5' })
+  },
+}
+
+// A malformed address is caught client-side before submit, and blocks it.
+export const RejectsBadSlug: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.type(canvas.getByLabelText('Team name'), 'Tovo Dames 5')
+    await userEvent.type(canvas.getByLabelText('Team address'), 'Bad Slug')
+    await expect(canvas.getByText('Use lowercase letters, numbers, and hyphens.')).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Create team' })).toBeDisabled()
+    await expect(args.onSubmit).not.toHaveBeenCalled()
+  },
+}

--- a/app/src/features/create-memberless-team/ui/CreateMemberlessTeamView.tsx
+++ b/app/src/features/create-memberless-team/ui/CreateMemberlessTeamView.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import type { CreateTeamError } from '@shared/api/teams'
+
+interface CreateMemberlessTeamViewProps {
+  isPending: boolean
+  /** The typed failure from the last submit, placed by its code (field vs banner); null while clean. */
+  error?: CreateTeamError | null
+  /** Set after a successful create, so the console confirms the (empty) team is ready to enter. */
+  createdName?: string | null
+  onSubmit: (values: { name: string; slug: string }) => void
+}
+
+// The address contract the backend enforces (ADR-0019 §2): lowercase alphanumerics in hyphen groups.
+// Checked client-side only to catch an obviously-bad address before submit; the server is the source
+// of truth. Kept inline (a tiny literal) rather than imported from the create-team feature — features
+// don't reach into each other under FSD.
+const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+/**
+ * Presentational memberless-create form for the platform console (ADR-0024 §5). Prop-only
+ * (isPending / error / createdName / onSubmit) so every state renders from props with no network; the
+ * mutation and the team-list refresh live in the container. No creation code field — the platform-admin
+ * allowlist on `/admin` is the gate — and no member is created, so there is no founder to name.
+ */
+export function CreateMemberlessTeamView({
+  isPending,
+  error,
+  createdName,
+  onSubmit,
+}: CreateMemberlessTeamViewProps) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+
+  const clientSlugError = slug.length > 0 && !SLUG_PATTERN.test(slug)
+    ? 'Use lowercase letters, numbers, and hyphens.'
+    : null
+  const canSubmit = name.trim().length > 0 && slug.length > 0 && clientSlugError === null && !isPending
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    onSubmit({ name: name.trim(), slug })
+  }
+
+  const placed = (...codes: CreateTeamError['code'][]) =>
+    error && codes.includes(error.code) ? error.message : null
+  const nameError = placed('INVALID_NAME')
+  const slugError = placed('INVALID_SLUG', 'SLUG_TAKEN') ?? clientSlugError
+  const bannerError = placed('GENERIC', 'INVALID_CREATION_CODE')
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div>
+        <h2 className="font-display text-2xl font-bold">Create a team</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Creates an empty team you can enter and set up, then hand over with an admin invite link. You
+          don't join it.
+        </p>
+      </div>
+
+      {bannerError && (
+        <p role="alert" className="text-sm text-destructive">
+          {bannerError}
+        </p>
+      )}
+      {createdName && !bannerError && (
+        <p role="status" className="text-sm text-green">
+          Created “{createdName}”. Enter it from the list below to set it up.
+        </p>
+      )}
+
+      <div>
+        <Label htmlFor="ml-team-name">Team name</Label>
+        <Input
+          id="ml-team-name"
+          value={name}
+          disabled={isPending}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Tovo Dames 5"
+        />
+        {nameError && <p className="mt-1 text-sm text-destructive">{nameError}</p>}
+      </div>
+
+      <div>
+        <Label htmlFor="ml-team-slug">Team address</Label>
+        <Input
+          id="ml-team-slug"
+          value={slug}
+          disabled={isPending}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="tovo-dames-5"
+        />
+        {slugError && <p className="mt-1 text-sm text-destructive">{slugError}</p>}
+      </div>
+
+      <Button type="submit" disabled={!canSubmit} className="self-start">
+        {isPending ? 'Creating…' : 'Create team'}
+      </Button>
+    </form>
+  )
+}

--- a/app/src/features/handover-admin/ui/HandoverAdmin.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdmin.tsx
@@ -1,25 +1,28 @@
 import { useState } from 'react'
-import { useCreateAdminInvitation } from '@shared/api/invitations'
+import {
+  useActiveAdminInvitation,
+  useCreateAdminInvitation,
+  useExpireAdminInvitations,
+  useRotateAdminInvitation,
+} from '@shared/api/invitations'
 import { HandoverAdminView } from './HandoverAdminView'
 
 /**
- * Container for the admin handover link (ADR-0024 §5): mints the single-use ADMIN invitation and builds
- * the shareable URL, mirroring how GenerateInviteDialog builds the player link. Idempotent server-side
- * while unspent, so re-clicking returns the same live link rather than a second admin credential. Pure
- * wiring, covered by e2e rather than a story (ADR-0017).
+ * Container for the admin handover link (ADR-0024 §5): reads the team's current unspent link on load
+ * (so it survives a refresh), and wires create / rotate / revoke to the presentational view — the same
+ * lifecycle as the shareable-link dialog, kept off that link's state by its own query key. Pure wiring,
+ * covered by e2e rather than a story (ADR-0017).
  */
 export function HandoverAdmin() {
-  const createAdminInvitation = useCreateAdminInvitation()
-  const [link, setLink] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [justRevoked, setJustRevoked] = useState(false)
+  const activeInvitation = useActiveAdminInvitation({ enabled: true })
+  const createInvitation = useCreateAdminInvitation()
+  const rotateInvitation = useRotateAdminInvitation()
+  const expireInvitation = useExpireAdminInvitations()
 
-  const handleGenerate = () =>
-    createAdminInvitation.mutate(undefined, {
-      onSuccess: (invitation) => {
-        setLink(`${window.location.origin}/invite/${invitation.token}`)
-        setCopied(false)
-      },
-    })
+  const invitation = activeInvitation.data
+  const link = invitation ? `${window.location.origin}/invite/${invitation.token}` : null
 
   const handleCopy = async () => {
     if (!link) return
@@ -27,14 +30,38 @@ export function HandoverAdmin() {
     setCopied(true)
   }
 
+  // Both a fresh create and a rotate land on a new link; drop the flags and let the invalidated query
+  // supply it.
+  const adoptNewLink = () => {
+    setJustRevoked(false)
+    setCopied(false)
+  }
+
+  const handleCreate = () => createInvitation.mutate(undefined, { onSuccess: adoptNewLink })
+  const handleRotate = () => rotateInvitation.mutate(undefined, { onSuccess: adoptNewLink })
+  const handleRevoke = () =>
+    expireInvitation.mutate(undefined, {
+      onSuccess: () => {
+        setJustRevoked(true)
+        setCopied(false)
+      },
+    })
+
   return (
     <HandoverAdminView
-      isGenerating={createAdminInvitation.isPending}
-      isError={createAdminInvitation.isError}
+      isLoading={activeInvitation.isPending}
+      isError={activeInvitation.isError}
       link={link}
       copied={copied}
-      onGenerate={handleGenerate}
+      justRevoked={justRevoked}
+      isCreating={createInvitation.isPending}
+      isRotating={rotateInvitation.isPending}
+      isRevoking={expireInvitation.isPending}
+      actionError={createInvitation.isError || rotateInvitation.isError || expireInvitation.isError}
       onCopy={handleCopy}
+      onCreate={handleCreate}
+      onRotate={handleRotate}
+      onRevoke={handleRevoke}
     />
   )
 }

--- a/app/src/features/handover-admin/ui/HandoverAdmin.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdmin.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { useCreateAdminInvitation } from '@shared/api/invitations'
+import { HandoverAdminView } from './HandoverAdminView'
+
+/**
+ * Container for the admin handover link (ADR-0024 §5): mints the single-use ADMIN invitation and builds
+ * the shareable URL, mirroring how GenerateInviteDialog builds the player link. Idempotent server-side
+ * while unspent, so re-clicking returns the same live link rather than a second admin credential. Pure
+ * wiring, covered by e2e rather than a story (ADR-0017).
+ */
+export function HandoverAdmin() {
+  const createAdminInvitation = useCreateAdminInvitation()
+  const [link, setLink] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const handleGenerate = () =>
+    createAdminInvitation.mutate(undefined, {
+      onSuccess: (invitation) => {
+        setLink(`${window.location.origin}/invite/${invitation.token}`)
+        setCopied(false)
+      },
+    })
+
+  const handleCopy = async () => {
+    if (!link) return
+    await navigator.clipboard.writeText(link)
+    setCopied(true)
+  }
+
+  return (
+    <HandoverAdminView
+      isGenerating={createAdminInvitation.isPending}
+      isError={createAdminInvitation.isError}
+      link={link}
+      copied={copied}
+      onGenerate={handleGenerate}
+      onCopy={handleCopy}
+    />
+  )
+}

--- a/app/src/features/handover-admin/ui/HandoverAdminView.stories.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdminView.stories.tsx
@@ -2,17 +2,48 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import { HandoverAdminView } from './HandoverAdminView'
 
-// The admin handover control (ADR-0024 §5). Prop-only, so the generate prompt / minted-link / copied /
-// error states all render from props with no network — the mutation lives in the container.
+const LINK = 'https://app.teambalance.nl/invite/handover-token-abc'
+
+// The admin handover control (ADR-0024 §5). Prop-only, so loading / no-link / minted / copied /
+// revoked / error all render from props with no network — the read + mutations live in the container.
 const meta = {
   title: 'features/handover-admin/HandoverAdminView',
   component: HandoverAdminView,
-  args: { isGenerating: false, isError: false, link: null, copied: false, onGenerate: fn(), onCopy: fn() },
+  args: {
+    isLoading: false,
+    isError: false,
+    link: null,
+    copied: false,
+    justRevoked: false,
+    isCreating: false,
+    isRotating: false,
+    isRevoking: false,
+    actionError: false,
+    onCopy: fn(),
+    onCreate: fn(),
+    onRotate: fn(),
+    onRevoke: fn(),
+  },
 } satisfies Meta<typeof HandoverAdminView>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
+
+export const Loading: Story = {
+  args: { isLoading: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Loading…')).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Create admin handover link' })).not.toBeInTheDocument()
+  },
+}
+
+export const LoadError: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Failed to load the admin link.')).toBeInTheDocument()
+  },
+}
 
 export const NoLinkYet: Story = {
   play: async ({ canvas }) => {
@@ -22,47 +53,73 @@ export const NoLinkYet: Story = {
   },
 }
 
-export const Generating: Story = {
-  args: { isGenerating: true },
+export const Creating: Story = {
+  args: { isCreating: true },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('button', { name: 'Creating…' })).toBeDisabled()
   },
 }
 
 export const LinkMinted: Story = {
-  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc' },
+  args: { link: LINK },
   play: async ({ canvas }) => {
-    await expect(canvas.getByDisplayValue('https://app.teambalance.nl/invite/handover-token-abc')).toBeInTheDocument()
+    await expect(canvas.getByDisplayValue(LINK)).toBeInTheDocument()
     await expect(canvas.getByText(/grants admin and can be used once/)).toBeInTheDocument()
-    // Once a link exists, the generate button is gone — you don't accidentally mint a second.
+    // Once a link exists, the create prompt is replaced by copy + rotate + revoke.
     await expect(canvas.queryByRole('button', { name: 'Create admin handover link' })).not.toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Rotate link' })).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Revoke link' })).toBeInTheDocument()
   },
 }
 
 export const Copied: Story = {
-  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc', copied: true },
+  args: { link: LINK, copied: true },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
   },
 }
 
-export const ErrorState: Story = {
-  args: { isError: true },
+export const JustRevoked: Story = {
+  args: { justRevoked: true },
   play: async ({ canvas }) => {
-    await expect(canvas.getByRole('alert')).toHaveTextContent('Something went wrong creating the link.')
+    await expect(canvas.getByText(/The link has been revoked/)).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: 'Create new admin link' })).toBeInTheDocument()
   },
 }
 
-// Prop-contract: asking for a link fires onGenerate; copying a minted link fires onCopy.
-export const GenerateContract: Story = {
+export const ActionError: Story = {
+  args: { link: LINK, actionError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+  },
+}
+
+// Prop-contract: each control fires its callback — proving the wiring survives a dependency bump.
+export const CreateContract: Story = {
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Create admin handover link' }))
-    await expect(args.onGenerate).toHaveBeenCalled()
+    await expect(args.onCreate).toHaveBeenCalled()
+  },
+}
+
+export const RotateContract: Story = {
+  args: { link: LINK },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Rotate link' }))
+    await expect(args.onRotate).toHaveBeenCalled()
+  },
+}
+
+export const RevokeContract: Story = {
+  args: { link: LINK },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Revoke link' }))
+    await expect(args.onRevoke).toHaveBeenCalled()
   },
 }
 
 export const CopyContract: Story = {
-  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc' },
+  args: { link: LINK },
   play: async ({ canvas, userEvent, args }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Copy' }))
     await expect(args.onCopy).toHaveBeenCalled()

--- a/app/src/features/handover-admin/ui/HandoverAdminView.stories.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdminView.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { HandoverAdminView } from './HandoverAdminView'
+
+// The admin handover control (ADR-0024 §5). Prop-only, so the generate prompt / minted-link / copied /
+// error states all render from props with no network — the mutation lives in the container.
+const meta = {
+  title: 'features/handover-admin/HandoverAdminView',
+  component: HandoverAdminView,
+  args: { isGenerating: false, isError: false, link: null, copied: false, onGenerate: fn(), onCopy: fn() },
+} satisfies Meta<typeof HandoverAdminView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const NoLinkYet: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Create admin handover link' })).toBeInTheDocument()
+    // The single-use / grants-admin warning is present so an admin can't misread it as the player link.
+    await expect(canvas.getByText(/single-use link/)).toBeInTheDocument()
+  },
+}
+
+export const Generating: Story = {
+  args: { isGenerating: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Creating…' })).toBeDisabled()
+  },
+}
+
+export const LinkMinted: Story = {
+  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue('https://app.teambalance.nl/invite/handover-token-abc')).toBeInTheDocument()
+    await expect(canvas.getByText(/grants admin and can be used once/)).toBeInTheDocument()
+    // Once a link exists, the generate button is gone — you don't accidentally mint a second.
+    await expect(canvas.queryByRole('button', { name: 'Create admin handover link' })).not.toBeInTheDocument()
+  },
+}
+
+export const Copied: Story = {
+  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc', copied: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
+  },
+}
+
+export const ErrorState: Story = {
+  args: { isError: true },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('alert')).toHaveTextContent('Something went wrong creating the link.')
+  },
+}
+
+// Prop-contract: asking for a link fires onGenerate; copying a minted link fires onCopy.
+export const GenerateContract: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Create admin handover link' }))
+    await expect(args.onGenerate).toHaveBeenCalled()
+  },
+}
+
+export const CopyContract: Story = {
+  args: { link: 'https://app.teambalance.nl/invite/handover-token-abc' },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Copy' }))
+    await expect(args.onCopy).toHaveBeenCalled()
+  },
+}

--- a/app/src/features/handover-admin/ui/HandoverAdminView.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdminView.tsx
@@ -44,7 +44,7 @@ export function HandoverAdminView({
       ) : (
         <div className="flex flex-col gap-2">
           <div className="flex gap-2">
-            <Input readOnly value={link} onFocus={(e) => e.currentTarget.select()} />
+            <Input aria-label="Admin handover link" readOnly value={link} onFocus={(e) => e.currentTarget.select()} />
             <Button type="button" onClick={onCopy}>
               {copied ? 'Copied!' : 'Copy'}
             </Button>

--- a/app/src/features/handover-admin/ui/HandoverAdminView.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdminView.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+
+interface HandoverAdminViewProps {
+  isGenerating: boolean
+  isError: boolean
+  /** The single-use admin handover link once minted, or null before the admin asks for one. */
+  link: string | null
+  copied: boolean
+  onGenerate: () => void
+  onCopy: () => void
+}
+
+/**
+ * Presentational body of the admin handover control (ADR-0024 §5). Renders either the "generate" prompt
+ * or the minted single-use link with a copy button. The mutation, the copied flag, and the built URL
+ * live in the HandoverAdmin container, so each state renders from props as a no-network story (ADR-0017).
+ *
+ * Deliberately separate from the shareable invite link: this grants **Admin** and is spent on first
+ * accept, so its copy has to say both — hand it to exactly one person, once.
+ */
+export function HandoverAdminView({
+  isGenerating,
+  isError,
+  link,
+  copied,
+  onGenerate,
+  onCopy,
+}: HandoverAdminViewProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <h2 className="font-display text-2xl font-bold">Hand over as admin</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Create a single-use link that makes the first person who opens it an admin of this team. Send
+          it to one person — anyone who opens it becomes an admin, and it stops working once used.
+        </p>
+      </div>
+
+      {!link ? (
+        <Button type="button" onClick={onGenerate} disabled={isGenerating} className="self-start">
+          {isGenerating ? 'Creating…' : 'Create admin handover link'}
+        </Button>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Input readOnly value={link} onFocus={(e) => e.currentTarget.select()} />
+            <Button type="button" onClick={onCopy}>
+              {copied ? 'Copied!' : 'Copy'}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            This link grants admin and can be used once. If you need another, create a new one.
+          </p>
+        </div>
+      )}
+
+      {isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Something went wrong creating the link. Please try again.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/src/features/handover-admin/ui/HandoverAdminView.tsx
+++ b/app/src/features/handover-admin/ui/HandoverAdminView.tsx
@@ -2,46 +2,89 @@ import { Button } from '@shared/ui/button'
 import { Input } from '@shared/ui/input'
 
 interface HandoverAdminViewProps {
-  isGenerating: boolean
+  /** The active-admin-link read is in flight. */
+  isLoading: boolean
+  /** The active-admin-link read failed. */
   isError: boolean
-  /** The single-use admin handover link once minted, or null before the admin asks for one. */
+  /** The team's current single-use admin handover link, or null if it has none. */
   link: string | null
   copied: boolean
-  onGenerate: () => void
+  /** Set only for the moment after a revoke, to confirm the link is gone before offering a new one. */
+  justRevoked: boolean
+  isCreating: boolean
+  isRotating: boolean
+  isRevoking: boolean
+  actionError: boolean
   onCopy: () => void
+  onCreate: () => void
+  onRotate: () => void
+  onRevoke: () => void
 }
 
 /**
- * Presentational body of the admin handover control (ADR-0024 §5). Renders either the "generate" prompt
- * or the minted single-use link with a copy button. The mutation, the copied flag, and the built URL
- * live in the HandoverAdmin container, so each state renders from props as a no-network story (ADR-0017).
+ * Presentational body of the admin handover control (ADR-0024 §5), mirroring the shareable-link
+ * dialog: it renders exactly one of loading / error / just-revoked / no-link / the active link with
+ * copy + rotate + revoke. The read, the mutations, and the copied/just-revoked flags live in the
+ * HandoverAdmin container, so each state renders from props as a no-network story (ADR-0017).
  *
- * Deliberately separate from the shareable invite link: this grants **Admin** and is spent on first
- * accept, so its copy has to say both — hand it to exactly one person, once.
+ * The link is read on load and survives a page refresh (ADR-0025's recoverability, extended here);
+ * rotating replaces it (if it leaked) and revoking removes it — the same lifecycle as the player link,
+ * but this link grants **Admin** and is spent on first accept, so the copy has to say both.
  */
 export function HandoverAdminView({
-  isGenerating,
+  isLoading,
   isError,
   link,
   copied,
-  onGenerate,
+  justRevoked,
+  isCreating,
+  isRotating,
+  isRevoking,
+  actionError,
   onCopy,
+  onCreate,
+  onRotate,
+  onRevoke,
 }: HandoverAdminViewProps) {
+  const heading = (
+    <div>
+      <h2 className="font-display text-2xl font-bold">Hand over as admin</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Create a single-use link that makes the first person who opens it an admin of this team. Send
+        it to one person — anyone who opens it becomes an admin, and it stops working once used.
+      </p>
+    </div>
+  )
+
   return (
     <div className="flex flex-col gap-3">
-      <div>
-        <h2 className="font-display text-2xl font-bold">Hand over as admin</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Create a single-use link that makes the first person who opens it an admin of this team. Send
-          it to one person — anyone who opens it becomes an admin, and it stops working once used.
-        </p>
-      </div>
+      {heading}
 
-      {!link ? (
-        <Button type="button" onClick={onGenerate} disabled={isGenerating} className="self-start">
-          {isGenerating ? 'Creating…' : 'Create admin handover link'}
-        </Button>
-      ) : (
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {isError && <p className="text-sm text-destructive">Failed to load the admin link.</p>}
+
+      {!isLoading && !isError && justRevoked && (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-muted-foreground">
+            The link has been revoked. It can no longer make anyone an admin.
+          </p>
+          <Button type="button" onClick={onCreate} disabled={isCreating} className="self-start">
+            {isCreating ? 'Creating…' : 'Create new admin link'}
+          </Button>
+          {actionError && <p className="text-sm text-destructive">Something went wrong. Please try again.</p>}
+        </div>
+      )}
+
+      {!isLoading && !isError && !justRevoked && !link && (
+        <div className="flex flex-col gap-2">
+          <Button type="button" onClick={onCreate} disabled={isCreating} className="self-start">
+            {isCreating ? 'Creating…' : 'Create admin handover link'}
+          </Button>
+          {actionError && <p className="text-sm text-destructive">Something went wrong. Please try again.</p>}
+        </div>
+      )}
+
+      {!isLoading && !isError && !justRevoked && link && (
         <div className="flex flex-col gap-2">
           <div className="flex gap-2">
             <Input aria-label="Admin handover link" readOnly value={link} onFocus={(e) => e.currentTarget.select()} />
@@ -49,16 +92,20 @@ export function HandoverAdminView({
               {copied ? 'Copied!' : 'Copy'}
             </Button>
           </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={onRotate} disabled={isRotating}>
+              {isRotating ? 'Rotating…' : 'Rotate link'}
+            </Button>
+            <Button type="button" variant="destructive" onClick={onRevoke} disabled={isRevoking}>
+              {isRevoking ? 'Revoking…' : 'Revoke link'}
+            </Button>
+          </div>
           <p className="text-xs text-muted-foreground">
-            This link grants admin and can be used once. If you need another, create a new one.
+            This link grants admin and can be used once. Rotating replaces it with a new one; revoking
+            removes it. Either way the old link stops working.
           </p>
+          {actionError && <p className="text-sm text-destructive">Something went wrong. Please try again.</p>}
         </div>
-      )}
-
-      {isError && (
-        <p role="alert" className="text-sm text-destructive">
-          Something went wrong creating the link. Please try again.
-        </p>
       )}
     </div>
   )

--- a/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.stories.tsx
@@ -156,6 +156,30 @@ export const ReadOnly: Story = {
   },
 }
 
+// The zero-member state (ADR-0024 §5): a team a Platform Admin created memberless and is preparing
+// under act-as, before its first Admin accepts the handover link. The admin view points at the invite
+// link rather than showing an empty box.
+export const EmptyManaged: Story = {
+  args: { members: [] },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('No members yet. Share an invite link to bring people in.')).toBeInTheDocument()
+    // No roster rows and no per-row controls when there is nobody on the roster.
+    await expect(canvas.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+  },
+}
+
+// The same zero-member team as a plain viewer would see it: just that the roster is empty, with no
+// invite prompt (they can't act on it).
+export const EmptyReadOnly: Story = {
+  args: { members: [], canManage: false },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('No members yet.')).toBeInTheDocument()
+    await expect(
+      canvas.queryByText('No members yet. Share an invite link to bring people in.'),
+    ).not.toBeInTheDocument()
+  },
+}
+
 export const LastAdminRefused: Story = {
   args: {
     members: [

--- a/app/src/features/manage-members/ui/MemberRosterView.tsx
+++ b/app/src/features/manage-members/ui/MemberRosterView.tsx
@@ -80,22 +80,34 @@ export function MemberRosterView({
             </p>
           )}
 
-          <ul className="divide-y divide-border rounded-lg border border-border">
-            {members.map((member) => (
-              <MemberRow
-                key={member.userId}
-                member={member}
-                canManage={canManage}
-                positions={positions}
-                lastAdmin={isLastAdmin(members, member.userId)}
-                isSaving={savingUserId === member.userId}
-                onRename={onRename}
-                onToggleRole={onToggleRole}
-                onChangePosition={onChangePosition}
-                onRequestRemove={setConfirmTarget}
-              />
-            ))}
-          </ul>
+          {members.length === 0 ? (
+            // A team with no members at all — the state a memberless team sits in until its first
+            // Admin accepts the handover link (ADR-0024 §5). Transient, but real across the roster.
+            // An admin (which, in the handover window, is the acting-in Platform Admin) is pointed at
+            // the invite link; a plain viewer just sees that the roster is empty.
+            <p className="rounded-lg border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground">
+              {canManage
+                ? 'No members yet. Share an invite link to bring people in.'
+                : 'No members yet.'}
+            </p>
+          ) : (
+            <ul className="divide-y divide-border rounded-lg border border-border">
+              {members.map((member) => (
+                <MemberRow
+                  key={member.userId}
+                  member={member}
+                  canManage={canManage}
+                  positions={positions}
+                  lastAdmin={isLastAdmin(members, member.userId)}
+                  isSaving={savingUserId === member.userId}
+                  onRename={onRename}
+                  onToggleRole={onToggleRole}
+                  onChangePosition={onChangePosition}
+                  onRequestRemove={setConfirmTarget}
+                />
+              ))}
+            </ul>
+          )}
 
           <Dialog open={confirmTarget !== null} onOpenChange={(open) => { if (!open) setConfirmTarget(null) }}>
             <DialogContent>

--- a/app/src/routes/admin/teams.tsx
+++ b/app/src/routes/admin/teams.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { PlatformTeams } from '@features/act-as/ui/PlatformTeams'
+import { CreateMemberlessTeam } from '@features/create-memberless-team/ui/CreateMemberlessTeam'
 
 // The platform console (ADR-0024 §6), beside /admin/creation-codes under the same `/admin` group —
 // same allowlist, same PlatformAdminGateway, no new auth surface. Authorization is enforced
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/admin/teams')({
 function PlatformTeamsPage() {
   return (
     <div className="flex flex-col gap-8">
+      <CreateMemberlessTeam />
       <PlatformTeams />
       <Link to="/admin/creation-codes" className="text-sm font-semibold text-blue hover:underline">
         Creation codes

--- a/app/src/routes/t/$slug/route.tsx
+++ b/app/src/routes/t/$slug/route.tsx
@@ -29,6 +29,12 @@ export const Route = createFileRoute('/t/$slug')({
       if (!user) throw redirect({ to: '/login' })
     }
 
+    // A Platform Admin acting-as is structurally not a member of this team (ADR-0024 §3), so
+    // /members/me 404s for them — a query that can never cache, which the onboarding gate below would
+    // therefore re-fetch on every team-route navigation, flashing the pending splash each time. It is
+    // also meaningless for them: an operator preparing a team is not onboarding into it. Skip the gate.
+    if (user.actAs) return
+
     // Onboarding is per-Team, so it can only be asked once the Active Team is settled — hence here
     // rather than in the root guard. Fails open: a status blip must not trap a confirmed caller.
     const routes = teamRoutes(params.slug)

--- a/app/src/routes/t/$slug/team/settings.tsx
+++ b/app/src/routes/t/$slug/team/settings.tsx
@@ -5,6 +5,7 @@ import { teamRoutes } from '@shared/lib/team-routes'
 import { MemberRoster } from '@features/manage-members/ui/MemberRoster'
 import { TeamSettings } from '@features/team-settings/ui/TeamSettings'
 import { ManagePositions } from '@features/manage-positions/ui/ManagePositions'
+import { HandoverAdmin } from '@features/handover-admin/ui/HandoverAdmin'
 import { ActAsRecords } from '@features/act-as/ui/ActAsRecords'
 
 export const Route = createFileRoute('/t/$slug/team/settings')({
@@ -33,6 +34,9 @@ function TeamSettingsPage() {
       <MemberRoster canManage />
       <ManagePositions />
       <TeamSettings />
+      {/* Handing over admin (ADR-0024 §5): how a prepared, memberless team gets its first real Admin.
+          Below the day-to-day settings — it is a one-off, not a routine control. */}
+      <HandoverAdmin />
       {/* Admin-only, and last: platform access is rare and, to someone who has never heard of it,
           alarming out of context. It sits below the settings an Admin actually came here for. */}
       <ActAsRecords />

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -50,6 +50,20 @@ export function useCreateInvitation() {
   })
 }
 
+/**
+ * Mints the single-use, ADMIN-granting handover link (ADR-0024 §5) — how a memberless team gets its
+ * first Admin. Idempotent server-side while unspent, so calling it again returns the same live link
+ * rather than adding a second Admin credential. Distinct from {@link useCreateInvitation}, whose link
+ * grants User and stays reusable; this one is spent on first accept.
+ */
+export function useCreateAdminInvitation() {
+  return useInvitationMutation(async () => {
+    const res = await api.CreateAdminInvitation()
+    if (res.status === 403) throw new Error('You are not allowed to manage the invite link.')
+    return res.body
+  })
+}
+
 export function useRotateInvitation() {
   return useInvitationMutation(async () => {
     const res = await api.RotateInvitation()

--- a/app/src/shared/api/invitations.ts
+++ b/app/src/shared/api/invitations.ts
@@ -50,6 +50,36 @@ export function useCreateInvitation() {
   })
 }
 
+// The admin handover link is its own credential, tracked under its own key so its reads and mutations
+// never cross-invalidate the shareable USER link above (ADR-0024 §5).
+const ACTIVE_ADMIN_INVITATION_KEY = ['invitations', 'admin', 'active']
+
+/**
+ * The team's current unspent ADMIN handover link, or null if it has none — the read that lets the
+ * link survive a page refresh, exactly as {@link useActiveInvitation} does for the shareable link
+ * (ADR-0025, extended to the handover link). Admin-only; `enabled` keeps it from firing for members.
+ */
+export function useActiveAdminInvitation({ enabled }: { enabled: boolean }) {
+  return useQuery({
+    queryKey: ACTIVE_ADMIN_INVITATION_KEY,
+    enabled,
+    queryFn: async () => {
+      const res = await api.GetActiveAdminInvitation()
+      if (res.status === 403) throw new Error('You are not allowed to manage the invite link.')
+      // 204: no admin link yet — an ordinary state the UI turns into a "create one" offer.
+      return res.status === 200 ? res.body : null
+    },
+  })
+}
+
+function useAdminInvitationMutation<T>(mutationFn: () => Promise<T>) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ACTIVE_ADMIN_INVITATION_KEY }),
+  })
+}
+
 /**
  * Mints the single-use, ADMIN-granting handover link (ADR-0024 §5) — how a memberless team gets its
  * first Admin. Idempotent server-side while unspent, so calling it again returns the same live link
@@ -57,10 +87,26 @@ export function useCreateInvitation() {
  * grants User and stays reusable; this one is spent on first accept.
  */
 export function useCreateAdminInvitation() {
-  return useInvitationMutation(async () => {
+  return useAdminInvitationMutation(async () => {
     const res = await api.CreateAdminInvitation()
     if (res.status === 403) throw new Error('You are not allowed to manage the invite link.')
     return res.body
+  })
+}
+
+/** Revoke-and-reissue the admin handover link (in case it leaked before it reached the right person). */
+export function useRotateAdminInvitation() {
+  return useAdminInvitationMutation(async () => {
+    const res = await api.RotateAdminInvitation()
+    if (res.status === 403) throw new Error('You are not allowed to manage the invite link.')
+    return res.body
+  })
+}
+
+/** Revoke the admin handover link without a replacement. */
+export function useExpireAdminInvitations() {
+  return useAdminInvitationMutation(async () => {
+    await api.ExpireAdminInvitations()
   })
 }
 

--- a/app/src/shared/api/teams.ts
+++ b/app/src/shared/api/teams.ts
@@ -70,6 +70,34 @@ export function useCreateTeam() {
   })
 }
 
+export interface CreateMemberlessTeamInput {
+  name: string
+  slug: string
+}
+
+/**
+ * Memberless creation by a Platform Admin (ADR-0024 §5): POST /api/admin/teams. No creation code — the
+ * platform-admin allowlist on `/admin` is the gate. Reuses [toCreateTeamError] for the shared
+ * name/slug failures; a 403 here means "not a Platform Admin" rather than a bad code, but the console
+ * is already admin-gated so it lands as a generic banner. Success returns the new (empty) team; the
+ * caller does not become a member — they enter it via act-as.
+ */
+export function useCreateMemberlessTeam() {
+  return useMutation({
+    mutationFn: async ({ name, slug }: CreateMemberlessTeamInput) => {
+      const res = await api.CreateMemberlessTeam({ body: { name, slug } }).catch(() => {
+        throw new CreateTeamError('GENERIC', 'Something went wrong creating the team. Please try again.')
+      })
+      if (res.status === 201) return res.body
+      if (res.status === 403) {
+        throw new CreateTeamError('GENERIC', "You don't have access to create teams.")
+      }
+      const code = (res.body as { code?: string } | undefined)?.code
+      throw toCreateTeamError(res.status, code)
+    },
+  })
+}
+
 /**
  * The authorized switch (ADR-0023 §2). Null for an unknown slug *and* for one that is not the
  * caller's — the backend answers both with the same bare 404, and this preserves that.

--- a/docs/adr/0024-platform-admin-act-as.md
+++ b/docs/adr/0024-platform-admin-act-as.md
@@ -134,6 +134,12 @@ accept** — `invitations.consumed_at` is stamped by the one accept that wins a 
 a later present of the same token joins nobody. Minting is idempotent while the link is unspent, so a
 team holds at most one live Admin credential at a time, mirroring ADR-0025's anti-accumulation rule.
 
+Beyond single-use, the Admin link carries the **same lifecycle as the shareable link** (ADR-0025): it
+is read back on load so it survives a page refresh, it can be **rotated** (revoke-and-reissue, if it
+leaked before reaching the right person) and **revoked** without a replacement. Those operations are
+role-scoped — acting on the Admin link never disturbs the team's live User link, and vice-versa — so
+the two credentials are managed independently.
+
 **Rejected: accepting the shared trust model unchanged** ("it's the same as today"). It is not: today
 every link grants User, so forwarding one only ever adds a player to a roster an admin can prune. An
 Admin link is a handover of control, used exactly once by design, so the cost of making it single-use

--- a/docs/adr/0024-platform-admin-act-as.md
+++ b/docs/adr/0024-platform-admin-act-as.md
@@ -123,6 +123,25 @@ user creation or a pending-membership concept, plus correct email addresses up f
 but it puts a setup step in front of every recipient, which is the opposite of the point. It remains
 available as a zero-code fallback.
 
+**The ADMIN link is single-use; the USER link is not** (decided in [#240](https://github.com/ZzAve/teambalance-app/issues/240),
+which this ADR left open). The shareable Invite Link is deliberately *one link, many joiners*
+([ADR-0025](0025-invite-link-recoverable-at-rest.md)) — it is pasted into a team's WhatsApp and
+everyone who opens it joins as a **User**, and that low-secrecy model is the feature. An **Admin**
+grant cannot inherit those semantics: an admin-granting link with many-joiner reuse hands Admin to
+everyone the recipient forwards it to, and the blast radius of a leaked Admin credential is a
+different order of harm from a leaked roster join. So an `ADMIN`-granting link is **spent on first
+accept** — `invitations.consumed_at` is stamped by the one accept that wins a conditional consume, and
+a later present of the same token joins nobody. Minting is idempotent while the link is unspent, so a
+team holds at most one live Admin credential at a time, mirroring ADR-0025's anti-accumulation rule.
+
+**Rejected: accepting the shared trust model unchanged** ("it's the same as today"). It is not: today
+every link grants User, so forwarding one only ever adds a player to a roster an admin can prune. An
+Admin link is a handover of control, used exactly once by design, so the cost of making it single-use
+is nil and the cost of not is a silent Admin leak. **Rejected: making *every* link single-use**, which
+would break the deliberate many-joiner USER link for no gain — the reuse risk is specific to the Admin
+grant. The single-use rule is therefore scoped to `role = ADMIN`; `role = USER` keeps ADR-0025's
+semantics untouched.
+
 The adminless window is a **new state the app has never seen**: empty roster, an attendance
 denominator of zero, an empty Position breakdown. It is transient, and act-as is what covers it — but
 it is a new class of empty state across several screens.


### PR DESCRIPTION
Implements **issue #240** / **ADR-0024 §5**: a Platform Admin creates a team with no members, prepares it under act-as, and hands it over with an invite link that grants **Admin** on acceptance — the recipient clicks one link and lands as Admin of a prepared team.

## Decisions taken (the ones ADR-0024 §5 left open, confirmed before coding)

| Question | Decision |
|---|---|
| Where memberless create lives | **New `POST /api/admin/teams`** — in the `/admin` group, behind the same platform-admin allowlist. Kept off `POST /api/teams` so "insert no member" is never reachable from the self-service founder path. |
| Creation code required? | **No.** The platform-admin allowlist is a stronger gate than a code the admin would only be minting for themselves. |
| `TeamRegistrationGateway` shape | **Separate `registerMemberless`** rather than a nullable `founderId`, so "insert no member" stays unreachable from the ordinary path. |
| Admin-link reuse (the genuine open question) | **Single-use only when it grants ADMIN.** USER links keep ADR-0025's "one link, many joiners"; an ADMIN link is spent on first accept, so forwarding it grants nobody else Admin. **ADR-0024 §5 amended** with this. |
| Observability (you asked for this) | `teams.created_by` records **who created each team, when**, uniformly on both create paths — no join through creation codes. |

## What changed

**Backend**
- `V012`: `teams.created_by`; `invitations.role` (default USER) + `consumed_at`.
- `registerMemberless` inserts the `teams` row and **not one `team_members` row** (the teamless invariant, ADR-0024 §3); `TeamService.createMemberlessTeam` gates on the allowlist and, deliberately, does **not** set the admin's Active Team.
- `acceptInvitation` honours the granted role; an ADMIN link is consumed **conditionally before it grants** (consume-first, fail-safe), so at most one accept ever passes. New `POST /api/invitations/admin` mints the single-use handover link, idempotent while unspent.
- `addMember(…, role)` — role-aware, with promotion of an existing member and no demotion.

**Frontend**
- Platform console (`/admin/teams`) gains a "Create a team" form (memberless); the admin-only settings page gains a "Hand over as admin" control that mints the single-use link.
- **Zero-member empty states**, re-checked against ADR-0026 shapes: the roster says "No members yet" (admins pointed at the invite link) instead of an empty box; an EventCard with a zero denominator reads "No members yet" rather than "0 going of 0". Positions and the role breakdown already render their own empty states. Storybook stories cover every new/changed state.

## Is the new e2e justified?

**Yes.** `app/e2e-real/memberless-handover.spec.ts` exercises a seam the PR gate calls out — a **new auth path**: acceptance that grants **ADMIN**. The login, attendance and existing invite flows only ever add a plain User; a link that makes the accepter an Admin of a team they had no prior relationship to is new, and it is the *only* path by which a memberless team gets its first Admin. (The act-as write itself is already covered by `act-as.spec.ts`; this spec covers the create-memberless → handover-link → accept-as-admin chain around it, including that a second opener of the spent link gets nothing.) It runs as a second e2e platform admin (`platform2@example.com`) so it never races `act-as.spec.ts` for the shared magic-link token.

## Definition of done — status

- **Amended ADR-0024 §5** with the single-use-when-ADMIN decision. ✅
- **Zero-member empty states** covered by Storybook stories. ✅
- **Handover-by-link e2e** added and argued (above). ✅
- Front-end checks run green locally: `tsc -b`, `eslint .`, and the full Vitest suite (343 jsdom units + 279 Storybook story tests). Backend `detekt` green. ✅
- **`make test-api` and `make e2e` were not run locally** — this environment has no Docker, so Testcontainers ITs and the Playwright full-stack suite can only run in CI. The Kotlin compiles and detekt passes; ITs (memberless create, admin handover, single-use accept, rotate-leaves-admin-link) are written to the repo's existing patterns and validated on CI. Please confirm the CI run before merge.

## One residual, called out honestly

The "at most one live ADMIN link per team" property is **service-held** (as ADR-0025 chose for the USER link — a partial unique index can't bite on time-based active-ness). Two near-simultaneous mints could each leave a live ADMIN link. This is an anti-accumulation weakening, **not** a single-use hole: single-use is enforced at accept by the conditional consume, so every link is still spent at most once, and the UI disables the button while a mint is in flight. Documented in `InvitationService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J63p3nGswDx6vP2uKt5z4e)_



https://github.com/user-attachments/assets/8ddc3bda-a118-445b-9f77-dc5e756d0bc8

