### PR TITLE
test: use ASCII hyphens in test names so reports build on non-UTF-8 locales

### DIFF
--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActAsServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActAsServiceTest.kt
@@ -124,7 +124,7 @@ class ActAsServiceTest : FunSpec() {
                 f.episodes.all().shouldBeEmpty()
             }
 
-            test("entering a second Team closes the first — one open grant, so the banner can't lie") {
+            test("entering a second Team closes the first - one open grant, so the banner can't lie") {
                 val f = fixture()
                 val dames5 = f.directory.addTeam("Dames 5", "dames-5")
                 val heren3 = f.directory.addTeam("Heren 3", "heren-3")
@@ -150,7 +150,7 @@ class ActAsServiceTest : FunSpec() {
                 resolved.routing shouldBe f.directory.tenantRoutingOf(dames5)
             }
 
-            test("a caller who never entered resolves None — act-as is not a property you carry") {
+            test("a caller who never entered resolves None - act-as is not a property you carry") {
                 val f = fixture()
                 f.directory.addTeam("Dames 5", "dames-5")
 
@@ -182,7 +182,7 @@ class ActAsServiceTest : FunSpec() {
                 f.service.resolve(operator).shouldBeInstanceOf<ActAsResolution.Lapsed>()
             }
 
-            test("a lapse keeps saying Lapsed — every request in between, not just the first") {
+            test("a lapse keeps saying Lapsed - every request in between, not just the first") {
                 val f = fixture()
                 val dames5 = f.directory.addTeam("Dames 5", "dames-5")
                 f.service.enter(operator, dames5)
@@ -285,7 +285,7 @@ class ActAsServiceTest : FunSpec() {
                 record.actorKind.name shouldBe "PLATFORM_ADMIN"
             }
 
-            test("is scoped to its Team — another Team's episodes are not its business") {
+            test("is scoped to its Team - another Team's episodes are not its business") {
                 val f = fixture()
                 val dames5 = f.directory.addTeam("Dames 5", "dames-5")
                 val heren3 = f.directory.addTeam("Heren 3", "heren-3")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/ActiveTeamServiceTest.kt
@@ -36,7 +36,7 @@ class ActiveTeamServiceTest : FunSpec() {
                 service.resolveLanding(member)?.teamId shouldBe setpoint
             }
 
-            test("a teamless caller lands nowhere — no silent default tenant") {
+            test("a teamless caller lands nowhere - no silent default tenant") {
                 val (_, _, service) = fixture()
 
                 service.resolveLanding(member).shouldBeNull()
@@ -140,7 +140,7 @@ class ActiveTeamServiceTest : FunSpec() {
             }
         }
 
-        context("switching by slug — what a shared /t/:slug link performs") {
+        context("switching by slug - what a shared /t/:slug link performs") {
             test("a slug the caller is entitled to switches and hands back the Team") {
                 val (directory, gateway, service) = fixture()
                 val tovo = directory.addTeam("Tovo Heren 5", "tovo-heren-5")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/AuthorizationServiceTest.kt
@@ -155,13 +155,13 @@ class AuthorizationServiceTest : FunSpec() {
                 actingAs(teamId, who = otherOperator).isAdmin(operator, teamId) shouldBe false
             }
 
-            test("the synthesis never touches team_members — no row is written, ever") {
+            test("the synthesis never touches team_members - no row is written, ever") {
                 actingAs(teamId).requireAdmin(operator, teamId)
 
                 roster.writes.shouldBeEmpty()
             }
 
-            test("an existing member keeps their own role — the grant does not overwrite it") {
+            test("an existing member keeps their own role - the grant does not overwrite it") {
                 actingAs(teamId).isAdmin(memberId, teamId) shouldBe false
                 actingAs(teamId).isMember(memberId, teamId) shouldBe true
             }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/InvitationServiceTest.kt
@@ -158,7 +158,7 @@ class InvitationServiceTest : FunSpec() {
             f.invitations.saved.single().createdBy shouldBe adminId
         }
 
-        test("acceptInvitation requires no admin role — any authenticated user may join") {
+        test("acceptInvitation requires no admin role - any authenticated user may join") {
             val f = newFixture()
             val joinedTeam = f.service.acceptInvitation(token = "anything", userId = nonAdmin)
             joinedTeam shouldBe f.teamId

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/MemberServiceTest.kt
@@ -301,7 +301,7 @@ class MemberServiceTest : FunSpec() {
             memberRepo.findByTeamId(teamId).first { it.userId == lisaId }.onboarded shouldBe true
         }
 
-        test("completeOnboarding is idempotent — a second call keeps onboarded true") {
+        test("completeOnboarding is idempotent - a second call keeps onboarded true") {
             val (service, _, _) = newService()
             service.completeOnboarding(lisaId, teamId, "Lisa Nova", setterPositionId)
             val again = service.completeOnboarding(lisaId, teamId, "Lisa Nova", setterPositionId)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/EventIdTest.kt
@@ -14,7 +14,7 @@ import java.util.UUID
  */
 class EventIdTest : FunSpec({
 
-    test("wrapping and unwrapping is lossless — the edges can convert either way") {
+    test("wrapping and unwrapping is lossless - the edges can convert either way") {
         val raw = UUID.randomUUID()
 
         EventId(raw).value shouldBe raw

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/OccurrenceScheduleTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/OccurrenceScheduleTest.kt
@@ -30,7 +30,7 @@ class OccurrenceScheduleTest : FunSpec({
         after.atZone(amsterdam).toLocalTime() shouldBe eight30pm
     }
 
-    test("naive 7-day arithmetic would drift by an hour across the boundary — resolution does not") {
+    test("naive 7-day arithmetic would drift by an hour across the boundary - resolution does not") {
         val before = OccurrenceSchedule.startInstant(LocalDate.of(2026, 10, 20), eight30pm, amsterdam)
         val after = OccurrenceSchedule.startInstant(LocalDate.of(2026, 10, 27), eight30pm, amsterdam)
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/PlatformAdminAllowlistTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/PlatformAdminAllowlistTest.kt
@@ -12,7 +12,7 @@ class PlatformAdminAllowlistTest : FunSpec({
         allowlist.contains("  ADMIN@teambalance.NL ") shouldBe true
     }
 
-    test("an empty allowlist admits nobody — fail-closed default") {
+    test("an empty allowlist admits nobody - fail-closed default") {
         PlatformAdminAllowlist(emptyList()).contains("admin@teambalance.nl") shouldBe false
     }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RecurrenceContractTest.kt
@@ -56,14 +56,14 @@ class RecurrenceContractTest : FunSpec({
             val expected = case["affectedIds"].map { it.asText() }
 
             // A scoped DELETE's affected set is exactly the ids it removes.
-            test("$name — planDelete") {
+            test("$name - planDelete") {
                 SeriesModification.planDelete(series, currentId, scope)
                     .map { idByUuid.getValue(it) } shouldBe expected
             }
 
             // A scoped EDIT's affected set is its `edited` occurrences — the "affects N" the UI
             // previews (the regrouped THIS-tail keeps its fields and is deliberately not "affected").
-            test("$name — planEdit.edited") {
+            test("$name - planEdit.edited") {
                 SeriesModification.planEdit(series, currentId, scope, EDIT, TAIL_GROUP, ZoneId.of("UTC"))
                     .edited.map { idByUuid.getValue(it.id) } shouldBe expected
             }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirementTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/domain/model/RosterRequirementTest.kt
@@ -45,7 +45,7 @@ class RosterRequirementTest : FunSpec() {
             requirement.totalTarget shouldBe HeadcountTarget(12)
         }
 
-        test("the two axes are independent — either may be set without the other") {
+        test("the two axes are independent - either may be set without the other") {
             RosterRequirement(trackRoster = true, totalTarget = HeadcountTarget(12)).positionTargets shouldBe emptyList()
             RosterRequirement(
                 trackRoster = true,
@@ -62,7 +62,7 @@ class RosterRequirementTest : FunSpec() {
             requirement.targetFor(positionId()) shouldBe null
         }
 
-        test("withoutPosition drops only that position's target — how a deleted position leaves") {
+        test("withoutPosition drops only that position's target - how a deleted position leaves") {
             val setter = positionId()
             val libero = positionId()
             val requirement = RosterRequirement(

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGatewayAdapterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/identity/PlatformAdminGatewayAdapterTest.kt
@@ -40,7 +40,7 @@ class PlatformAdminGatewayAdapterTest : FunSpec() {
             guard(listOf("admin@teambalance.nl")).isPlatformAdmin(plainId) shouldBe false
         }
 
-        test("empty allowlist is fail-closed — nobody is a platform admin") {
+        test("empty allowlist is fail-closed - nobody is a platform admin") {
             guard(emptyList()).isPlatformAdmin(adminId) shouldBe false
         }
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/infrastructure/multitenancy/SessionTenantContextFilterTest.kt
@@ -122,7 +122,7 @@ class SessionTenantContextFilterTest : TeamBalanceIT() {
 
         // The other half of the same guarantee: a refused switch must not disturb the memo either, or
         // a probe for someone else's Team would knock the caller out of their own.
-        test("a refused switch leaves the memo — and the Active Team — exactly as it was") {
+        test("a refused switch leaves the memo - and the Active Team - exactly as it was") {
             tenantSchemaAdapter.provisionPlatformSchema()
             val userId = UUID.randomUUID()
             val mine = UUID.randomUUID()

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActAsControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/ActAsControllerIT.kt
@@ -77,7 +77,7 @@ class ActAsControllerIT : TeamBalanceIT() {
         }
 
         context("entering a Team") {
-            test("answers with the Team it entered — the name the banner needs") {
+            test("answers with the Team it entered - the name the banner needs") {
                 enterAs(OPERATOR_ID, TEAM_ID)
                     .andExpect(status().isOk)
                     .andExpect(jsonPath("$.team.id").value(TEAM_ID))
@@ -141,7 +141,7 @@ class ActAsControllerIT : TeamBalanceIT() {
                     .andExpect(jsonPath("$.code").value("ACT_AS_EXPIRED"))
             }
 
-            test("leaves no tenant behind — a lapsed operator writes nowhere, not somewhere else") {
+            test("leaves no tenant behind - a lapsed operator writes nowhere, not somewhere else") {
                 enterAs(OPERATOR_ID, TEAM_ID).andExpect(status().isOk)
                 expireGrant()
 

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreateTeamControllerIT.kt
@@ -165,7 +165,7 @@ class CreateTeamControllerIT : TeamBalanceIT() {
             teamRepository.findBySlug(Slug("create-it-happy")).shouldNotBeNull().id shouldBe summary.id
         }
 
-        test("a consumed code cannot be reused — second use returns opaque 403") {
+        test("a consumed code cannot be reused - second use returns opaque 403") {
             val founder = UUID.randomUUID().toString()
             val other = UUID.randomUUID().toString()
             seedUser(founder, "reuse-a-${founder.take(8)}@test.com")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreationCodeAdminControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/CreationCodeAdminControllerIT.kt
@@ -99,7 +99,7 @@ class CreationCodeAdminControllerIT : TeamBalanceIT() {
             seedUser(outsider, "codes-outsider@test.com")
         }
 
-        test("a platform admin creates a code, then sees it in the list — redeemable in the DB") {
+        test("a platform admin creates a code, then sees it in the list - redeemable in the DB") {
             val result = createAs(admin)
                 .andExpect(MockMvcResultMatchers.status().isCreated)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").isString)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/MemberControllerIT.kt
@@ -171,7 +171,7 @@ class MemberControllerIT : TeamBalanceIT() {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.members.length()").value(2))
         }
 
-        test("GET /api/members as a non-admin returns the roster — any active member may read it") {
+        test("GET /api/members as a non-admin returns the roster - any active member may read it") {
             seedTeam(janRole = "USER")
 
             listMembersAs(JAN_USER_ID)

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RosterFillIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/RosterFillIT.kt
@@ -118,7 +118,7 @@ class RosterFillIT : TeamBalanceIT() {
 
         // Only ATTENDING fills a slot. A maybe is not a body on the court, and an event whose whole
         // squad answered "maybe" must still read as needing everyone.
-        test("only attending rows fill slots — maybe, absent and no-response do not") {
+        test("only attending rows fill slots - maybe, absent and no-response do not") {
             seedTeam()
             val setter = positionId(SETTER)
             seedMember(SETTER_USER_ID, "fill-setter@test.com", SETTER)


### PR DESCRIPTION
## What

Replace the em-dash separator (`" — "`) with `" - "` in 24 Kotest test/context names across the `:api` test suite. Declaration lines only — comments are left untouched.

## Why

A Kotest test name becomes a directory in the Gradle HTML test report. When a name embeds a non-ASCII character (the em-dash), the report writer cannot encode that path on a filesystem whose charset is not UTF-8 (e.g. a runner with `LANG` unset / `LC_CTYPE=POSIX`), and `:api:test` fails at report generation — **even though every test passes**. The failure surfaces as `Malformed input or input contains unmappable characters` (and, on stale report dirs, `Failed to create MD5 hash … No such file or directory`).

Making all test names ASCII removes the dependency on the runner's locale.

## Verification

`:api:test` is `BUILD SUCCESSFUL` under `LANG` unset / `LC_CTYPE=POSIX` (the previously-failing condition). No test logic or behaviour changes — only display strings.

Co-Authored-By: Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ii6zM9izBGZArHihsfhWd

---
_Generated by [Claude Code](https://claude.ai/code/session_013ii6zM9izBGZArHihsfhWd)_