### PR TITLE
fix(app): stop cold-start black screen + self-heal stuck PWA updates

### DIFF
--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -5,12 +5,20 @@ import { routeTree } from '../routeTree.gen'
 import { WakingSplash } from '@shared/ui/ColdStartSplash'
 import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
 import { installChunkErrorHandler } from '@shared/lib/chunk-reload'
+import { registerAppServiceWorker } from '@app/pwa/sw-registration'
 import './styles/global.css'
 
 // A stale shell can dynamic-import a route chunk whose hash the last deploy pruned → a blank frame.
 // This reloads once to the fresh index.html (which references chunk hashes that exist) rather than
 // leaving the screen blank; a second failure falls through to the router fallback below (Phase 1).
 installChunkErrorHandler()
+
+// Register the service worker and drive its update lifecycle here at bootstrap — outside the router,
+// so it runs on every load regardless of what renders. If a load ends on the error fallback (a cold
+// session probe failing) or crashes before the shell mounts, this still activates a waiting new
+// worker, so a broken build can always update itself on the next open instead of stranding the
+// client. The in-shell refinements (prompt, defer-to-navigation) live in SwUpdateManager.
+registerAppServiceWorker()
 
 // While the root guard probes the session (and on any route load), show the brand splash rather
 // than a blank frame. WakingSplash escalates its copy as it waits, so a cold-start backend wake

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -3,11 +3,20 @@ import { setupServer } from 'msw/node'
 import { render, screen, waitFor } from '@testing-library/react'
 import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../../routeTree.gen'
+import { WakingSplash } from '@shared/ui/ColdStartSplash'
+import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+import { queryClient } from '@shared/api/query-client'
 import type { AuthenticatedUser } from '@shared/api/auth'
 
 // The guard is a true render gate: a protected route must not mount (and therefore must not
-// fetch protected data) until the session is confirmed. An unconfirmed session — a 401 probe OR
-// any /me error — fails closed to the login screen.
+// fetch protected data) until the session is confirmed. It distinguishes the two ways a session
+// fails to confirm:
+//   • a *clean* 401 (backend reachable, not signed in) → redirect to /login;
+//   • a *backend error* (network / 5xx while the scale-to-zero container is still waking) → the
+//     router's themed error fallback (Retry reloads), NOT /login. Redirecting to /login there
+//     would log out a still-valid session, and — because the errored /me query stayed in cache
+//     while the layout mounted — used to crash the initial render into a blank screen.
+// Either way it fails closed: the protected route never mounts and its data never fetches.
 
 const TEAM = { id: 'team-1', name: 'Setpoint VT', slug: 'setpoint-vt' }
 
@@ -38,15 +47,33 @@ const server = setupServer(
 )
 
 beforeAll(() => server.listen())
+beforeEach(() => {
+  // The guard reads the shared query client, so the ['auth','me'] result must not leak between
+  // tests (a cached null from one case would skip the next case's probe). Also pin retry off for
+  // this seam: the retry/backoff timing is exercised in retry-policy.test.ts; here we only assert
+  // how the guard reacts to the settled outcome, and real backoff would make the test slow + flaky.
+  queryClient.clear()
+  queryClient.setQueryDefaults(['auth', 'me'], { retry: false })
+})
 afterEach(() => {
   server.resetHandlers()
   meStatus = 401
   eventsFetched = false
+  queryClient.clear()
+  queryClient.setQueryDefaults(['auth', 'me'], {})
 })
 afterAll(() => server.close())
 
+// Mirror the real router config from app/index.tsx so the gate is exercised with the same pending
+// and error components the app ships — the error fallback in particular is what a probe failure
+// must render instead of a blank frame.
 function renderAppAt(path: string) {
-  const router = createRouter({ routeTree, history: createMemoryHistory({ initialEntries: [path] }) })
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+    defaultPendingComponent: WakingSplash,
+    defaultErrorComponent: () => <RouteErrorFallback onRetry={() => {}} />,
+  })
   render(<RouterProvider router={router} />)
   return router
 }
@@ -63,11 +90,17 @@ describe('auth gate', () => {
     expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })
 
-  it('fails closed: a non-401 /me error also redirects to login and never mounts the route', async () => {
+  it('fails closed on a non-401 /me error to the error fallback — not /login, never mounts the route', async () => {
     meStatus = 500
     const router = renderAppAt('/')
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/login'), { timeout: 5000 })
+    // The themed retry fallback, not a blank frame and not the login screen: a cold-start backend
+    // error must not be mistaken for "signed out".
+    await waitFor(() => expect(screen.getByText(/couldn't load this page/i)).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    expect(router.state.location.pathname).not.toBe('/login')
+    // Still gated: the protected route never mounted, so its data fetch never fired.
     expect(eventsFetched).toBe(false)
     expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })

--- a/app/src/app/pwa/sw-registration.ts
+++ b/app/src/app/pwa/sw-registration.ts
@@ -1,0 +1,99 @@
+import { registerSW } from 'virtual:pwa-register'
+import { decideUpdateAction } from '@shared/lib/update-decision'
+
+// The service-worker update lifecycle, owned at module level so it runs at bootstrap — before, and
+// independent of, any React render (see index.tsx, which calls registerAppServiceWorker outside the
+// router).
+//
+// Why not keep this inside a component (it used to live in SwUpdateManager, mounted by RootLayout)?
+// Because the one moment we most need an update to apply is exactly when the shell fails to render:
+// an errored session probe drops us on the router's error fallback, or a bad build crashes the tree
+// — RootLayout never mounts, so a component-owned registration never runs, a waiting new worker
+// sits unactivated forever, and the client is stranded on the broken build that can no longer
+// update itself. A crashed/error-fallback load is always a fresh, pre-interaction one, so the
+// decision table below resolves it to `auto`/`activate` and we self-heal.
+//
+// The richer, in-shell refinements (prompt-when-dirty, defer-to-next-navigation) still live in the
+// React layer (sw-update.tsx) and feed signals in through the setters here — but they only ever
+// apply once the user has interacted, which means the shell did render and that layer is present.
+
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000 // hourly — page load + regained visibility do the rest.
+
+let hasInteracted = false
+let isDirty = false
+let deferred = false
+let registered = false
+let updateSW: (reloadPage?: boolean) => Promise<void> = () => Promise.resolve()
+let promptListener: ((show: boolean) => void) | null = null
+
+// First real input this session flips hasInteracted — past this point a silent auto-reload would read
+// as an interruption, so the decision table stops auto-applying.
+if (typeof window !== 'undefined') {
+  const mark = () => {
+    hasInteracted = true
+  }
+  window.addEventListener('pointerdown', mark, { once: true })
+  window.addEventListener('keydown', mark, { once: true })
+}
+
+/** Apply a waiting worker now (SKIP_WAITING → controllerchange → reload). Used by the prompt's Reload. */
+export function applyUpdate(): void {
+  void updateSW(true)
+}
+
+/** Mirror pending mutations in so a deploy landing mid-work prompts instead of auto-reloading. */
+export function setDirty(dirty: boolean): void {
+  isDirty = dirty
+}
+
+/** A safe seam arrived (a route navigation, or the tab going hidden) — apply a deferred update. */
+export function applyDeferredUpdate(): void {
+  if (!deferred) return
+  deferred = false
+  void updateSW(true)
+}
+
+/** The React UX layer subscribes to learn when to show the reload prompt. */
+export function onUpdatePrompt(listener: (show: boolean) => void): () => void {
+  promptListener = listener
+  return () => {
+    if (promptListener === listener) promptListener = null
+  }
+}
+
+/**
+ * Register the worker and own its update lifecycle. Called once from bootstrap (index.tsx), outside
+ * the router, so it runs on every load no matter what — or whether — the app renders.
+ */
+export function registerAppServiceWorker(): void {
+  if (registered) return
+  registered = true
+  updateSW = registerSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return
+      // Re-check on regaining visibility and on a long periodic interval (the initial load check is
+      // the registration itself). Backgrounding is also a safe seam to apply a deferred update.
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') void registration.update()
+        else applyDeferredUpdate()
+      })
+      window.setInterval(() => void registration.update(), UPDATE_CHECK_INTERVAL_MS)
+    },
+    onNeedRefresh() {
+      const action = decideUpdateAction({
+        hasController: Boolean(navigator.serviceWorker?.controller),
+        hasInteracted,
+        visibility: document.visibilityState,
+        isDirty,
+      })
+      if (action === 'activate' || action === 'auto') {
+        void updateSW(true)
+      } else if (action === 'defer') {
+        deferred = true
+      } else {
+        promptListener?.(true)
+      }
+    },
+  })
+}

--- a/app/src/app/pwa/sw-update.tsx
+++ b/app/src/app/pwa/sw-update.tsx
@@ -1,92 +1,34 @@
 import { useEffect, useRef, useState } from 'react'
-import { useRegisterSW } from 'virtual:pwa-register/react'
 import { useIsMutating } from '@tanstack/react-query'
 import { useRouterState } from '@tanstack/react-router'
-import { decideUpdateAction } from '@shared/lib/update-decision'
 import { UpdateToast } from '@shared/ui/UpdateToast'
-
-// Knob 1 — how often we even look for an update while a tab stays open. A long interval, not
-// aggressive polling: the real triggers are page load (registration) and regaining visibility.
-const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000 // hourly
+import { applyDeferredUpdate, applyUpdate, onUpdatePrompt, setDirty } from './sw-registration'
 
 /**
- * Owns the service-worker update lifecycle (caching plan Phase 3). Registers the worker via
- * `virtual:pwa-register/react` and, when a new version is ready (`onNeedRefresh`), routes the
- * decision through `decideUpdateAction`:
+ * The in-shell half of the service-worker update flow (caching plan Phase 3). Registration and the
+ * auto-apply decision live at bootstrap in sw-registration.ts so they run even when the app shell
+ * fails to render; this component adds only the refinements that need React context and that only
+ * matter once the shell is up and the user is active:
  *
- *  - `activate` / `auto` → apply immediately (invisible; perceived as a normal load).
- *  - `defer`             → apply at the next safe seam — a route navigation or the tab going hidden —
- *                          falling back to the prompt only if none arrives.
- *  - `prompt`            → show the toast; the user reloads when their work is safe.
+ *  - the `isDirty` signal (pending mutations) so a deploy mid-work prompts instead of auto-reloading;
+ *  - the defer seam — apply a deferred update at the next route navigation;
+ *  - the reload prompt itself (`UpdateToast`), shown only for the "focused, interacted, dirty" case.
  *
- * Signals: `hasInteracted` (first real input this session) and `isDirty` (pending TanStack Query
- * mutations via `useIsMutating` — the pragmatic minimal source; unsaved-form tracking can extend it
- * later). Both are read through refs inside the SW callbacks, which `useRegisterSW` registers once
- * and would otherwise close over stale values.
- *
- * This is the thin lifecycle shell the plan flags as manual-verified: the risk lives in
- * decideUpdateAction (unit-tested) and the toast (storied), not here.
+ * The tab-hidden defer seam and every auto/activate path are owned by sw-registration.ts, which does
+ * not need React to run.
  */
 export function SwUpdateManager() {
   const [showPrompt, setShowPrompt] = useState(false)
 
-  // isDirty — pending mutations. Mirrored into a ref so the register-once SW callback reads it live.
+  // isDirty — pending mutations. Mirrored into the bootstrap controller so its register-once
+  // onNeedRefresh callback reads a live value.
   const pendingMutations = useIsMutating()
-  const isDirtyRef = useRef(false)
   useEffect(() => {
-    isDirtyRef.current = pendingMutations > 0
+    setDirty(pendingMutations > 0)
   }, [pendingMutations])
 
-  const hasInteractedRef = useRef(false)
-  const deferredRef = useRef(false)
-  const updateSWRef = useRef<(reloadPage?: boolean) => Promise<void>>(() => Promise.resolve())
-
-  // First real user input this session flips hasInteracted — the point past which a silent
-  // auto-reload would read as an interruption rather than a normal load.
-  useEffect(() => {
-    const mark = () => {
-      hasInteractedRef.current = true
-    }
-    window.addEventListener('pointerdown', mark, { once: true })
-    window.addEventListener('keydown', mark, { once: true })
-    return () => {
-      window.removeEventListener('pointerdown', mark)
-      window.removeEventListener('keydown', mark)
-    }
-  }, [])
-
-  const { updateServiceWorker } = useRegisterSW({
-    onRegisteredSW(_swUrl, registration) {
-      if (!registration) return
-      // Knob 1 — re-check on regaining visibility and on a long periodic interval. (The initial
-      // load check is the registration itself.) Never torn down: the manager lives for the app's
-      // lifetime, so the listener and interval are process-scoped by design.
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') void registration.update()
-      })
-      window.setInterval(() => void registration.update(), UPDATE_CHECK_INTERVAL_MS)
-    },
-    onNeedRefresh() {
-      const action = decideUpdateAction({
-        hasController: Boolean(navigator.serviceWorker?.controller),
-        hasInteracted: hasInteractedRef.current,
-        visibility: document.visibilityState,
-        isDirty: isDirtyRef.current,
-      })
-      if (action === 'activate' || action === 'auto') {
-        void updateSWRef.current(true)
-      } else if (action === 'defer') {
-        deferredRef.current = true
-      } else {
-        setShowPrompt(true)
-      }
-    },
-  })
-  // Keep the ref pointing at the latest updater so the register-once callbacks and the seam effects
-  // don't close over a stale one.
-  useEffect(() => {
-    updateSWRef.current = updateServiceWorker
-  }, [updateServiceWorker])
+  // The controller tells us when to surface the prompt (the one case it does not auto-resolve).
+  useEffect(() => onUpdatePrompt(setShowPrompt), [])
 
   // Defer seam — a route navigation. A navigation already unmounts the current view, so applying a
   // waiting update there loses nothing. Skips the first run (nothing deferred yet at mount).
@@ -97,19 +39,8 @@ export function SwUpdateManager() {
       didMountRef.current = true
       return
     }
-    if (deferredRef.current) void updateSWRef.current(true)
+    applyDeferredUpdate()
   }, [href])
 
-  // Defer seam — the tab going hidden. Backgrounding is a safe moment to refresh silently.
-  useEffect(() => {
-    const onHidden = () => {
-      if (deferredRef.current && document.visibilityState === 'hidden') {
-        void updateSWRef.current(true)
-      }
-    }
-    document.addEventListener('visibilitychange', onHidden)
-    return () => document.removeEventListener('visibilitychange', onHidden)
-  }, [])
-
-  return <UpdateToast show={showPrompt} onReload={() => void updateSWRef.current(true)} />
+  return <UpdateToast show={showPrompt} onReload={applyUpdate} />
 }

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -36,15 +36,17 @@ export const Route = createRootRoute({
   component: RootLayout,
   // A true gate: the session is probed before a protected route loads, so its component never
   // mounts (and never fetches protected data) unless the session is confirmed. An unauthenticated
-  // 401 — or any /me error (fail closed) — redirects to login before render.
+  // 401 redirects to login before render; a backend error surfaces the router's error fallback
+  // (see below) — either way the protected route is never rendered.
   beforeLoad: async ({ location }) => {
     if (isAuthRoute(location.pathname)) return
-    let user = null
-    try {
-      user = await queryClient.ensureQueryData(authMeQueryOptions)
-    } catch {
-      // Session could not be confirmed (network / 5xx) — fail closed.
-    }
+    // A genuine 401 resolves to null → /login. A backend error (network / 5xx while the
+    // scale-to-zero container is still waking) REJECTS: let it propagate to the router's
+    // themed error fallback (Retry reloads, by which point the backend is warm) instead of
+    // failing closed to /login. Failing closed here both logged out a still-valid session
+    // and — because the errored /me query stayed in cache while RootLayout mounted — crashed
+    // the render into a blank frame.
+    const user = await queryClient.ensureQueryData(authMeQueryOptions)
     if (!user) throw redirect({ to: '/login' })
 
     // Has-ANY-team gate (ADR-0023 §4). Which Team is active is a separate question, answered by

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/react" />
+/// <reference types="vite-plugin-pwa/vanillajs" />
 
 interface ImportMetaEnv {
   // Base URL for the API in a split-origin build (e.g. https://api.teambalance.nl).


### PR DESCRIPTION
## Problem

After a quiet spell, opening `app.teambalance.nl` (browser or installed PWA) would run through the loading splash and then turn into a **black screen**, cleared only by a manual refresh. Reported as unusable and unwarranted.

## Root cause (found by reproducing in a real browser)

The prod backend scales to zero, so on a cold start the `/me` session probe can return a transient error (5xx / connection reset) while the container wakes. The root route guard caught **every** such error and failed closed with `throw redirect({ to: '/login' })`. With the errored `['auth','me']` query still in cache as `RootLayout` mounted, React surfaced an uncaught `throw undefined` that emptied `#root` — a black screen in dark mode. A refresh worked only because the backend was warm by then.

Reproduced deterministically against a running build: any non-401 `/me` error → 5/5 blank; a clean 401 or a 200 → 0 blank. jsdom/RTL couldn't surface it (synchronous `act()` flush hides React's concurrent scheduling); a headless-Chromium repro against the dev server and the production PWA build did.

## Fix

**1. Don't blank on a cold-start probe error** (`__root.tsx`)
Distinguish the two failure modes in the guard: a clean 401 still resolves to `null` → `/login`; a backend error (5xx / network while waking) now propagates to the router's themed error fallback (`RouteErrorFallback`, whose Retry reloads — by which point the backend is warm), instead of failing closed to `/login`. Because the error fallback renders in place of `RootLayout`, nothing reads the poisoned query, so the crash is gone. This also corrects a latent bug: a cold backend no longer logs an authenticated user out to `/login`.

**2. Self-heal service-worker updates so a bad deploy can't strand clients** (`sw-registration.ts`, `sw-update.tsx`, `index.tsx`)
Registration + the auto-apply decision used to live inside `SwUpdateManager`, which only mounts under `RootLayout`. A load that lands on the error fallback (or crashes) never mounted the shell → never registered the worker → a waiting new version sat unactivated forever, pinning the client to the broken build that could no longer update itself (the "deployed the fix but the PWA is still broken" trap). Registration + the auto/activate decision now live in a module-level controller called at bootstrap in `index.tsx`, **outside the router**, so the update lifecycle runs on every load regardless of what renders. `SwUpdateManager` stays as the thin in-shell layer for the refinements that need React context (the dirty-work signal, the defer-to-navigation seam, the reload prompt). `decideUpdateAction` is unchanged.

## Verification

- **Real browser, production build:** slow cold start → Events; `/me` 502 / reset → themed "Couldn't load — Retry"; never a blank frame. Confirmed cross-origin (`app` and `api` on different origins, service worker active) — `/api/**` is `NetworkOnly` and not cached.
- **Self-heal proven end-to-end:** the worker now registers even on the error-fallback path, and an installed v1 client that reopens straight onto the error fallback auto-updates to a freshly deployed v2 — no manual step.
- 316 unit tests, typecheck, and lint all green.

## Tests

- Updated the sanctioned `auth-gate.test.tsx` render-gate to assert the corrected behavior (non-401 error → error fallback, not `/login`, protected route never mounts), mirror the app's real router config, and fix a cross-test cache-pollution bug in that file.
- No new e2e: no new auth/tenant/integration seam is introduced (per the PR gate). The service-worker update logic (`decideUpdateAction`) keeps its existing Vitest unit coverage; the registration shell is manual-verified as before.

## Note for the currently-stuck PWA

This makes **future** deploys self-healing. A PWA already stranded on the original black-screen build predates all of this, so it needs one manual unstick to adopt a self-healing build (DevTools → Application → Service Workers → Unregister, or reinstall the PWA). Worth also confirming the CDN edge purge runs so plain browser tabs don't keep serving a stale `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012V1v7o67D1QrpkVsbRarqN)_