### PR TITLE
feat: local logout escape hatch on out-of-shell states (Slice 3, ADR-0027 §3)

### DIFF
--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -4,6 +4,8 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { routeTree } from '../routeTree.gen'
 import { WakingSplash } from '@shared/ui/ColdStartSplash'
 import { RouteErrorFallback } from '@shared/ui/RouteErrorFallback'
+import { NotFoundView } from '@shared/ui/NotFoundView'
+import { clearSession, hasClearableSession } from '@shared/api/clear-session'
 import { RootErrorBoundary } from '@app/RootErrorBoundary'
 import { installChunkErrorHandler } from '@shared/lib/chunk-reload'
 import { registerAppServiceWorker } from '@app/pwa/sw-registration'
@@ -29,8 +31,18 @@ const router = createRouter({
   defaultPendingComponent: WakingSplash,
   // A route that still throws after the reload guard (e.g. the fresh shell also 404s a chunk — a
   // real outage, not a stale-chunk race) renders the retry fallback instead of nothing. Retry does
-  // a full reload to re-fetch the shell and its current chunk hashes.
-  defaultErrorComponent: () => <RouteErrorFallback onRetry={() => window.location.reload()} />,
+  // a full reload to re-fetch the shell and its current chunk hashes. Both out-of-shell fallbacks
+  // carry a client-only Log out (ADR-0027 §3) when a session exists — or might — since `/account`'s
+  // Log out can't reach a screen that renders in place of RootLayout.
+  defaultErrorComponent: () => (
+    <RouteErrorFallback
+      onRetry={() => window.location.reload()}
+      onLogout={hasClearableSession() ? () => clearSession() : undefined}
+    />
+  ),
+  defaultNotFoundComponent: () => (
+    <NotFoundView onLogout={hasClearableSession() ? () => clearSession() : undefined} />
+  ),
 })
 
 declare module '@tanstack/react-router' {

--- a/app/src/routes/auth/verify.tsx
+++ b/app/src/routes/auth/verify.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { useVerifyMagicLink } from '@shared/api/auth'
+import { clearSession, hasClearableSession } from '@shared/api/clear-session'
 import { takePendingInviteTokenForEmail, useAcceptInvitation } from '@shared/api/invitations'
+import { VerifyErrorView } from '@shared/ui/VerifyErrorView'
 
 export const Route = createFileRoute('/auth/verify')({
   component: VerifyPage,
@@ -56,15 +58,13 @@ function VerifyPage() {
 
   if (!token || error) {
     return (
-      <div className="mx-auto mt-16 max-w-sm text-center">
-        <h1 className="font-display text-2xl font-bold">Link expired</h1>
-        <p className="mt-3 text-sm text-muted-foreground">
-          {error ?? 'This link is missing a token. Request a new one.'}
-        </p>
-        <Link to="/login" className="mt-6 inline-block text-sm font-medium text-blue">
-          Back to login
-        </Link>
-      </div>
+      <VerifyErrorView
+        message={error ?? 'This link is missing a token. Request a new one.'}
+        // Escape hatch (ADR-0027 §3): show a client-only Log out whenever a session exists — or might.
+        // The invite-accept-failure edge is exactly this: the magic link verified (a server session
+        // exists) but we withheld the auth cache, so there's a session with no in-app way out.
+        onLogout={hasClearableSession() ? () => clearSession() : undefined}
+      />
     )
   }
 

--- a/app/src/shared/api/clear-session.test.ts
+++ b/app/src/shared/api/clear-session.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AuthenticatedUser } from './auth'
 import { authMeQueryOptions } from './auth'
-import { clearSession } from './clear-session'
+import { clearSession, hasClearableSession } from './clear-session'
 import { queryClient } from './query-client'
 import { useUserStore } from '@shared/stores/user-store'
 
@@ -60,5 +60,24 @@ describe('clearSession', () => {
   it('makes no network call', () => {
     clearSession()
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('hasClearableSession', () => {
+  afterEach(() => queryClient.clear())
+
+  it('shows the hatch when a session is present', () => {
+    queryClient.setQueryData(authMeQueryOptions.queryKey, USER)
+    expect(hasClearableSession()).toBe(true)
+  })
+
+  it('hides the hatch once the probe resolves to no user', () => {
+    queryClient.setQueryData(authMeQueryOptions.queryKey, null)
+    expect(hasClearableSession()).toBe(false)
+  })
+
+  it('fails open: shows the hatch while the session is indeterminate', () => {
+    // Cache never populated — the probe has not resolved, so we cannot rule out a session.
+    expect(hasClearableSession()).toBe(true)
   })
 })

--- a/app/src/shared/api/clear-session.ts
+++ b/app/src/shared/api/clear-session.ts
@@ -19,3 +19,13 @@ export function clearSession() {
   // states that render without the router's shell.
   window.location.assign(LOGIN_PATH)
 }
+
+/**
+ * Whether an out-of-shell escape hatch should offer "Log out" (ADR-0027 §3). Logout is a property of
+ * *having a session*, so the hatch shows whenever a session exists — or *might* (the `/auth/me` probe
+ * hasn't resolved) — and hides only once the cache has positively resolved to "no user". Fail-open:
+ * an indeterminate session (`undefined`, never fetched) still shows the hatch.
+ */
+export function hasClearableSession(): boolean {
+  return queryClient.getQueryData(authMeQueryOptions.queryKey) !== null
+}

--- a/app/src/shared/ui/NotFoundView.stories.tsx
+++ b/app/src/shared/ui/NotFoundView.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import { NotFoundView } from './NotFoundView'
+
+// The router's not-found screen (ADR-0027 §3). Prop-only: it renders a <Link to="/"> ("Go home"), so
+// it takes the shared withRouter decorator. The escape hatch renders only when `onLogout` is passed —
+// the container passes it iff a session exists (or might); LoggedOut proves it's absent otherwise.
+const meta = {
+  title: 'shared/ui/NotFoundView',
+  component: NotFoundView,
+  decorators: [withRouter],
+  args: { onLogout: fn() },
+} satisfies Meta<typeof NotFoundView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByText('Page not found')).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/')
+    await userEvent.click(canvas.getByRole('button', { name: 'Log out' }))
+    await expect(args.onLogout).toHaveBeenCalled()
+  },
+}
+
+// No session: "Go home" stands alone, no escape hatch.
+export const LoggedOut: Story = {
+  args: { onLogout: undefined },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('link', { name: 'Go home' })).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Log out' })).not.toBeInTheDocument()
+  },
+}

--- a/app/src/shared/ui/NotFoundView.tsx
+++ b/app/src/shared/ui/NotFoundView.tsx
@@ -1,0 +1,36 @@
+import { Link } from '@tanstack/react-router'
+import { Button } from '@shared/ui/button'
+
+interface NotFoundViewProps {
+  /**
+   * Local escape hatch (ADR-0027 §3): a client-only `clearSession()`. Present only when a session
+   * exists — or might; omitted once the auth probe has resolved to "no user".
+   */
+  onLogout?: () => void
+}
+
+/**
+ * The router's `defaultNotFoundComponent` (ADR-0027 §3): a real not-found screen for an unknown URL.
+ * It renders *instead of* RootLayout, so `/account`'s Log out can't reach it — hence a local escape
+ * hatch beside "Go home". Prop-only; the container reads the session and passes `onLogout`.
+ */
+export function NotFoundView({ onLogout }: NotFoundViewProps) {
+  return (
+    <div className="mx-auto mt-16 max-w-sm text-center">
+      <h1 className="font-display text-2xl font-bold">Page not found</h1>
+      <p className="mt-3 text-sm text-muted-foreground">
+        We couldn't find that page. It may have moved, or the link may be out of date.
+      </p>
+      <div className="mt-6 flex items-center justify-center gap-2">
+        <Button asChild>
+          <Link to="/">Go home</Link>
+        </Button>
+        {onLogout && (
+          <Button variant="ghost" onClick={onLogout}>
+            Log out
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/shared/ui/RouteErrorFallback.stories.tsx
+++ b/app/src/shared/ui/RouteErrorFallback.stories.tsx
@@ -3,11 +3,13 @@ import { expect, fn } from 'storybook/test'
 import { RouteErrorFallback } from './RouteErrorFallback'
 
 // The fallback the router shows when a route load still fails after the chunk-reload guard (Phase 1).
-// Prop-only: the retry callback comes in as a prop, so it stories with no router or network.
+// Prop-only: the retry/logout callbacks come in as props, so it stories with no router or network.
+// The escape hatch (ADR-0027 §3) renders only when `onLogout` is passed — the container passes it iff
+// a session exists (or might); LoggedOut proves the hatch is absent once the probe says "no user".
 const meta = {
   title: 'shared/ui/RouteErrorFallback',
   component: RouteErrorFallback,
-  args: { onRetry: fn() },
+  args: { onRetry: fn(), onLogout: fn() },
 } satisfies Meta<typeof RouteErrorFallback>
 
 export default meta
@@ -15,10 +17,21 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  // Prop-contract spy: proves Retry actually reaches onRetry, not merely that the shell renders.
+  // Prop-contract spies: prove Retry and Log out actually reach their callbacks, not merely render.
   play: async ({ canvas, userEvent, args }) => {
     await expect(canvas.getByText("Couldn't load this page")).toBeInTheDocument()
     await userEvent.click(canvas.getByRole('button', { name: /retry/i }))
     await expect(args.onRetry).toHaveBeenCalled()
+    await userEvent.click(canvas.getByRole('button', { name: 'Log out' }))
+    await expect(args.onLogout).toHaveBeenCalled()
+  },
+}
+
+// No session (the auth probe resolved to no user): Retry stands alone, no escape hatch.
+export const LoggedOut: Story = {
+  args: { onLogout: undefined },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Log out' })).not.toBeInTheDocument()
   },
 }

--- a/app/src/shared/ui/RouteErrorFallback.tsx
+++ b/app/src/shared/ui/RouteErrorFallback.tsx
@@ -1,22 +1,36 @@
+import { Button } from '@shared/ui/button'
 import { QueryErrorState } from './QueryErrorState'
 
 interface RouteErrorFallbackProps {
   /** Recover — typically a full reload to re-fetch the shell and its current chunk hashes. */
   onRetry: () => void
+  /**
+   * Local escape hatch (ADR-0027 §3): a client-only `clearSession()`. Present only when a session
+   * exists — or might; omitted once the auth probe has resolved to "no user", when there is nothing
+   * to log out of. Rendered beside Retry.
+   */
+  onLogout?: () => void
 }
 
 /**
  * The router's last-resort error fallback (caching plan Phase 1), rendered by the router's
  * `defaultErrorComponent` when a route still throws after the one-shot chunk-reload guard has run —
  * e.g. the fresh shell also failed to load a chunk. Reuses the shared QueryErrorState shell so a
- * load failure is never a blank frame; Retry reloads to re-fetch the shell.
+ * load failure is never a blank frame; Retry reloads to re-fetch the shell. Because this renders
+ * *instead of* RootLayout, `/account`'s Log out can't reach it — so it carries its own (ADR-0027 §3).
  */
-export function RouteErrorFallback({ onRetry }: RouteErrorFallbackProps) {
+export function RouteErrorFallback({ onRetry, onLogout }: RouteErrorFallbackProps) {
   return (
     <QueryErrorState
       title="Couldn't load this page"
       description="Something went wrong loading the app. Please try again."
       onRetry={onRetry}
-    />
+    >
+      {onLogout && (
+        <Button variant="ghost" onClick={onLogout}>
+          Log out
+        </Button>
+      )}
+    </QueryErrorState>
   )
 }

--- a/app/src/shared/ui/VerifyErrorView.stories.tsx
+++ b/app/src/shared/ui/VerifyErrorView.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import { withRouter } from '@shared/testing/router-decorator'
+import { VerifyErrorView } from './VerifyErrorView'
+
+// The /auth/verify error state (ADR-0027 §3). Prop-only: it renders a <Link to="/login">, so it takes
+// the shared withRouter decorator. "Back to login" is always present; the escape hatch renders only
+// when `onLogout` is passed — the container passes it iff a session exists (or might). Stranded is the
+// key edge: sign-in worked but the invite failed, so a client-only logout is the only way out.
+const meta = {
+  title: 'shared/ui/VerifyErrorView',
+  component: VerifyErrorView,
+  decorators: [withRouter],
+  args: { onLogout: fn() },
+} satisfies Meta<typeof VerifyErrorView>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Authenticated but stranded (invite-accept-failure): both "Back to login" and the escape hatch show.
+export const Stranded: Story = {
+  args: {
+    message:
+      'Your sign-in worked, but the invite link has expired or is no longer valid. Ask your team admin for a new invitation.',
+  },
+  play: async ({ canvas, userEvent, args }) => {
+    await expect(canvas.getByRole('link', { name: 'Back to login' })).toHaveAttribute('href', '/login')
+    await userEvent.click(canvas.getByRole('button', { name: 'Log out' }))
+    await expect(args.onLogout).toHaveBeenCalled()
+  },
+}
+
+// No session (an expired/used magic link never signed anyone in): "Back to login" only, no hatch.
+export const LoggedOut: Story = {
+  args: {
+    message: 'This link has expired or already been used. Request a new one.',
+    onLogout: undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('link', { name: 'Back to login' })).toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Log out' })).not.toBeInTheDocument()
+  },
+}

--- a/app/src/shared/ui/VerifyErrorView.tsx
+++ b/app/src/shared/ui/VerifyErrorView.tsx
@@ -1,0 +1,38 @@
+import { Link } from '@tanstack/react-router'
+import { Button } from '@shared/ui/button'
+
+interface VerifyErrorViewProps {
+  /** The failure copy — a missing/expired magic link, or the invite-accept-failure message. */
+  message: string
+  /**
+   * Local escape hatch (ADR-0027 §3): a client-only `clearSession()`. Present when a session exists —
+   * or might (e.g. the "authenticated but stranded" invite-accept-failure); omitted once the auth
+   * probe has resolved to "no user".
+   */
+  onLogout?: () => void
+}
+
+/**
+ * The `/auth/verify` error state, rendered *instead of* RootLayout (ADR-0027 §3). "Back to login" is
+ * always offered; the escape hatch is added when a session exists — most importantly the
+ * "authenticated but stranded, no team" invite-accept-failure edge, where a client-only logout is the
+ * only way out. Prop-only; the container reads the session and passes `onLogout`.
+ */
+export function VerifyErrorView({ message, onLogout }: VerifyErrorViewProps) {
+  return (
+    <div className="mx-auto mt-16 max-w-sm text-center">
+      <h1 className="font-display text-2xl font-bold">Link expired</h1>
+      <p className="mt-3 text-sm text-muted-foreground">{message}</p>
+      <div className="mt-6 flex items-center justify-center gap-4">
+        <Link to="/login" className="text-sm font-medium text-blue">
+          Back to login
+        </Link>
+        {onLogout && (
+          <Button variant="ghost" onClick={onLogout}>
+            Log out
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What & why

**Slice 3 of #261** (per **ADR-0027 §3**). Three signed-in states render _in place of_ `RootLayout`, so `/account`'s bottom-bar **Log out** can't reach them. Each now carries its own **client-only** escape hatch wired to `clearSession()` — **no `api.Logout()` round-trip**, so it survives a dead backend:

1. **`RouteErrorFallback`** (the router's `defaultErrorComponent`) — **Log out** beside Retry.
2. **`VerifyErrorView`** — extracts the `/auth/verify` error block into a prop-only shell and adds the hatch. Covers the "authenticated but stranded, no team" invite-accept-failure edge (the magic link verified — a server session exists — but the auth cache was withheld, so there's a session with no in-app way out).
3. **`NotFoundView`** — a new `defaultNotFoundComponent` (a real 404 with a **Go home** link **and** the hatch); none existed before.

The cold-start `WakingSplash` is **deliberately skipped** (ADR-0027 §3 rejected item): it renders before the session probe resolves, and a failed wake escalates to `RouteErrorFallback`, which now carries the hatch.

## Session-driven, fail-open visibility

Per review discussion, the hatch's visibility is a property of _having a session_, not of the specific error branch. New pure helper **`hasClearableSession()`** reads the `['auth','me']` cache and returns `me !== null`: it shows the hatch when a session exists **or might** (the probe hasn't resolved — `undefined`), and hides it **only** once the cache positively resolves to "no user". Each container passes `onLogout = hasClearableSession() ? () => clearSession() : undefined`; the shells render **Log out** iff `onLogout` is present.

`clearSession()` is untouched — its zero-network contract stands (the escape hatch calls it alone).

## Container/View split

All three are **prop-only shells** taking an `onLogout` callback, so they stay story-able with no router/network.

## Tests (lowest layer that proves it)

- **Storybook** stories for `RouteErrorFallback`, `NotFoundView`, `VerifyErrorView` — each with a logged-in variant (an `fn()` `onLogout` spy, `play` asserts it fires) and a logged-out variant (asserts the hatch is absent).
- **Vitest unit** for `hasClearableSession` (user → show, `null` → hide, `undefined` → fail-open show).
- **No new e2e** — that's Slice 4. These are prop-only shells, ideal story targets.

## Verification note

The three new **Storybook stories pass** in a real headless browser, **ESLint is green** across the project, and the changed files are type-clean. The generated Wirespec client (`src/shared/api/generated`, git-ignored) could **not** be regenerated in this environment — `./gradlew :api:wirespec-typescript` fails on upstream **Maven Central 429 (Too Many Requests)** — so the API-layer Vitest units, `tsc -b`, and detekt (all of which transitively need that codegen) rely on **CI**, where `make wirespec` runs. The `hasClearableSession` unit was verified locally against a throwaway stub of the generated module (not committed) and passes.

Closes part of #261 (Slice 3 boxes ticked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6upmJdqC6YuY4C96n27H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QswmJyqtwt5LMpp7bAUaqK)_