### PR TITLE
ci: let a new push supersede an unapproved production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,12 +166,30 @@ jobs:
 
   # MANUAL deploy gate: runs only on push to `main`/`deploy*`, after `build`; each pauses for
   # approval via the `production` environment. Deploys the exact commit CI validated (tag = SHA).
-  deploy-api:
+  #
+  # The wait for approval sits in its own tiny `approve-*` job, separate from the `deploy-*` job
+  # that does the work. That split is what makes a stale gate harmless: `approve-*` is
+  # `cancel-in-progress: true`, so a newer push to `main` cancels a still-unapproved gate from an
+  # older commit and immediately asks for approval on the new one — no manual reject needed. The
+  # `deploy-*` jobs only ever start once approved and stay `cancel-in-progress: false`, so a
+  # rollout that is already under way is never interrupted; a second approved deploy queues behind
+  # it. API and frontend keep their own gate, so they are still approved independently.
+  approve-api:
     needs: build
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/deploy')) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     environment: production
+    concurrency:
+      group: deploy-prod-api-approval
+      cancel-in-progress: true
+    steps:
+      - run: echo "Production ${GITHUB_SHA::12} approved — starting the api rollout."
+
+  deploy-api:
+    needs: approve-api
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: deploy-prod-api
       cancel-in-progress: false
@@ -246,12 +264,22 @@ jobs:
           echo "::error::Image ${EXPECTED_SHA} never became live within $(( 360 / 60 )) min — deployment NOT verified. The new container likely failed to boot; check Scaleway Cockpit logs for a crash (e.g. Flyway validation)."
           exit 1
 
-  deploy-frontend:
+  approve-frontend:
     needs: build
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/deploy')) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     environment: production
+    concurrency:
+      group: deploy-prod-frontend-approval
+      cancel-in-progress: true
+    steps:
+      - run: echo "Production ${GITHUB_SHA::12} approved — starting the frontend rollout."
+
+  deploy-frontend:
+    needs: approve-frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: deploy-prod-frontend
       cancel-in-progress: false

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -7,6 +7,10 @@ branch, only after `build` is green, and each **pauses for a one-click approval*
 `production` GitHub Environment. They deploy the exact commit CI just validated
 (image tag = commit SHA — no drift between what was tested and what ships).
 
+The approval itself is waited for by a separate one-step job per side — `approve-api` /
+`approve-frontend` — and `deploy-api` / `deploy-frontend` only start once their gate is
+approved. See *Superseding an unapproved deploy* below for why.
+
 ## One-time setup (REQUIRED — this *is* the manual gate)
 
 Settings → **Environments** → **New environment** named `production`:
@@ -20,14 +24,34 @@ Settings → **Environments** → **New environment** named `production`:
 ## Trigger a deploy
 
 1. Push to `main` (normal merge) or to a `deploy*` branch.
-2. CI runs `build` (lint + all tests + real e2e). If green, `deploy-api` and
-   `deploy-frontend` appear as **Pending — waiting for approval**.
+2. CI runs `build` (lint + all tests + real e2e). If green, `approve-api` and
+   `approve-frontend` appear as **Pending — waiting for approval**.
 3. In the run (or **Deployments** → `production`), click **Review deployments**, pick the
    job(s) to approve, and confirm. Each job is approved independently, so you can ship the
-   API without the frontend or vice-versa.
+   API without the frontend or vice-versa. Approving releases the gate; the `deploy-*` job
+   behind it then runs unattended.
 
 There is no `dry_run` input: **not approving is the dry run.** A default push builds and
 tests everything and simply waits — nothing deploys until you approve.
+
+> **Caveat.** Because the `production` environment is bound to the *gate* job, **Deployments**
+> → `production` flips to green the moment you approve, not when the rollout is verified. The
+> `deploy-*` job's own red/green in the Actions run is the truth.
+
+## Superseding an unapproved deploy
+
+A gate waiting for approval holds its concurrency group, so an obsolete pending deploy used to
+park the next push behind it: you had to approve or reject yesterday's commit before today's
+could even ask. It no longer does.
+
+- **Push to `main` while an older commit still sits unapproved** → the old `approve-*` job is
+  **cancelled** (`cancel-in-progress: true`) and the new commit asks for approval instead.
+  Nothing to reject by hand. The old run shows the gate as *cancelled* — expected, not a failure.
+- **Push while an approved deploy is mid-rollout** → the rollout is **never** interrupted. The
+  `deploy-*` jobs are `cancel-in-progress: false` on their own group, so the new deploy simply
+  queues behind it and starts when it finishes.
+
+That is the whole reason the wait and the work are two jobs: only the wait is disposable.
 
 ## What each job does
 
@@ -116,6 +140,7 @@ Settings → Secrets and variables → Actions (names only — never commit valu
 ## Rollback
 
 To roll back, re-deploy an earlier good commit: Actions → the CI run for that commit →
-**Re-run jobs**, then approve `deploy-api`. The image tag is that commit's SHA, so the old
-image is rebuilt/redeployed deterministically. (Old image tags are also retained in the
-registry.) Alternatively, revert the offending commit on `main` and approve the new deploy.
+**Re-run jobs**, then approve the API gate (`approve-api`). The image tag is that commit's
+SHA, so the old image is rebuilt/redeployed deterministically. (Old image tags are also
+retained in the registry.) Alternatively, revert the offending commit on `main` and approve
+the new deploy.


### PR DESCRIPTION
## The problem

A deploy job that is waiting for approval still **holds its `deploy-prod-*` concurrency group**. So after a push to `main`, the next push parked its own deploy behind the old one: you had to approve or reject the obsolete commit before the new commit could even *ask* for approval.

Naively flipping `cancel-in-progress: true` on the existing groups would fix that — but it would also kill a deploy that was already approved and is mid-rollout (Scaleway container update, S3 sync, Edge purge). Not acceptable.

## The change

Split the *wait* from the *work*.

| Job | `environment` | concurrency group | `cancel-in-progress` |
|---|---|---|---|
| `approve-api` / `approve-frontend` (new, one `echo` step) | `production` | `deploy-prod-*-approval` | **`true`** |
| `deploy-api` / `deploy-frontend` (unchanged steps) | — | `deploy-prod-*` | `false` |

Only the gate is disposable:

- **Push to `main` while an older commit sits unapproved** → the old `approve-*` job is cancelled and the new commit asks for approval immediately. No manual reject.
- **Push while an approved deploy is mid-rollout** → the rollout is never interrupted; the new deploy queues behind it on the unchanged `deploy-prod-*` group.
- **Independent approval preserved** — each side keeps its own gate, so you can still ship the API without the frontend.

Dropping `environment: production` from the deploy jobs is safe because all deploy secrets are repository-level (`Settings → Secrets and variables → Actions`, per the runbook), not environment-scoped. Keeping the environment on both the gate and the deploy job would have cost a second approval click per deploy.

## Trade-off worth knowing

Because the `production` environment is now bound to the gate job, **Deployments → `production` flips to green the moment you approve**, not when the rollout is verified. The `deploy-*` job's own red/green in the Actions run remains the truth (the post-deploy SHA verification is untouched). This is documented in the runbook.

## Testing

No test layer covers workflow YAML, so per the PR gate there is nothing to add:

- Verified the file parses and the job graph is correct — `build → approve-api → deploy-api`, same for frontend; gates carry `environment: production` + `cancel-in-progress: true`, deploys carry neither the environment nor cancellation.
- Deploy job steps are byte-identical; only the job header changed.
- **Not verifiable from CI:** the cancel-on-supersede behaviour itself can only be proven by pushing twice to `main` and watching the first run's gate flip to *cancelled*. The reasoning is sound — the currently-observed "pending" state proves the waiting job holds the group, and `cancel-in-progress` cancels whatever holds it — but the first real double-push is the actual confirmation.

## Docs

`docs/ops/deploy.md` updated: the gate jobs are named correctly in *Trigger a deploy*, a new *Superseding an unapproved deploy* section covers both cases above, the Deployments-page caveat is called out, and *Rollback* now says to approve `approve-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcH8gFsTrFE87hXDLMTqos


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcH8gFsTrFE87hXDLMTqos)_