### PR TITLE
feat(app): give the Next Up hero a readiness signal (#275)

### DIFF
--- a/app/src/entities/event/ui/ReadinessBadge.tsx
+++ b/app/src/entities/event/ui/ReadinessBadge.tsx
@@ -5,6 +5,14 @@ interface ReadinessBadgeProps {
   roster: EventRoster
   /** A write is in flight: the roster the server last computed is now stale, so dim it while it settles. */
   pending?: boolean
+  /**
+   * Which ground the badge is drawn on (#275).
+   *
+   * `card` is the light surface the tints below are built for. `hero` is the Next Up hero's solid
+   * green: `bg-green/15` over green is invisible there, so the chip inverts to solid white and the
+   * tone survives in the dot alone. Same `rosterChip`, same words — only the paint differs.
+   */
+  variant?: 'card' | 'hero'
 }
 
 // Semantic colours, read against the attendance palette already on the card: green means "as it
@@ -28,17 +36,23 @@ const DOT_TONE: Record<RosterTone, string> = {
  * Presentational — the verdict is `rosterChip`, already computed by the server (#219). Two roster
  * states carry no verdict (a social, and tracking-on-with-no-targets): rather than leave the row with
  * no team information at all, both fall back to a plain headcount from `roster.totalAttending` (⑥,
- * #271). That headcount counts coaches as players today — deliberately left as-is until #281.
+ * #271). That headcount counts coaches as players today — deliberately left as-is until #281. The
+ * `hero` variant renders nothing instead, because that surface already prints the headcount itself.
  *
  * While an attendance write is in flight the badge shows a `pending` state (⑤): the roster is not
  * recomputed client-side (see `applyOptimisticAttendance`), so the last-known verdict is dimmed while
  * it settles rather than asserted as current — it is most prominent at the moment it is most stale.
  */
-export function ReadinessBadge({ roster, pending = false }: ReadinessBadgeProps) {
+export function ReadinessBadge({ roster, pending = false, variant = 'card' }: ReadinessBadgeProps) {
   const chip = rosterChip(roster)
+  const hero = variant === 'hero'
   const dim = pending ? 'animate-pulse opacity-60' : ''
 
   if (!chip) {
+    // On the hero there is nothing to fall back to: its status line is already a headcount
+    // ("10 going - you're in"), so a chip repeating that number would say the same thing twice.
+    if (hero) return null
+
     // No verdict to give — say who is coming rather than nothing.
     return (
       <span aria-busy={pending} className={`text-xs font-semibold text-muted-foreground ${dim}`}>
@@ -50,7 +64,11 @@ export function ReadinessBadge({ roster, pending = false }: ReadinessBadgeProps)
   return (
     <span
       aria-busy={pending}
-      className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold ${CHIP_TONE[chip.tone]} ${dim}`}
+      // The hero's ink is the fixed --color-green-dark its own white "I'm in" button already uses.
+      // `text-foreground` would be wrong there: the hero's ground stays green in both themes while
+      // that token inverts, so the label would go near-white on a white chip in dark mode.
+      style={hero ? { color: 'var(--color-green-dark)' } : undefined}
+      className={`flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold ${hero ? 'bg-white' : CHIP_TONE[chip.tone]} ${dim}`}
     >
       <span className={`size-1.5 rounded-full ${DOT_TONE[chip.tone]}`} aria-hidden />
       {chip.text}

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn } from 'storybook/test'
 import { withRouter } from '@shared/testing/router-decorator'
-import { makeEvent } from '@shared/testing/event-fixtures'
+import { makeEvent, makeRoster, NO_ROSTER } from '@shared/testing/event-fixtures'
 import { allModes } from '../../../../.storybook/modes'
 import { NextEventHeroView } from './NextEventHeroView'
 
@@ -212,5 +212,99 @@ export const StartingToday: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('11h')).toBeInTheDocument()
+  },
+}
+
+// ── Readiness (#275) ────────────────────────────────────────────────────────────────────────────
+// The hero was the last surface in the app with no roster verdict. It carries the same
+// `ReadinessBadge` as the card row (#273) — same `rosterChip`, no second computation — in its
+// `hero` variant: a solid white chip, because the tinted card chip's green-on-green would vanish
+// against this ground.
+
+const READY_EVENT = makeEvent({
+  ...EVENT,
+  roster: makeRoster({
+    state: 'LINEUP_SET',
+    positions: [
+      { id: 'pos-setter', label: 'Setter', required: 2, attending: 2 },
+      { id: 'pos-libero', label: 'Libero', required: 1, attending: 1 },
+      { id: 'pos-middle', label: 'Middle', required: 2, attending: 2 },
+    ],
+    totalAttending: 10,
+  }),
+})
+
+export const ReadinessCovered: Story = {
+  args: { event: READY_EVENT, myState: 'ATTENDING' },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Lineup set')).toBeInTheDocument()
+    // The verdict joins the headcount the hero already carried; it does not replace it.
+    await expect(canvas.getByText(/10 going · you're in/)).toBeInTheDocument()
+  },
+}
+
+export const ReadinessShort: Story = {
+  args: {
+    event: makeEvent({ ...EVENT, roster: makeRoster({ totalAttending: 10 }) }),
+    myState: 'ATTENDING',
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('1 spot open')).toBeInTheDocument()
+  },
+}
+
+// Nobody at all at two targeted positions. The headcount moves with it: a roster with no one
+// attending cannot sit on a summary claiming ten are.
+export const ReadinessCritical: Story = {
+  args: {
+    event: makeEvent({
+      ...EVENT,
+      attendanceSummary: { attending: 0, maybe: 0, absent: 2, notResponded: 13, roleBreakdown: [] },
+      roster: makeRoster({
+        state: 'CRITICAL',
+        positions: [
+          { id: 'pos-setter', label: 'Setter', required: 2, attending: 0 },
+          { id: 'pos-libero', label: 'Libero', required: 1, attending: 0 },
+        ],
+        totalAttending: 0,
+      }),
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('3 spots open')).toBeInTheDocument()
+  },
+}
+
+// Tracking is on but nothing is targeted, so there is no verdict to give. On the card that falls
+// back to a plain headcount — here it renders nothing, because the hero's own status line is
+// already a headcount and printing "10 going" twice on one card says nothing twice.
+export const ReadinessTallyOnly: Story = {
+  // Behavioural twin of Going — no chip, so the picture is the unbadged hero (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: {
+    event: makeEvent({
+      ...EVENT,
+      roster: makeRoster({ state: 'TALLY_ONLY', positions: [], totalAttending: 10, openSlots: 0 }),
+    }),
+    myState: 'ATTENDING',
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByText(/\bgoing\b/)).toHaveLength(1)
+  },
+}
+
+// A social: tracking off entirely. No chip — and, because the chip shares the status line's row
+// rather than claiming one of its own, no reserved space either.
+export const ReadinessNotTracked: Story = {
+  // Behavioural twin of Going — no chip, identical picture (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: { event: makeEvent({ ...EVENT, roster: NO_ROSTER }), myState: 'ATTENDING' },
+  play: async ({ canvas }) => {
+    const status = canvas.getByText(/10 going · you're in/)
+    await expect(canvas.queryByText(/spot|spots|Lineup set|Full|more needed/)).not.toBeInTheDocument()
+    // The row the chip would have shared claims no more height than the status line inside it, so
+    // an absent verdict leaves no gap above the RSVP buttons.
+    const row = status.parentElement!
+    await expect(row.getBoundingClientRect().height).toBe(status.getBoundingClientRect().height)
   },
 }

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { Check, Clock, MapPin, X } from 'lucide-react'
 import type { Event } from '@shared/api/events'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
+import { ReadinessBadge } from '@entities/event/ui/ReadinessBadge'
 import { heroCountdown } from '../lib/countdown'
 import { useTeamRoutes } from '@shared/lib/team-routes'
 
@@ -118,9 +119,17 @@ export function NextEventHeroView({
         </p>
       )}
 
-      <p className="mt-2.5 text-[13px] text-white/90">
-        {event.attendanceSummary.attending} going · {MY_STATE_TEXT[myState]}
-      </p>
+      {/* The headcount and the viewer's answer on the left; the roster verdict on the right (#275).
+          One row, not two: with no verdict to give the badge renders nothing and the row collapses
+          to the height of the status line, so a social reserves no space for a chip it never shows.
+          The badge is deliberately *not* lifted above the stretched overlay — it is information, not
+          a control, so tapping it opens the event like the rest of the passive rows. */}
+      <div className="mt-2.5 flex items-center justify-between gap-2">
+        <p className="text-[13px] text-white/90">
+          {event.attendanceSummary.attending} going · {MY_STATE_TEXT[myState]}
+        </p>
+        <ReadinessBadge roster={event.roster} variant="hero" pending={isSaving} />
+      </div>
 
       {/* The answer the viewer has given is the solid button; the other one recedes. With no answer
           yet, "I'm in" is solid because it is the invitation, not because it has been chosen. */}


### PR DESCRIPTION
Closes #275. Step 4 of 4 for #271, decision ⑧.

After #273 the hero was the only surface in the app without a roster verdict — and it is the most imminent event, the one most worth chasing people for.

## What changed

`NextEventHeroView` now renders the same `ReadinessBadge` extracted in #273 — same `rosterChip`, same words, no second implementation. Three files, ~40 lines of source.

The badge takes a `variant` prop (`card` | `hero`), because the card's tints are built for a light surface and `bg-green/15` over the hero's green ground is invisible. The `hero` variant inverts the chip to solid white and lets the tone live in the dot alone.

## Contrast

Checked rather than assumed, rendered in both themes and reviewed before commit.

- **Chip**: solid white on the green ground.
- **Ink**: the fixed `--color-green-dark` the hero's own white "I'm in" button already uses — 5.1:1 on white.
- **Not** `text-foreground`: the hero's ground stays green in both themes while that token inverts, so the label would go near-white on a white chip in dark mode.
- **Not** the card's tone-coloured text: `text-gold-dark` (#C89200) on white is ~2.8:1, below AA. Carrying the tone in the dot instead keeps this out of the contrast batch you're planning, without adding to it.

The trade-off, deliberately taken: tone is a weaker signal here than the card's tinted chip. On this surface the chip is one item on an otherwise busy green card, and legibility won.

## No verdict → nothing

Where the card falls back to a plain `{n} going`, the hero renders **nothing**. Its status line is already a headcount (`10 going · you're in`), so a fallback chip would print the same number twice on one card. This applies to both no-verdict states — tracking off, and tracking-on-with-no-targets.

The badge shares the status line's row rather than claiming one of its own, so an absent verdict leaves no gap — nothing to collapse, because nothing was reserved.

## Explicitly unchanged

The hero's 2-way RSVP (`I'm in` / `Can't make it`, no Maybe), `selectHeroEvent`, and the countdown logic. Per the issue, the RSVP asymmetry is deliberate and was not "fixed" for consistency.

## Testing

Stories on `NextEventHeroView` for every roster state the hero can be in: covered (`Lineup set`), short (`1 spot open`), critical (`3 spots open`), tally-only, and tracking-off. The no-gap requirement is asserted by measuring the status row against the status line inside it, rather than eyeballed.

The two no-verdict stories are marked as behavioural twins (ADR-0027 §2) — they render the unbadged hero, so they carry assertions but no Chromatic snapshot. Net new snapshots: 3 stories × 2 modes. The visual review of the chip itself is what Chromatic picks up on those three.

Per the PR gate: **no new e2e is justified.** This introduces no new seam — no auth path, no cross-tenant write, no external integration. It is a presentational addition to a prop-only View, which is exactly what a story proves.

`make test-app`: 751 passed (113 files). `tsc -b` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HWN5hHUM34Qdf4Pzz1qog