### PR TITLE
fix(app): eliminate the residual cold-start black screen with a top-level error boundary + empty-200 /me hardening

### DIFF
--- a/app/src/app/RootErrorBoundary.test.tsx
+++ b/app/src/app/RootErrorBoundary.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { RootErrorBoundary } from './RootErrorBoundary'
+
+// The prod crash surfaced as React's onUncaughtError with the thrown value `undefined` — an error
+// that escaped every boundary and blanked the root. This boundary must catch exactly that (a thrown
+// primitive/undefined, not just an Error) and render the themed retry screen instead of nothing.
+function Thrower({ value }: { value: unknown }): never {
+  throw value
+}
+
+describe('RootErrorBoundary', () => {
+  it('renders the children when nothing throws', () => {
+    render(
+      <RootErrorBoundary>
+        <p>all good</p>
+      </RootErrorBoundary>,
+    )
+    expect(screen.getByText('all good')).toBeInTheDocument()
+  })
+
+  it('catches a thrown `undefined` and shows the themed retry fallback (not a blank frame)', () => {
+    // React logs the caught error; silence the expected noise so the run stays readable.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <RootErrorBoundary>
+        <Thrower value={undefined} />
+      </RootErrorBoundary>,
+    )
+    expect(screen.getByText(/couldn't load this page/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it('also catches a thrown Error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <RootErrorBoundary>
+        <Thrower value={new Error('boom')} />
+      </RootErrorBoundary>,
+    )
+    expect(screen.getByText(/couldn't load this page/i)).toBeInTheDocument()
+    spy.mockRestore()
+  })
+})

--- a/app/src/app/RootErrorBoundary.tsx
+++ b/app/src/app/RootErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ReactNode } from 'react'
+import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+/**
+ * The last-resort error boundary, mounted ABOVE <RouterProvider> in index.tsx.
+ *
+ * The router has its own error boundary, but it wraps only the matched-route subtree — the router's
+ * own load/transition machinery renders as a sibling of it, so an error thrown there (a redirect or
+ * a value that surfaces as `undefined` during a concurrent transition) escapes every boundary,
+ * reaches React's onUncaughtError, and unmounts the whole tree to a blank (black in dark mode) frame.
+ * That is the residual cold-start crash the route-level fixes could not reach.
+ *
+ * This boundary sits above all of that, so ANY render/commit error React would otherwise leave
+ * uncaught becomes a themed "Couldn't load — Retry" screen instead of a black void. Retry reloads
+ * (by which point a cold backend is usually warm, and a new service worker — see sw-registration —
+ * can take over). It is a safety net, not a router replacement: real route errors are still caught
+ * lower down by the router's own error component; only what escapes that reaches here.
+ */
+export class RootErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    // Surface it for diagnostics; the thrown value can be anything (including undefined).
+    console.error('Uncaught render error surfaced to the root boundary:', error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <RouteErrorFallback onRetry={() => window.location.reload()} />
+    }
+    return this.props.children
+  }
+}

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -4,6 +4,7 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../routeTree.gen'
 import { WakingSplash } from '@shared/ui/ColdStartSplash'
 import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+import { RootErrorBoundary } from '@app/RootErrorBoundary'
 import { installChunkErrorHandler } from '@shared/lib/chunk-reload'
 import { registerAppServiceWorker } from '@app/pwa/sw-registration'
 import './styles/global.css'
@@ -40,6 +41,11 @@ declare module '@tanstack/react-router' {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    {/* Last-resort boundary ABOVE the router: anything that escapes the router's own error handling
+        (an error thrown in its load/transition machinery, which sits outside that boundary) becomes
+        a themed retry screen here instead of an uncaught error that blanks the root. */}
+    <RootErrorBoundary>
+      <RouterProvider router={router} />
+    </RootErrorBoundary>
   </StrictMode>,
 )

--- a/app/src/app/providers/auth-gate.test.tsx
+++ b/app/src/app/providers/auth-gate.test.tsx
@@ -33,12 +33,16 @@ const USER: AuthenticatedUser = {
 }
 
 let meStatus = 401
+// A 200 with an empty (0-byte) body — what a cold/misbehaving backend can send. The wirespec client
+// surfaces it as an undefined user, which must be treated as unconfirmed, not signed-out.
+let meEmptyBody = false
 let eventsFetched = false
 
 const server = setupServer(
-  http.get('/api/auth/me', () =>
-    meStatus === 200 ? HttpResponse.json(USER) : new HttpResponse(null, { status: meStatus }),
-  ),
+  http.get('/api/auth/me', () => {
+    if (meEmptyBody) return new HttpResponse('', { status: 200 })
+    return meStatus === 200 ? HttpResponse.json(USER) : new HttpResponse(null, { status: meStatus })
+  }),
   http.get('/api/events', () => {
     eventsFetched = true
     return HttpResponse.json({ events: [] })
@@ -58,6 +62,7 @@ beforeEach(() => {
 afterEach(() => {
   server.resetHandlers()
   meStatus = 401
+  meEmptyBody = false
   eventsFetched = false
   queryClient.clear()
   queryClient.setQueryDefaults(['auth', 'me'], {})
@@ -101,6 +106,21 @@ describe('auth gate', () => {
     })
     expect(router.state.location.pathname).not.toBe('/login')
     // Still gated: the protected route never mounted, so its data fetch never fired.
+    expect(eventsFetched).toBe(false)
+    expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
+  })
+
+  it('treats an empty (0-byte) 200 /me as unconfirmed → error fallback, not a signed-out /login', async () => {
+    // A cold/misbehaving backend answering the probe with an empty body is not "signed out": it must
+    // not bounce a valid session to /login (nor, historically, blank the screen), so it lands on the
+    // same retry fallback as a 5xx.
+    meEmptyBody = true
+    const router = renderAppAt('/')
+
+    await waitFor(() => expect(screen.getByText(/couldn't load this page/i)).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    expect(router.state.location.pathname).not.toBe('/login')
     expect(eventsFetched).toBe(false)
     expect(screen.queryByRole('heading', { name: 'Events' })).not.toBeInTheDocument()
   })

--- a/app/src/shared/api/auth.ts
+++ b/app/src/shared/api/auth.ts
@@ -1,5 +1,6 @@
 import { queryOptions, useMutation, useQuery } from '@tanstack/react-query'
 import { api } from './wirespec-client'
+import type { AuthenticatedUser } from './generated/model/AuthenticatedUser'
 
 export type { AuthenticatedUser } from './generated/model/AuthenticatedUser'
 
@@ -31,13 +32,24 @@ export function useLogout() {
 
 // Shared so the root route's beforeLoad guard can prime this exact query (ensureQueryData) and
 // useAuthMe reads it back from cache — no duplicate fetch, no drifting query key. A 401 probe
-// resolves to null (unauthenticated); a non-401 error rejects and is treated as unconfirmed.
+// resolves to null (unauthenticated); anything else that isn't a usable user rejects and is treated
+// as unconfirmed (retried, then the router's error fallback).
 export const authMeQueryOptions = queryOptions({
   queryKey: ['auth', 'me'],
   queryFn: async () => {
     const res = await api.GetAuthMe()
     if (res.status === 401) return null
-    return res.body
+    // A 200 must carry the user. A cold or misbehaving backend can answer with an empty (0-byte) or
+    // partial body — the wirespec client has no "a 200 has a body" contract, so it surfaces that as
+    // `undefined`. That is NOT a signed-out session: reading it as such would bounce a valid user to
+    // /login, and letting a bare `undefined` through would only reject later inside react-query
+    // ("Query data cannot be undefined"). Reject it explicitly as an unconfirmed session instead, so
+    // the guard's fail-closed path routes it to the retry/error fallback exactly like a 5xx.
+    const user = res.body as AuthenticatedUser | undefined
+    if (!user || typeof user !== 'object' || !Array.isArray(user.teams)) {
+      throw new Error(`Unconfirmed session: /me returned status ${res.status} without a usable body`)
+    }
+    return user
   },
 })
 


### PR DESCRIPTION
Follow-up to #270 (merged). After that shipped, prod **still** blanked to black on a cold start — React 19 `onUncaughtError` fired with a thrown `undefined`. This PR closes the seam #270 could not reach, plus lands a hardening commit that was orphaned when #270 auto-merged.

## Root cause of the residual crash

The route-guard fix in #270 stopped the *guard* path from crashing, but the crash was coming from elsewhere: **TanStack Router's own error boundary wraps only the matched-route subtree, while the router's load/transition machinery renders as a *sibling* of that boundary.** An error thrown there — a redirect, or a value that surfaces as `undefined` during a concurrent transition — escapes every boundary, reaches `onUncaughtError`, and unmounts the whole tree to a blank (black in dark mode) frame. Decoding the deployed bundle confirmed the stack (`onUncaughtError` with value `undefined`) and that only #270's guard change was live.

## Changes

**1. Top-level React error boundary above `<RouterProvider>` (`RootErrorBoundary`)**
The belt-and-suspenders fix. Anything that would otherwise be uncaught — a thrown `undefined` included — now renders the themed **"Couldn't load — Retry"** screen instead of a black void; Retry reloads. It's a net *above* the router, not a replacement: real route errors are still caught lower down by the router's own error component, and the happy path passes straight through.

**2. Empty/partial `200 /me` treated as unconfirmed, not signed-out (`auth.ts`)**
A cold or misbehaving backend can answer the session probe with an empty (0-byte) or partial body; the wirespec client surfaces that as `undefined`, which is not a signed-out session. This rejects it explicitly as unconfirmed so it routes to the retry/error fallback exactly like a 5xx — never a blank frame, never a false bounce to `/login`. (This commit was written for #270 but landed after the auto-merge squashed the branch, so it never merged.)

## Verification

- **Unit tests** prove the boundary catches a thrown **`undefined`** (the exact prod signature) and a thrown `Error`, rendering the fallback; and an `auth-gate` render-gate case covers empty-200 `/me` → error fallback, not `/login`.
- **Real-browser check**: happy path still renders Events; a `/me` error still shows the themed fallback; the boundary is transparent on the happy path.
- 347 unit tests + typecheck + lint green.

## Tests

- New `RootErrorBoundary.test.tsx` (pure boundary-contract test — catches a thrown primitive, which cannot be a story) and an added `auth-gate` case. No new e2e: no new auth/tenant/integration seam is introduced (per the PR gate).

## Note for the currently-installed PWA

This makes new loads self-heal, but a PWA already stranded on the pre-fix bundle still needs one manual unstick to adopt it (DevTools → Application → Service Workers → Unregister, or reinstall the PWA). #270's self-heal SW keeps future deploys clean once clients are on a build that has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012V1v7o67D1QrpkVsbRarqN)_