### PR TITLE
test: logout-everywhere Slice 4 — teamless logout e2e + cleanup (ADR-0027)

### DIFF
--- a/app/e2e-real/logout-teamless.spec.ts
+++ b/app/e2e-real/logout-teamless.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+// Real e2e (ADR-0027, Slice 4): log out from a TEAMLESS session — the one logout seam the login and
+// attendance flows never exercise, so it earns a single new flow (ADR-0017's bar).
+//
+// Before ADR-0027, Log out lived on `/t/:slug/profile`, reachable only once the URL carried a team
+// slug — so a teamless (or mid-onboarding) user had no way out. This proves the gap is closed: the
+// BottomNav Profile tab points at the team-independent `/account` even with no team, and Log out there
+// tears the session down server-side. Spans browser → API → DB: verify creates a brand-new teamless
+// user, `/account` renders without a tenant, and `/auth/me` stops resolving after logout.
+//
+// The existing onboarded-user logout (auth-guard.spec.ts) reaches Events first; this one never does.
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+// A per-run-unique email so the magic-link verify always creates a FRESH, teamless user — a warm DB
+// never carries a prior run's now-onboarded or team-joined identity past the has-any-team gate.
+const RUN = Date.now()
+const TEAMLESS_EMAIL = `logout-teamless-${RUN}@example.com`
+
+// Start unauthenticated — this spec mints its own throwaway teamless session, overriding the
+// project-wide storageState.
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test('log out from a teamless session returns to login and ends the session', async ({ page, request }) => {
+  // 1. Sign in a brand-new email → verify will create the user teamless (no invite, no team).
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(TEAMLESS_EMAIL)
+  await page.getByRole('button', { name: 'Send magic link' }).click()
+  await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+  const tokenResponse = await request.get(`${BACKEND_URL}/internal/e2e/magic-link-token`, {
+    params: { email: TEAMLESS_EMAIL },
+  })
+  expect(tokenResponse.ok()).toBeTruthy()
+  const { token } = await tokenResponse.json()
+
+  // 2. Click the emailed link → the has-any-team gate parks the teamless user on /onboarding (they
+  //    are NOT bounced to /login — the teamless session is valid, it just has no team yet).
+  await page.goto(`/auth/verify?token=${token}`)
+  await expect(page.getByRole('heading', { name: /Welcome to TeamBalance/ })).toBeVisible({ timeout: 10_000 })
+
+  // 3. The BottomNav Profile tab points at the team-independent /account even with no team (ADR-0027
+  //    §1), so Log out is reachable from this teamless state — the gap this ADR closes.
+  await page.getByRole('link', { name: 'Profile' }).click()
+  await expect(page).toHaveURL('/account')
+
+  // 4. Log out → a clean server-side teardown, then a hard-redirect to /login.
+  await page.getByRole('button', { name: 'Log out' }).click()
+  await expect(page).toHaveURL('/login')
+  await expect(page.getByRole('heading', { name: 'TeamBalance' })).toBeVisible()
+
+  // 5. The session is gone server-side: /auth/me no longer resolves to a user.
+  const me = await page.request.get('/api/auth/me')
+  expect(me.status()).toBe(401)
+})

--- a/app/src/routes/admin/creation-codes.tsx
+++ b/app/src/routes/admin/creation-codes.tsx
@@ -3,7 +3,7 @@ import { ManageCreationCodes } from '@features/manage-creation-codes/ui/ManageCr
 
 // Platform-admin creation-codes surface (#154 Slice 4). Authorization is enforced server-side: the
 // endpoints 403 for non–platform-admins and the container renders a no-access shell. The route isn't
-// gated in beforeLoad; the entry point (a link on /profile) is shown only when /auth/me reports
+// gated in beforeLoad; the entry point (a link on /account) is shown only when /auth/me reports
 // isPlatformAdmin.
 export const Route = createFileRoute('/admin/creation-codes')({
   component: CreationCodesAdminPage,


### PR DESCRIPTION
Final slice of the "logout everywhere" work ([ADR-0027](https://github.com/ZzAve/teambalance-app/blob/main/docs/adr/0027-logout-reachable-everywhere-account-tab.md)). Slices 0–3 already landed the `clearSession()` primitive, the team-independent `/account` tab, the generalized Teams sub-page, and the out-of-shell escape hatch. This closes the tracker.

Closes #261

## What's here

### 1. One new e2e — teamless logout (`app/e2e-real/logout-teamless.spec.ts`)

The single genuinely-new seam per ADR-0017 / the CLAUDE.md PR gate: **logout from a teamless session**, which the login and attendance flows never exercise. Before ADR-0027, Log out lived on `/t/:slug/profile`, reachable only once the URL carried a team slug — so a teamless (or mid-onboarding) user had no way out.

Flow: sign in a fresh, per-run teamless user → the has-any-team gate parks them on `/onboarding` → open **Profile** via the BottomNav (it points at the team-independent `/account`, ADR-0027 §1) → **Log out** → assert redirect to `/login` and that `/auth/me` no longer resolves (session torn down server-side).

It reuses the suite's existing patterns: the magic-link request/verify + `internal/e2e/magic-link-token` helper and the fresh-per-run-email idiom from `create-team.spec.ts` (self-contained; no shared session to tear down). No new helper invented, and exactly **one** flow added — everything else is proven lower down (the `accountSections` unit, the `AccountView`/`TeamsView`/fallback stories).

> Note: the existing `auth-guard.spec.ts` logout test already covers the **onboarded** `/account` logout; this PR adds only the **teamless** case, so no coverage is duplicated.

### 2. Cleanup

The migration's dead code was already removed across Slices 1–3 — there is no orphaned `LogoutButton` component, `teamRoutes.profile` is gone (with a `team-routes` unit asserting its absence), `useLogout`/`clearSession` are cleanly wired, and the `/t/$slug/profile → /account` redirect is intentionally kept for bookmarks. The only lingering residue was a stale `/profile` reference in the `admin/creation-codes` route comment (the platform-admin entry link now lives on `/account`, ADR-0027 §2), corrected to `/account`.

## Verification — all green

- `make test` — `test-api` + `test-app` (710 frontend tests, 106 files)
- `make e2e` — 14 specs, including the new `logout-teamless` flow
- `make lint` — detekt + eslint

## Deviations from the plan

None material. The tracker's Slice 4 checklist assumed dead code would remain to remove; in practice Slices 1–3 had already pruned it, so the cleanup reduced to the one stale comment above. The gap map holds: there is no signed-in state left without a reachable logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6upmJdqC6YuY4C96n27H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR8PqFU9AAMoodegATneuz)_