### PR TITLE
feat: expose changedBy and updatedAt on attendance

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendance.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/model/EventAttendance.kt
@@ -1,5 +1,6 @@
 package com.github.zzave.teambalance.api.domain.model
 
+import java.time.Instant
 
 /**
  * Bucket label for attendees who have no position assigned. A [PositionLabel] like any other, so
@@ -12,11 +13,15 @@ val UNASSIGNED = PositionLabel("Unassigned")
  * One member's resolved attendance for an event: their response-row state, or NOT_RESPONDED when
  * they have no row. [responseId] is the attendance row's id when they responded, null otherwise —
  * so a view can key off the real row while a not-responded member falls back to their user id.
+ * [changedBy] and [updatedAt] carry the row's attribution (who last set it, when); both are null
+ * for a member with no response row.
  */
 data class MemberAttendance(
     val member: TeamMember,
     val state: AttendanceState,
     val responseId: AttendanceId?,
+    val changedBy: UserId?,
+    val updatedAt: Instant?,
 )
 
 /**
@@ -86,6 +91,8 @@ class EventAttendance private constructor(
                         member = member,
                         state = response?.state ?: AttendanceState.NOT_RESPONDED,
                         responseId = response?.id,
+                        changedBy = response?.changedBy,
+                        updatedAt = response?.updatedAt,
                     )
                 },
             )

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceController.kt
@@ -14,6 +14,7 @@ import com.github.zzave.teambalance.api.interfaces.generated.endpoint.SetAttenda
 import com.github.zzave.teambalance.api.interfaces.generated.model.Attendance
 import com.github.zzave.teambalance.api.interfaces.generated.model.BulkAttendanceResult
 import com.github.zzave.teambalance.api.interfaces.generated.model.AttendanceEntry
+import com.github.zzave.teambalance.api.interfaces.generated.model.DateTimestampWithTimezone
 import com.github.zzave.teambalance.api.interfaces.generated.model.AttendanceState as GeneratedAttendanceState
 import com.github.zzave.teambalance.api.interfaces.generated.model.AttendanceSummary
 import com.github.zzave.teambalance.api.interfaces.generated.model.RoleCount
@@ -52,6 +53,8 @@ class AttendanceController(
                 displayName = member?.displayName?.value ?: "Unknown",
                 role = (member?.position ?: UNASSIGNED).value,
                 state = attendance.state.name,
+                changedBy = attendance.changedBy.produce(),
+                updatedAt = DateTimestampWithTimezone(attendance.updatedAt.toString()),
             )
         )
     }
@@ -97,6 +100,9 @@ internal fun MemberAttendance.produce() = AttendanceEntry(
     displayName = member.displayName.value,
     role = (member.position ?: UNASSIGNED).value,
     state = state.produce(),
+    // Attribution is present only for a real response row; a not-responded member carries neither.
+    changedBy = changedBy?.produce(),
+    updatedAt = updatedAt?.let { DateTimestampWithTimezone(it.toString()) },
 )
 
 internal fun Map<AttendanceState, Int>.produce(roleBreakdown: List<Pair<PositionLabel, Int>>) =

--- a/api/src/main/wirespec/attendances.ws
+++ b/api/src/main/wirespec/attendances.ws
@@ -8,7 +8,9 @@ type Attendance {
     userId: String,
     displayName: String,
     role: String,
-    state: String
+    state: String,
+    changedBy: String,
+    updatedAt: DateTimestampWithTimezone
 }
 
 endpoint SetAttendance PUT SetAttendanceRequest /api/events/{eventId: String}/attendances/{userId: String} -> {

--- a/api/src/main/wirespec/events.ws
+++ b/api/src/main/wirespec/events.ws
@@ -102,12 +102,15 @@ type EventDetail {
     roster: EventRoster
 }
 
+// `changedBy` is the user id of whoever last set this row (ADR-0003 trust-based editing, so it may be a teammate); it and `updatedAt` are null for a member with no response row (NOT_RESPONDED). The client compares `changedBy` to `userId` and only shows attribution when they differ.
 type AttendanceEntry {
     id: String,
     userId: String,
     displayName: String,
     role: String,
-    state: AttendanceState
+    state: AttendanceState,
+    changedBy: String?,
+    updatedAt: DateTimestampWithTimezone?
 }
 
 type EventList {

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/AttendanceControllerTest.kt
@@ -3,6 +3,8 @@ package com.github.zzave.teambalance.api.interfaces
 import com.github.zzave.teambalance.api.TeamBalanceIT
 import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
 import io.kotest.matchers.shouldBe
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.nullValue
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
@@ -213,6 +215,78 @@ class AttendanceControllerTest : TeamBalanceIT() {
 
             queryChangedBy(eventId, ownerId) shouldBe UUID.fromString(editorId)
         }
+
+        test("GET /api/events/{id} returns changedBy as the acting user, not the target") {
+            tenantSchemaAdapter.provisionPlatformSchema()
+            tenantSchemaAdapter.provisionTenantSchema("public")
+
+            val teamId = UUID.randomUUID().toString()
+            val ownerId = UUID.randomUUID().toString()
+            val editorId = UUID.randomUUID().toString()
+            val selfId = UUID.randomUUID().toString()
+
+            jdbcTemplate.execute("""
+                INSERT INTO public.teams (id, name, slug, schema_name)
+                VALUES ('$teamId'::uuid, 'Attribution Team', 'attribution-team-$teamId', 'attribution-team-$teamId')
+                ON CONFLICT DO NOTHING
+            """)
+            jdbcTemplate.execute("""
+                INSERT INTO public.users (id, email, display_name) VALUES
+                    ('$ownerId'::uuid, 'owner-$ownerId@test.com', 'Owner'),
+                    ('$editorId'::uuid, 'editor-$editorId@test.com', 'Editor'),
+                    ('$selfId'::uuid, 'self-$selfId@test.com', 'Self')
+                ON CONFLICT DO NOTHING
+            """)
+            jdbcTemplate.execute("SELECT public.tb_add_member('$teamId'::uuid, '$ownerId'::uuid, 'USER', 'Setter')")
+            jdbcTemplate.execute("SELECT public.tb_add_member('$teamId'::uuid, '$editorId'::uuid, 'ADMIN', 'Libero')")
+            jdbcTemplate.execute("SELECT public.tb_add_member('$teamId'::uuid, '$selfId'::uuid, 'USER', 'Middle')")
+
+            val eventId = UUID.randomUUID()
+            jdbcTemplate.execute("""
+                INSERT INTO public.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+                VALUES ('$eventId'::uuid,
+                    (SELECT id FROM public.event_types WHERE name = 'Training'),
+                    'Attribution Match', '2026-07-01 20:00:00+00', '2026-07-01 22:00:00+00',
+                    '$editorId'::uuid, now(), now())
+            """)
+
+            // The editor sets the owner's attendance (acting user differs from target)…
+            putAttendanceAs(eventId, ownerId, editorId, "ATTENDING")
+            // …and the self member sets their own (acting user equals target).
+            putAttendanceAs(eventId, selfId, selfId, "MAYBE")
+
+            val getResult = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/events/$eventId")
+                    .header("X-Team-Id", "public")
+                    .header("X-User-Id", editorId),
+            )
+                .andExpect(MockMvcResultMatchers.request().asyncStarted())
+                .andReturn()
+
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(getResult))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                // Cross-edit: attribution is the editor, so the client can render "set by Editor".
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attendances[?(@.userId=='$ownerId')].changedBy").value(editorId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attendances[?(@.userId=='$ownerId')].updatedAt").isNotEmpty)
+                // Self-set: changedBy equals the target, so the client's "only attribute when they differ" rule holds.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attendances[?(@.userId=='$selfId')].changedBy").value(selfId))
+                // A member with no response row carries no attribution (null, not the acting viewer).
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attendances[?(@.userId=='$editorId')].changedBy").value(contains(nullValue())))
+        }
+    }
+
+    private fun putAttendanceAs(eventId: UUID, targetUserId: String, actingUserId: String, state: String) {
+        val started = mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/events/$eventId/attendances/$targetUserId")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"state":"$state"}""")
+                .header("X-Team-Id", "public")
+                .header("X-User-Id", actingUserId),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(started))
+            .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
     private fun putAttendance(eventId: UUID, state: String) {

--- a/app/src/entities/event/lib/attendee-panel.test.ts
+++ b/app/src/entities/event/lib/attendee-panel.test.ts
@@ -9,6 +9,8 @@ const attendee = (overrides: Partial<AttendanceEntry> = {}): AttendanceEntry => 
   displayName: 'Julius',
   role: 'Spelverdeler',
   state: 'ATTENDING',
+  changedBy: undefined,
+  updatedAt: undefined,
   ...overrides,
 })
 

--- a/app/src/shared/api/attendance-cache.test.ts
+++ b/app/src/shared/api/attendance-cache.test.ts
@@ -9,6 +9,8 @@ const attendee = (overrides: Partial<AttendanceEntry> = {}): AttendanceEntry => 
   displayName: 'Julius',
   role: 'Spelverdeler',
   state: 'ATTENDING',
+  changedBy: undefined,
+  updatedAt: undefined,
   ...overrides,
 })
 


### PR DESCRIPTION
AttendanceEntry now carries changedBy (who last set the row) and
updatedAt, so the detail page can render "set by X, N ago". Both are
null for a member with no response row. The single-write PUT response
(Attendance) carries them too, non-null since a write always sets them.

changed_by has been a NOT NULL column since V003; it was simply never
returned. No migration, no new endpoint, no authorization change
(ADR-0003 keeps editing trust-based within a team).

The IT asserts changedBy comes back as the acting user, not the target,
in the member-A-sets-member-B case, and equals userId on a self-set row.

Refs #272.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ii6zM9izBGZArHihsfhWd