### PR TITLE
fix(app): the detail page states a headcount when no position is targeted

### DIFF
--- a/app/src/entities/event/ui/RosterBar.stories.tsx
+++ b/app/src/entities/event/ui/RosterBar.stories.tsx
@@ -64,3 +64,80 @@ export const LineupSet: Story = {
     await expect(canvas.getByText(/Lineup set/)).toBeInTheDocument()
   },
 }
+
+// ── No position targets (#271 ⑥, the half the detail page never got) ────────────────────────────
+// `rosterChip` returns null for two states, and until now the bar refused to render for either, so
+// the detail page stated no headcount at all whenever no position carried a target: the card
+// advertised "4 more needed", you tapped through, and the number was gone.
+
+// A total target, no position targets. The fraction is against the target, and the verdict stands.
+export const HeadcountTarget: Story = {
+  args: {
+    roster: makeRoster({
+      positions: [],
+      totalTarget: 12,
+      totalAttending: 8,
+      openSlots: 4,
+      state: 'HEADCOUNT_SHORT',
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/8\/12 going/)).toBeInTheDocument()
+    await expect(canvas.getByText(/4 more needed/)).toBeInTheDocument()
+  },
+}
+
+// The headcount target met.
+export const HeadcountFull: Story = {
+  args: {
+    roster: makeRoster({
+      positions: [],
+      totalTarget: 12,
+      totalAttending: 12,
+      openSlots: 0,
+      state: 'HEADCOUNT_FULL',
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText(/12\/12 going/)).toBeInTheDocument()
+    await expect(canvas.getByText(/Full/)).toBeInTheDocument()
+  },
+}
+
+// A tally: tracking on, nothing targeted. There is no verdict and nothing to be a fraction of, so
+// the bar states the plain count and draws NO progress track — a bar with no denominator would
+// invent the judgement `rosterChip` deliberately withholds for this state.
+export const TallyOnly: Story = {
+  args: {
+    roster: makeRoster({
+      positions: [],
+      totalTarget: undefined,
+      totalAttending: 8,
+      openSlots: 0,
+      state: 'TALLY_ONLY',
+    }),
+  },
+  play: async ({ canvas, canvasElement }) => {
+    await expect(canvas.getByText(/8 going/)).toBeInTheDocument()
+    await expect(canvas.queryByText(/\//)).not.toBeInTheDocument()
+    await expect(canvasElement.querySelector('[data-slot="roster-track"]')).toBeNull()
+  },
+}
+
+// Tracking off entirely — a social. Still nothing: this is not a roster event, and the route falls
+// back to the role breakdown.
+export const TrackingOff: Story = {
+  args: {
+    roster: makeRoster({
+      trackRoster: false,
+      positions: [],
+      totalTarget: undefined,
+      totalAttending: 8,
+      openSlots: 0,
+      state: 'OFF',
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('div')?.textContent ?? '').toBe('')
+  },
+}

--- a/app/src/entities/event/ui/RosterBar.tsx
+++ b/app/src/entities/event/ui/RosterBar.tsx
@@ -18,55 +18,81 @@ const TONE_TEXT: Record<RosterTone, string> = {
 }
 
 /**
- * A compact, always-visible roster overview: overall spots filled, a progress track, and a chip per
+ * A compact, always-visible roster overview: how full the squad is, a progress track, and a chip per
  * targeted position coloured by its tone. Meant to be pinned above the attendee list so completeness
  * stays one glance away however far you scroll a large squad — the thing a flat list loses.
  *
  * Prop-only (ADR-0017), and it re-presents what the server already computed rather than re-deriving
- * status: the chips come from `rosterRows`, the headline chip from `rosterChip`, and the filled count
- * is `totalTarget − openSlots` (both server-owned; #219). Returns null when no position carries a
- * target — there is nothing to be a fraction of, and the route falls back to the headcount breakdown.
+ * status: the chips come from `rosterRows`, the headline chip from `rosterChip`, and the counts are
+ * server-owned (#219).
+ *
+ * Three shapes, because a roster can be targeted in two different ways or not at all (#271 (6)):
+ *
+ *   - **Positions targeted** — the fraction counts *slots*, and each position gets a chip.
+ *   - **A headcount target only** — the fraction counts *people* against `totalTarget`. No chips:
+ *     nothing is targeted per position, so there is nothing to list.
+ *   - **A tally** — tracking on, nothing targeted. The plain count, and deliberately **no progress
+ *     track**: a bar with no denominator would assert exactly the judgement `rosterChip` withholds
+ *     for this state.
+ *
+ * Only a roster with tracking switched off renders nothing — a social is not a roster event, and the
+ * route falls back to the role breakdown. The two headcount shapes were missing until this page
+ * caught up with the card: the card said "4 more needed", you tapped through, and the number was gone.
  */
 export function RosterBar({ roster }: RosterBarProps) {
   const rows = rosterRows(roster).filter((row) => row.pips.length > 0)
-  if (rows.length === 0) return null
+  const byPosition = rows.length > 0
 
-  const target = rows.reduce((sum, row) => sum + row.pips.length, 0)
-  const filled = target - roster.openSlots
-  const pct = target === 0 ? 0 : Math.round((filled / target) * 100)
+  // A social: not a roster event, so there is no overview to give.
+  if (!byPosition && !roster.trackRoster) return null
+
+  // What the fraction is *of* differs per shape: slots where positions are targeted, people where
+  // the target is a headcount, and nothing at all for a tally.
+  const slots = rows.reduce((sum, row) => sum + row.pips.length, 0)
+  const target = byPosition ? slots : roster.totalTarget
+  const filled = byPosition ? slots - roster.openSlots : roster.totalAttending
+  const met = target != null && filled >= target
+  const headline = target == null ? `${filled} going` : `${filled}/${target} ${byPosition ? 'spots' : 'going'}`
+  // Null for a tally — no denominator, no track.
+  const pct = target == null || target === 0 ? null : Math.min(100, Math.round((filled / target) * 100))
   const chip = rosterChip(roster)
 
   return (
     <div className="border-b border-border/40 bg-gradient-to-b from-card to-background px-4 py-3">
-      <div className="mb-2 flex items-baseline justify-between gap-3">
+      <div className={`flex items-baseline justify-between gap-3 ${pct == null && !byPosition ? '' : 'mb-2'}`}>
         <span className="text-[11px] font-bold uppercase tracking-[0.1em] text-muted-foreground">Roster</span>
         <span className="flex items-baseline gap-1.5">
-          <span
-            className={`font-display text-sm font-bold tabular-nums ${roster.openSlots === 0 ? 'text-green-dark' : 'text-foreground'}`}
-          >
-            {`${filled}/${target} spots`}
+          <span className={`font-display text-sm font-bold tabular-nums ${met ? 'text-green-dark' : 'text-foreground'}`}>
+            {headline}
           </span>
           {chip && <span className={`text-xs font-semibold ${TONE_TEXT[chip.tone]}`}>· {chip.text}</span>}
         </span>
       </div>
 
-      <div className="mb-2.5 h-1.5 overflow-hidden rounded-full bg-muted">
+      {pct != null && (
         <div
-          className="h-full rounded-full bg-green transition-[width] duration-300 ease-out"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
+          data-slot="roster-track"
+          className={`h-1.5 overflow-hidden rounded-full bg-muted ${byPosition ? 'mb-2.5' : ''}`}
+        >
+          <div
+            className="h-full rounded-full bg-green transition-[width] duration-300 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
 
-      <div className="flex flex-wrap gap-1.5">
-        {rows.map((row) => (
-          <span
-            key={row.id}
-            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11.5px] font-semibold tabular-nums ${CHIP_TONE[row.tone ?? 'short']}`}
-          >
-            {row.label} {row.countLabel}
-          </span>
-        ))}
-      </div>
+      {byPosition && (
+        <div className="flex flex-wrap gap-1.5">
+          {rows.map((row) => (
+            <span
+              key={row.id}
+              className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11.5px] font-semibold tabular-nums ${CHIP_TONE[row.tone ?? 'short']}`}
+            >
+              {row.label} {row.countLabel}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/src/routes/t/$slug/events/$eventId.tsx
+++ b/app/src/routes/t/$slug/events/$eventId.tsx
@@ -90,9 +90,13 @@ function EventDetailPage() {
       )
     }
   }
-  // The roster bar replaces RoleBreakdown only where a position carries a target; otherwise it has
-  // nothing to be a fraction of and RoleBreakdown stays as the fallback (⑥, same rule as the card).
+  // Two independent questions, and conflating them is what used to lose the headcount here (#271 ⑥).
+  // The bar shows for ANY tracked roster — with position targets it counts slots, without them it
+  // counts people (a target fraction, or a plain tally). RoleBreakdown is the per-role fallback and
+  // still turns on the narrower question: it survives only where no position carries a target, since
+  // there the bar states a total but nothing about who plays where.
   const hasPositionTargets = event.roster.positions.some((p) => p.required != null)
+  const showRosterBar = hasPositionTargets || event.roster.trackRoster
 
   // "Part of a series" peek: siblings are every event sharing this occurrence's recurring group.
   const siblings = event.recurringGroup
@@ -175,7 +179,7 @@ function EventDetailPage() {
       {/* Attendance — one list by position, no tabs. The roster bar pins beneath the sub-header so
           completeness stays visible however far a big squad scrolls; where no position carries a
           target it has nothing to show and the headcount breakdown stays as the fallback. */}
-      {hasPositionTargets && (
+      {showRosterBar && (
         <div
           className="sticky z-20 -mx-4 mt-6"
           style={{ top: `calc(var(--header-height) + ${subHeaderHeight}px)` }}
@@ -183,7 +187,7 @@ function EventDetailPage() {
           <RosterBar roster={event.roster} />
         </div>
       )}
-      <div className={`overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm ${hasPositionTargets ? 'mt-3' : 'mt-6'}`}>
+      <div className={`overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm ${showRosterBar ? 'mt-3' : 'mt-6'}`}>
         {!hasPositionTargets && <RoleBreakdown breakdown={event.attendanceSummary.roleBreakdown} />}
         <AttendeeList
           attendees={event.attendances}


### PR DESCRIPTION
Follow-up to #275. Closes a gap in #271's decision ⑥, found while checking whether that epic was actually complete.

## The bug

`rosterChip` returns `null` for **two** states, and `RosterBar` refused to render for either — it filters to rows with pips, so a roster with no position targets left `rows` empty and the bar bailed. The route then compounded it by gating the bar on position targets as well.

The result was the exact failure Phase 3 existed to fix, surviving for two roster configurations:

> the card says `12 more needed` → you tap through → **the number is nowhere on the page**.

⑥ ("headcount fallback wherever there is no verdict to give") reached the card and, in its own form, the hero. It never reached the detail page at all.

## The fix

`RosterBar` now has three shapes rather than one, and the route gates it on `trackRoster` instead of on position targets:

| Roster | Bar shows |
|---|---|
| Positions targeted | unchanged — the fraction counts **slots**, one chip per position |
| A headcount target only | `8/12 going` + the verdict — the fraction counts **people** |
| A tally (tracking on, nothing targeted) | `8 going`, and **no progress track** |
| Tracking off (a social) | nothing — not a roster event; `RoleBreakdown` stays |

The tally deliberately draws no track: a progress bar with no denominator would assert exactly the judgement `rosterChip` withholds for that state.

`RoleBreakdown` keeps the narrower question it always answered — it survives wherever no position carries a target, since there the bar states a total but nothing about who plays where. Conflating those two questions is what lost the headcount in the first place.

## Testing

Four `RosterBar` stories — `HeadcountTarget`, `HeadcountFull`, `TallyOnly`, `TrackingOff` — at the lowest layer that proves it (prop-only component, ADR-0017). `TallyOnly` asserts the absence of the track, which is the part a screenshot alone would let drift.

Also verified end-to-end against the real backend's own roster computation, not just in stories — the three states were driven by changing the event's roster override in the DB and reloading the real detail page:

- headcount target → `0/12 going · 12 more needed`
- tally → `0 going`, no fraction, no track
- tracking off → nothing

`make test-app`: 759 passed (113 files), up from 751. `tsc -b` and `eslint` clean.

Per the PR gate: **no new e2e is justified** — no new seam, no new auth path, no cross-tenant write, no external integration. This is a rendering rule on a prop-only component.

## Design provenance

Three treatments were prototyped on the real route against real data before picking this one: a pinned bar (this), a list header, and a header stat ring. The prototype and the switcher are preserved on `prototype/275-headcount-detail`, out of main.

The pinned bar won on #271's own argument for `RosterBar` — *"completeness stays one glance away however far you scroll a large squad"* — which does not depend on whether the target is per-position or a single number. The list header scrolls away on a big squad, reintroducing the loss the bar exists to prevent; the stat ring pushed "Your response" below the fold to make room for a squad statistic.

The first cut of the prototype gated every variant on `totalTarget != null` and so fixed only the target case, leaving the tally exactly as broken as before. That was caught in review and is why the fix covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HWN5hHUM34Qdf4Pzz1qog

---
_Generated by [Claude Code](https://claude.ai/code/session_017HWN5hHUM34Qdf4Pzz1qog)_