### PR TITLE
fix: stop the chase callout claiming one position when several are empty

### DIFF
--- a/app/src/entities/event/lib/roster-view.test.ts
+++ b/app/src/entities/event/lib/roster-view.test.ts
@@ -5,7 +5,7 @@ import {
   coveredSummary,
   hasRosterPanel,
   headcountLine,
-  oneToChase,
+  chaseNudge,
   rosterChip,
   rosterRows,
   unassignedNudge,
@@ -147,27 +147,52 @@ describe('rosterRows', () => {
   })
 })
 
-describe('oneToChase', () => {
-  it('picks the first targeted position with nobody at all', () => {
+describe('chaseNudge', () => {
+  it('names the single empty position and calls it the one to chase', () => {
     const r = roster({
-      positions: [pos('Setter', 2, 1), pos('Libero', 1, 0), pos('Middle', 2, 0)],
+      positions: [pos('Setter', 2, 1), pos('Libero', 1, 0), pos('Middle', 2, 1)],
     })
-    expect(oneToChase(r)?.label).toBe('Libero')
+    expect(chaseNudge(r)).toEqual({ lead: 'Libero', rest: 'still has no one — the one to chase.' })
   })
 
-  // One name, not a list: a callout naming three positions is an inventory, and the rows already
-  // show the rest.
-  it('names only one even when several are empty', () => {
+  // Two is still a nudge, so both are named. "the one to chase" must not survive: it is a definite
+  // article, and claiming uniqueness when two are empty says the other one is fine.
+  it('names both when two are empty, and drops the uniqueness claim', () => {
     const r = roster({ positions: [pos('Libero', 1, 0), pos('Middle', 2, 0)] })
-    expect(oneToChase(r)?.label).toBe('Libero')
+    expect(chaseNudge(r)).toEqual({ lead: 'Libero and Middle', rest: 'still have no one.' })
+  })
+
+  // Three names is an inventory, not a nudge, and the rows above already list them. The count is
+  // the news: it says "this is not one gap" without reprinting the panel.
+  it('counts them instead of listing once there are three or more', () => {
+    const r = roster({
+      positions: [pos('Libero', 1, 0), pos('Middle', 2, 0), pos('Setter', 2, 0)],
+    })
+    expect(chaseNudge(r)).toEqual({ lead: '3 positions', rest: 'still have no one.' })
+  })
+
+  // The reported case: nobody has answered at all, so every targeted position is empty. Singling
+  // one out implied the other five were covered.
+  it('counts them when nothing has been answered at all', () => {
+    const r = roster({
+      positions: [
+        pos('Diagonaal', 2, 0),
+        pos('Libero', 1, 0),
+        pos('Midden', 3, 0),
+        pos('Passer/Loper', 2, 0),
+        pos('Spelverdeler', 2, 0),
+        pos('Trainer/Coach', 1, 0),
+      ],
+    })
+    expect(chaseNudge(r)).toEqual({ lead: '6 positions', rest: 'still have no one.' })
   })
 
   it('is absent when every targeted position has somebody', () => {
-    expect(oneToChase(roster({ positions: [pos('Setter', 3, 1)] }))).toBeNull()
+    expect(chaseNudge(roster({ positions: [pos('Setter', 3, 1)] }))).toBeNull()
   })
 
-  it('never picks an untargeted position, however empty', () => {
-    expect(oneToChase(roster({ positions: [pos('Middle', undefined, 0)] }))).toBeNull()
+  it('never counts an untargeted position, however empty', () => {
+    expect(chaseNudge(roster({ positions: [pos('Middle', undefined, 0)] }))).toBeNull()
   })
 })
 

--- a/app/src/entities/event/lib/roster-view.ts
+++ b/app/src/entities/event/lib/roster-view.ts
@@ -107,12 +107,33 @@ function rowTone(position: RosterPosition): RosterTone | null {
   return position.attending >= position.required ? 'covered' : 'short'
 }
 
+/** The chase callout, split so the caller can bold the subject without owning any of the copy. */
+export interface ChaseNudge {
+  /** The subject — position names, or a count once naming them would be an inventory. */
+  lead: string
+  /** The rest of the sentence, already agreeing in number with `lead`. */
+  rest: string
+}
+
 /**
- * The first targeted position with nobody at all — the "one to chase". Only the first: a callout
- * naming three positions is a list, not a nudge, and the panel rows already show the rest.
+ * The callout under the rows for targeted positions with nobody at all.
+ *
+ * It scales with how many are empty, because one shape cannot honestly cover all three. Naming a
+ * single position and calling it "the one to chase" is the useful case and stays. Naming two is
+ * still a nudge. From three on it becomes an inventory the rows above already print, so the count
+ * carries it instead.
+ *
+ * What must not happen is the old behaviour: naming the *first* empty position and calling it "the
+ * one to chase" regardless of how many others were also empty. On an event nobody has answered yet
+ * that singled out one position and implied every other was covered.
  */
-export function oneToChase(roster: EventRoster): RosterRow | null {
-  return rosterRows(roster).find((row) => row.pips.length > 0 && row.pips.every((p) => p === 'missing')) ?? null
+export function chaseNudge(roster: EventRoster): ChaseNudge | null {
+  const empty = rosterRows(roster).filter((row) => row.pips.length > 0 && row.pips.every((p) => p === 'missing'))
+
+  if (empty.length === 0) return null
+  if (empty.length === 1) return { lead: empty[0].label, rest: 'still has no one — the one to chase.' }
+  if (empty.length === 2) return { lead: `${empty[0].label} and ${empty[1].label}`, rest: 'still have no one.' }
+  return { lead: `${empty.length} positions`, rest: 'still have no one.' }
 }
 
 /**

--- a/app/src/entities/event/ui/RosterPips.stories.tsx
+++ b/app/src/entities/event/ui/RosterPips.stories.tsx
@@ -78,6 +78,51 @@ export const Critical: Story = {
   },
 }
 
+// Two empty positions are still worth naming, but "the one to chase" must not survive: a definite
+// article claiming uniqueness tells you the other one is covered.
+export const TwoEmptyPositions: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'CRITICAL',
+      totalAttending: 2,
+      positions: [pos('Setter', 2, 2), pos('Libero', 1, 0), pos('Middle', 2, 0)],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Libero and Middle', { selector: 'b' })).toBeInTheDocument()
+    await expect(canvas.getByText(/still have no one/)).toBeInTheDocument()
+    await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
+  },
+}
+
+// The reported case: nobody has answered, so every targeted position is empty. Naming the first one
+// claimed the other five were fine — from three up the count is the news, and the rows above already
+// list which ones.
+export const NothingAnsweredYet: Story = {
+  args: {
+    roster: makeRoster({
+      state: 'CRITICAL',
+      totalAttending: 0,
+      positions: [
+        pos('Diagonaal', 2, 0),
+        pos('Libero', 1, 0),
+        pos('Midden', 3, 0),
+        pos('Passer/Loper', 2, 0),
+        pos('Spelverdeler', 2, 0),
+        pos('Trainer/Coach', 1, 0),
+      ],
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('6 positions', { selector: 'b' })).toBeInTheDocument()
+    await expect(canvas.getByText(/still have no one/)).toBeInTheDocument()
+    // No position is singled out, and none is called "the one".
+    await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
+    await expect(canvas.queryByText('Diagonaal', { selector: 'b' })).not.toBeInTheDocument()
+    await expect(canvas.getByText('0 of 6 covered')).toBeInTheDocument()
+  },
+}
+
 // No position carries a target, so there is no covered fraction and no pips — the header carries the
 // absolute headcount instead.
 export const HeadcountOnly: Story = {

--- a/app/src/entities/event/ui/RosterPips.tsx
+++ b/app/src/entities/event/ui/RosterPips.tsx
@@ -3,7 +3,7 @@ import type { EventRoster } from '@shared/api/events'
 import {
   coveredSummary,
   headcountLine,
-  oneToChase,
+  chaseNudge,
   rosterRows,
   unassignedNudge,
   type PipState,
@@ -40,7 +40,7 @@ const PIP_TONE: Record<PipState, string> = {
 export function RosterPips({ roster }: RosterPipsProps) {
   const rows = rosterRows(roster)
   const covered = coveredSummary(roster)
-  const chase = oneToChase(roster)
+  const chase = chaseNudge(roster)
   const nudge = unassignedNudge(roster)
   const headcount = headcountLine(roster)
 
@@ -71,7 +71,7 @@ export function RosterPips({ roster }: RosterPipsProps) {
         <p className="mt-2.5 flex items-start gap-1.5 rounded-[10px] bg-gold/15 px-2.5 py-2 text-[11.5px] text-foreground/80">
           <TriangleAlert size={13} className="mt-0.5 shrink-0 text-gold-dark" aria-hidden />
           <span>
-            <b>{chase.label}</b> still has no one — the one to chase.
+            <b>{chase.lead}</b> {chase.rest}
           </span>
         </p>
       )}


### PR DESCRIPTION
## The bug

On an event nobody has answered yet, every targeted position is empty — and the panel picked the first one and called it *the* one:

> ⚠️ **Diagonaal** still has no one — the one to chase.

"The one" is a definite article. It singled out whichever empty position happened to sort first and implied Libero, Midden, Passer/Loper, Spelverdeler and Trainer/Coach were all fine — on a card whose own header, three lines above, read **0 of 6 covered** and whose chip read **11 spots open**.

`oneToChase` returned `rosterRows(roster).find(...)` — the *first* match, always, however many there were.

## The fix

The callout scales with how many are actually empty, because one shape cannot honestly cover all three cases:

| empty | copy |
|---|---|
| 1 | **Libero** still has no one — the one to chase. *(unchanged)* |
| 2 | **Libero and Middle** still have no one. |
| 3+ | **6 positions** still have no one. |

Naming two is still a nudge, so both get named. From three it becomes an inventory the rows above already print, so the count carries it instead — which is the original *"a callout naming three positions is a list, not a nudge"* reasoning kept intact, just without the false uniqueness claim it used to ship with.

`oneToChase` is renamed **`chaseNudge`** and returns the sentence split into a bold subject and the rest:

```ts
{ lead: '6 positions', rest: 'still have no one.' }
```

That keeps number agreement (`has` vs `have`) with the copy in the pure lib rather than reassembling it in the component, so all three shapes are Vitest-testable and `RosterPips` just renders `<b>{lead}</b> {rest}`.

## Testing

**Written test-first** — the six `chaseNudge` units failed before the implementation existed.

- **Vitest** (`roster-view.test.ts`) — one, two, three, and the reported six-empty case; plus the two existing negatives (every position staffed; an untargeted position, however empty).
  - The old `it('names only one even when several are empty')` **asserted the behaviour being fixed** and is replaced. Worth a reviewer's eye: this is a deliberate design change, not a bug in the old test.
- **Storybook** — two new stories on `RosterPips`:
  - `TwoEmptyPositions` — both named, and asserts `/the one to chase/` is **gone**.
  - `NothingAnsweredYet` — reproduces the screenshot exactly (six positions, 11 open slots), asserts the count renders, that no position is bolded, and that nothing is called "the one".
  - The existing `Critical` story still covers the single-empty case unchanged.

**No new e2e.** Copy inside an already-covered component — no new seam.

Chromatic will want baselines for the two new stories.

Verified locally: **727 frontend tests / 109 files**, `tsc -b` and ESLint clean. Backend untouched.

<sub>Unrelated but worth knowing: the first full run after regenerating the wirespec TS client reported 9 failures with 7 file-level errors — a cold Vite dep-optimizer pass, not real failures. Two subsequent runs were clean.</sub>

## Note

Not related to #281 (coaches counting toward the headcount). That one is about the arithmetic; this is about the sentence underneath it. Both are visible in the same screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJMfkKZpBaSkTBVhgSzCrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJMfkKZpBaSkTBVhgSzCrn)_