### PR TITLE
chore: add Docker daemon startup hook for Claude Code remote sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SessionStart hook: bring up the Docker daemon in Claude Code on the web.
+#
+# Remote sessions ship the Docker CLI but no init system, so /var/run/docker.sock
+# is absent until dockerd is launched by hand. Testcontainers (`make test-api`)
+# and the compose infra (`make db`, `make infra`, `make e2e`) all need it.
+# Local machines run their own Docker, so this is a no-op there.
+set -euo pipefail
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+command -v dockerd >/dev/null 2>&1 || { echo "dockerd not installed — skipping Docker startup"; exit 0; }
+
+# Idempotent: a reachable daemon (resume/clear/compact re-fires this hook) needs nothing.
+if docker info >/dev/null 2>&1; then
+  echo "Docker daemon already running"
+  exit 0
+fi
+
+LOG=/tmp/dockerd.log
+nohup dockerd >"$LOG" 2>&1 &
+
+for _ in $(seq 1 30); do
+  if docker info >/dev/null 2>&1; then
+    echo "Docker daemon ready ($(docker --version))"
+    exit 0
+  fi
+  sleep 1
+done
+
+# Never fail the session over this — report and let the agent decide.
+echo "Docker daemon did not become ready within 30s; see $LOG"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ ci:  ## Run a build in CI
 # --- Infrastructure ---
 
 db: ## Start PostgreSQL only
-	docker-compose up -d postgres
+	docker compose up -d postgres
 
 infra: ## Start all local infrastructure (PostgreSQL + Redis)
-	docker-compose up -d
+	docker compose up -d
 
 infra-down: ## Stop local infrastructure
-	docker-compose down -v
+	docker compose down -v
 
 # --- Run ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -108,7 +108,7 @@ make test                       # test-api + test-app
 ## Real e2e internals
 
 **Entry point:** `app/e2e-real/` + `playwright.real.config.ts`. `make e2e` runs `scripts/e2e.sh`, which:
-1. Reuses whatever is listening on :5432/:6379 (CI service containers) or docker-compose ups them.
+1. Reuses whatever is listening on :5432/:6379 (CI service containers) or `docker compose` ups them.
 2. Boots `bootRun --spring.profiles.active=e2e` and health-gates on `/internal/actuator/health`.
 3. Runs Playwright, then kills the backend by port (the bootRun JVM is a daemon child, not the gradlew pid).
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -2,12 +2,12 @@
 # Orchestrates the real full-stack e2e suite (`make e2e`):
 #   infra (Postgres) → backend via bootRun under the `e2e` profile, health-gated → Playwright.
 #
-# Works both locally (brings docker-compose up if nothing listens on 5432) and in CI
+# Works both locally (brings docker compose up if nothing listens on 5432) and in CI
 # (reuses the workflow's Postgres service container already bound to localhost).
 #
 # Isolation note: the seed fixture is idempotent, and the login flow issues a fresh token per
 # run, so re-runs against a warm DB are safe. For a truly fresh DB locally:
-#   docker-compose down -v && make e2e
+#   docker compose down -v && make e2e
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -19,8 +19,8 @@ port_open() { (exec 3<>"/dev/tcp/localhost/$1") 2>/dev/null && exec 3>&-; }
 
 # --- Infra ---
 if ! port_open 5432; then
-  echo "Postgres not detected on :5432 — starting docker-compose infra"
-  docker-compose up -d
+  echo "Postgres not detected on :5432 — starting docker compose infra"
+  docker compose up -d
 fi
 for _ in $(seq 1 30); do
   port_open 5432 && break


### PR DESCRIPTION
## Summary

Adds automatic Docker daemon initialization for remote Claude Code sessions, and updates documentation to use the modern `docker compose` command syntax (instead of `docker-compose`).

## Changes

- **New SessionStart hook** (`.claude/hooks/session-start.sh`): Automatically starts the Docker daemon in Claude Code remote environments where it's not running by default. The hook is idempotent (skips if already running) and non-blocking (reports but doesn't fail the session if startup times out).
- **New Claude settings** (`.claude/settings.json`): Registers the SessionStart hook to run at session initialization.
- **Documentation updates**: Updated `Makefile`, `scripts/e2e.sh`, and `docs/testing.md` to use `docker compose` (the modern Docker CLI syntax) instead of the deprecated `docker-compose` command.

## Implementation details

The hook:
- Only runs in Claude Code remote sessions (`CLAUDE_CODE_REMOTE=true`)
- Checks if `dockerd` is installed before attempting startup
- Polls for daemon readiness (up to 30s) before returning
- Gracefully degrades if Docker is unavailable or startup fails — allows the session to proceed so the agent can decide how to handle it
- Logs output to `/tmp/dockerd.log` for debugging

This enables `make test-api` (Testcontainers) and `make e2e` (docker compose infra) to work seamlessly in remote Claude Code sessions without manual intervention.

https://claude.ai/code/session_01Sfonw52V8SbSnom9pPbSsD