### PR TITLE
feat: enforce act-as teamless invariant at entry + pin sign-in-closes-grant

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActAsService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/ActAsService.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.exception.PlatformAdminHasMembershipException
 import com.github.zzave.teambalance.api.domain.exception.TeamNotFoundException
 import com.github.zzave.teambalance.api.domain.model.ActAs
 import com.github.zzave.teambalance.api.domain.model.TeamId
@@ -52,6 +53,7 @@ class ActAsService(
      */
     fun enter(userId: UserId, teamId: TeamId): EnteredActAs {
         platformAdminGateway.requirePlatformAdmin(userId.value)
+        requireTeamless(userId)
         val routing = teamRepository.findTenantRoutingUnchecked(teamId) ?: throw TeamNotFoundException(teamId)
         val team = teamRepository.findById(teamId) ?: throw TeamNotFoundException(teamId)
         val now = clock.instant()
@@ -62,6 +64,15 @@ class ActAsService(
         tenantRoutingGateway.clearRouting()
         tenantRoutingGateway.pinRouting(routing)
         return EnteredActAs(grant, team)
+    }
+
+    /**
+     * A Platform Admin is structurally teamless (ADR-0024 §3). Refusing at entry fail-closes both
+     * orderings a linked state can arise through — including the member-then-allowlisted case that
+     * membership-side enforcement cannot catch. Reuses the same read the Active Team uses; no new port.
+     */
+    private fun requireTeamless(userId: UserId) {
+        if (teamRepository.findTeamsOf(userId.value).isNotEmpty()) throw PlatformAdminHasMembershipException(userId)
     }
 
     /**

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/exception/TeambalanceException.kt
@@ -127,3 +127,13 @@ class TeamSlugTakenException(slug: String) :
 // record of a real team's creation, not a pending invite to withdraw. The admin can't un-consume it.
 class CreationCodeConsumedException(code: String) :
     ConflictException("Creation code '$code' has already been consumed", "CREATION_CODE_CONSUMED")
+
+// A Platform Admin is structurally teamless (ADR-0024 §3): a human who both runs the platform and
+// plays holds two separate accounts. Entering act-as while holding any active membership is refused at
+// entry (ADR-0024 §3) — 409 because it is a state clash the operator resolves by switching accounts,
+// not a malformed request.
+class PlatformAdminHasMembershipException(userId: UserId) :
+    ConflictException(
+        "Platform admin $userId holds an active team membership; use a separate, teamless account to act as a team",
+        "PLATFORM_ADMIN_HAS_MEMBERSHIP",
+    )

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActAsServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActAsServiceTest.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.application
 
 import com.github.zzave.teambalance.api.domain.exception.NotPlatformAdminException
+import com.github.zzave.teambalance.api.domain.exception.PlatformAdminHasMembershipException
 import com.github.zzave.teambalance.api.domain.exception.TeamNotFoundException
 import com.github.zzave.teambalance.api.domain.model.ActAs
 import com.github.zzave.teambalance.api.domain.model.TeamId
@@ -96,6 +97,20 @@ class ActAsServiceTest : FunSpec() {
                 val dames5 = f.directory.addTeam("Dames 5", "dames-5")
 
                 shouldThrow<NotPlatformAdminException> { f.service.enter(outsider, dames5) }
+
+                f.episodes.all().shouldBeEmpty()
+                f.routing.writes.shouldBeEmpty()
+            }
+
+            // ADR-0024 §3: a Platform Admin is structurally teamless. Entry fail-closes both orderings
+            // a linked state can arise through — refusing whenever the caller holds *any* membership.
+            test("a Platform Admin who holds an active membership is refused entry, and opens nothing") {
+                val f = fixture()
+                val dames5 = f.directory.addTeam("Dames 5", "dames-5")
+                val heren3 = f.directory.addTeam("Heren 3", "heren-3")
+                f.directory.join(operator, heren3)
+
+                shouldThrow<PlatformAdminHasMembershipException> { f.service.enter(operator, dames5) }
 
                 f.episodes.all().shouldBeEmpty()
                 f.routing.writes.shouldBeEmpty()

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthServiceTest.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.application
 
+import com.github.zzave.teambalance.api.domain.model.ActAs
 import com.github.zzave.teambalance.api.domain.model.DisplayName
 import com.github.zzave.teambalance.api.domain.model.Email
 import com.github.zzave.teambalance.api.domain.model.MagicLinkToken
@@ -23,6 +24,7 @@ import com.github.zzave.teambalance.api.domain.port.TeamRepository
 import com.github.zzave.teambalance.api.domain.port.TenantRoutingGateway
 import com.github.zzave.teambalance.api.domain.port.UserRepository
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import java.time.Clock
 import java.time.Instant
@@ -81,6 +83,7 @@ class AuthServiceTest : FunSpec() {
             gateway: AuthSessionGateway,
             directory: TeamDirectory = TeamDirectory(),
             routingGateway: TenantRoutingGateway = RecordingTenantRoutingGateway(),
+            episodes: InMemoryActAsRepository = InMemoryActAsRepository(),
         ) = AuthService(
             magicLinkTokenRepository = FakeMagicLinkTokenRepository(),
             userRepository = directory.userRepository(user),
@@ -88,7 +91,7 @@ class AuthServiceTest : FunSpec() {
             activeTeamService = directory.activeTeamService(routingGateway, user),
             actAsService = directory.actAsService(
                 routingGateway = routingGateway,
-                actAsRepository = InMemoryActAsRepository(),
+                actAsRepository = episodes,
                 clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
                 platformAdmins = emptySet(),
             ),
@@ -134,6 +137,21 @@ class AuthServiceTest : FunSpec() {
 
             gateway.startedFor shouldBe userId
             routingGateway.pins shouldBe emptyList()
+        }
+
+        // ADR-0024 §4 guardrail: a fresh sign-in must not silently resume act-as. The grant outlives a
+        // session by design, so startSession closes any open one. Pinned here because the lower-level
+        // AuthSessionGateway.startSession does *not* — the invariant is one direct call away from bypass.
+        test("startSession closes an open act-as grant so a fresh sign-in never resumes it") {
+            val gateway = FakeAuthSessionGateway()
+            val directory = TeamDirectory()
+            val episodes = InMemoryActAsRepository()
+            val team = directory.addTeam("Dames 5", "dames-5")
+            episodes.save(ActAs.enter(userId = userId, teamId = team, now = Instant.EPOCH))
+
+            serviceWith(gateway, directory, episodes = episodes).startSession(userId)
+
+            episodes.findOpenFor(userId).shouldBeNull()
         }
 
         test("findTeamsFor lists every Team the caller is a Member of") {


### PR DESCRIPTION
Two backend guards from ADR-0024 §3/§4 (post-merge hardening for act-as):

1. ActAsService.enter refuses when the caller already holds any active
   membership, throwing PlatformAdminHasMembershipException (409,
   PLATFORM_ADMIN_HAS_MEMBERSHIP via the existing ConflictException mapping).
   Refusing at entry fail-closes both orderings a linked state can arise
   through. Reuses teamRepository.findTeamsOf — no new port method or
   constructor dependency.

2. Pin "a fresh sign-in closes an open grant" with a test at the
   AuthService/ActAsService seam. Production behaviour already correct; the
   test stops a direct AuthSessionGateway.startSession call bypassing it.

No contract, schema, or frontend change. Backend units only; no new e2e —
act-as's cross-tenant seam is already covered by act-as.spec.ts.

Closes #255

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AQAUmkjynCzEwV9J5WP5aS