### PR TITLE
chore: make vite config compatible with native configLoader

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { resolve } from 'path'
-import { pwaManifest, pwaWorkbox } from './src/app/pwa/manifest'
+import { pwaManifest, pwaWorkbox } from './src/app/pwa/manifest.ts'
 
 export default defineConfig({
   plugins: [
@@ -35,12 +35,12 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@app': resolve(__dirname, 'src/app'),
-      '@pages': resolve(__dirname, 'src/pages'),
-      '@widgets': resolve(__dirname, 'src/widgets'),
-      '@features': resolve(__dirname, 'src/features'),
-      '@entities': resolve(__dirname, 'src/entities'),
-      '@shared': resolve(__dirname, 'src/shared'),
+      '@app': resolve(import.meta.dirname, 'src/app'),
+      '@pages': resolve(import.meta.dirname, 'src/pages'),
+      '@widgets': resolve(import.meta.dirname, 'src/widgets'),
+      '@features': resolve(import.meta.dirname, 'src/features'),
+      '@entities': resolve(import.meta.dirname, 'src/entities'),
+      '@shared': resolve(import.meta.dirname, 'src/shared'),
     },
   },
   server: {

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { playwright } from '@vitest/browser-playwright'
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
-import viteConfig from './vite.config'
+import viteConfig from './vite.config.ts'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 


### PR DESCRIPTION
## What

Silences the Vite startup warning that the config uses features unsupported by `configLoader: 'native'` (the planned future default):

- `__dirname` in the resolve aliases → `import.meta.dirname`
- extensionless import of `./src/app/pwa/manifest` → add the `.ts` extension

Both are drop-in ESM-native equivalents.

## Why

`configLoader: 'native'` is slated to become Vite's default in a future major. Adopting the native-safe forms now keeps the dev server output clean and avoids a breaking surprise on the next major bump.

## Verification

- `npm run dev` starts clean — no `configLoader` / `__dirname` / file-extension warning (grep-confirmed against startup output).
- Pre-commit `make yolo test` passed.

No behavioural change; aliases resolve to the same paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)