### PR TITLE
feat(app): filter the events list by turnout (#311)

### DIFF
--- a/app/src/features/bulk-attend/lib/eligible-event-ids.test.ts
+++ b/app/src/features/bulk-attend/lib/eligible-event-ids.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { makeEvent } from '@shared/testing/event-fixtures'
 import { ALL_ATTENDANCE_STATES } from '@features/filter-event-types/model/attendance-states'
+import {
+  ALL_TURNOUT_BUCKETS,
+  type TurnoutBucket,
+} from '@features/filter-event-types/model/turnout'
 import { filterEvents } from '@features/filter-event-types/model/filter-events'
 import { eligibleEventIds } from './eligible-event-ids'
 
@@ -14,6 +18,7 @@ const TRAINING = { id: 'et-training', name: 'Training', color: '#22c55e' }
 const MATCH = { id: 'et-match', name: 'Match', color: '#3b82f6' }
 
 const ALL_TYPES = new Set([TRAINING.id, MATCH.id])
+const ALL_TURNOUTS = new Set<TurnoutBucket>(ALL_TURNOUT_BUCKETS)
 
 describe('eligibleEventIds', () => {
   it('returns nothing when there are no events', () => {
@@ -88,7 +93,7 @@ describe('eligibleEventIds under the answer filter', () => {
     makeEvent({ id: 'going', eventType: TRAINING, startTime: FUTURE, myState: 'ATTENDING' }),
   ]
   const shown = (activeStates: Set<AttendanceState>) =>
-    eligibleEventIds(filterEvents(EVENTS, ALL_TYPES, activeStates), ALL_TYPES, NOW)
+    eligibleEventIds(filterEvents(EVENTS, ALL_TYPES, activeStates, ALL_TURNOUTS), ALL_TYPES, NOW)
 
   it('offers the unanswered events when no answer chip narrows the list', () => {
     expect(shown(ALL_STATES)).toEqual(['blank'])
@@ -101,5 +106,12 @@ describe('eligibleEventIds under the answer filter', () => {
 
   it('offers exactly the visible list when filtered to Not responded — the bar\'s preview', () => {
     expect(shown(new Set<AttendanceState>(['NOT_RESPONDED']))).toEqual(['blank'])
+  })
+
+  // The Turnout chips narrow the bar the same way (#311): both fixtures are socials, so isolating
+  // any other band empties the list and with it the bar.
+  it('follows the turnout dimension too', () => {
+    const covered = filterEvents(EVENTS, ALL_TYPES, ALL_STATES, new Set<TurnoutBucket>(['covered']))
+    expect(eligibleEventIds(covered, ALL_TYPES, NOW)).toEqual([])
   })
 })

--- a/app/src/features/filter-event-types/model/empty-message.test.ts
+++ b/app/src/features/filter-event-types/model/empty-message.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import type {AttendanceState} from '@features/attendance-toggle/ui/AttendanceToggle'
 import {ALL_ATTENDANCE_STATES} from './attendance-states'
+import {ALL_TURNOUT_BUCKETS, type TurnoutBucket} from './turnout'
 import {emptyEventsMessage} from './empty-message'
 
 const ALL_TYPE_IDS = ['training', 'match']
@@ -12,6 +13,7 @@ const message = (overrides: Partial<Parameters<typeof emptyEventsMessage>[0]> = 
         activeTypeIds: new Set(ALL_TYPE_IDS),
         allTypeIds: ALL_TYPE_IDS,
         activeStates: new Set(ALL_ATTENDANCE_STATES),
+        activeTurnouts: new Set(ALL_TURNOUT_BUCKETS),
         ...overrides,
     })
 
@@ -51,6 +53,29 @@ describe('emptyEventsMessage', () => {
         expect(message({
             activeTypeIds: new Set(['match']),
             activeStates: new Set<AttendanceState>(['NOT_RESPONDED']),
+        })).toBe('No events match these filters.')
+    })
+
+    it('names the turnout dimension when it is narrowed to the short bands', () => {
+        expect(message({activeTurnouts: new Set<TurnoutBucket>(['spots-open'])}))
+            .toBe('No events are short of players.')
+        expect(message({activeTurnouts: new Set<TurnoutBucket>(['missing-position'])}))
+            .toBe('No events are short of players.')
+        expect(message({activeTurnouts: new Set<TurnoutBucket>(['missing-position', 'spots-open'])}))
+            .toBe('No events are short of players.')
+    })
+
+    it('stays generic for a covered selection, where "short of players" would be a lie', () => {
+        expect(message({activeTurnouts: new Set<TurnoutBucket>(['covered'])}))
+            .toBe('No events match these filters.')
+        expect(message({activeTurnouts: new Set<TurnoutBucket>(['spots-open', 'no-target'])}))
+            .toBe('No events match these filters.')
+    })
+
+    it('stays generic when turnout is narrowed alongside another dimension', () => {
+        expect(message({
+            activeStates: new Set<AttendanceState>(['NOT_RESPONDED']),
+            activeTurnouts: new Set<TurnoutBucket>(['spots-open']),
         })).toBe('No events match these filters.')
     })
 })

--- a/app/src/features/filter-event-types/model/empty-message.ts
+++ b/app/src/features/filter-event-types/model/empty-message.ts
@@ -1,5 +1,6 @@
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { ALL_ATTENDANCE_STATES } from './attendance-states'
+import { ALL_TURNOUT_BUCKETS, type TurnoutBucket } from './turnout'
 
 interface EmptyMessageInput {
     /** A hero is on screen, so the page is not empty — only the list beneath it is. */
@@ -8,16 +9,20 @@ interface EmptyMessageInput {
     activeTypeIds: Set<string>
     allTypeIds: string[]
     activeStates: Set<AttendanceState>
+    activeTurnouts: Set<TurnoutBucket>
 }
+
+/** The two bands that mean "short of people". The other two must not borrow their wording. */
+const SHORT_BUCKETS: TurnoutBucket[] = ['missing-position', 'spots-open']
 
 /**
  * What the events list says when it has nothing to show.
  *
- * With three filter dimensions the specific messages are combinatorial, so only a *single* narrowed
+ * With four filter dimensions the specific messages are combinatorial, so only a *single* narrowed
  * dimension earns one; anything else falls back to the generic line, which is true whatever the
- * combination. The answer dimension gets its specific line only for the "Not responded" selection —
- * it is the one whose emptiness has a plain-English meaning, and the wrong-status version of it
- * ("Nothing needs your answer" after filtering to `Going`) would be a lie.
+ * combination. The answer and turnout dimensions narrow that further to the selections whose
+ * emptiness has a plain-English meaning: "Nothing needs your answer" after filtering to `Going`, or
+ * "No events are short of players" after filtering to `Covered`, would both be lies.
  */
 export function emptyEventsMessage({
     hasHero,
@@ -25,16 +30,24 @@ export function emptyEventsMessage({
     activeTypeIds,
     allTypeIds,
     activeStates,
+    activeTurnouts,
 }: EmptyMessageInput): string {
     if (hasHero) return 'Nothing else coming up.'
 
     const typeFiltered = activeTypeIds.size < allTypeIds.length
     const stateFiltered = activeStates.size < ALL_ATTENDANCE_STATES.length
+    const turnoutFiltered = activeTurnouts.size < ALL_TURNOUT_BUCKETS.length
+    const narrowed = [typeFiltered, stateFiltered, turnoutFiltered].filter(Boolean).length
 
-    if (!typeFiltered && !stateFiltered) return showPast ? 'No events yet.' : 'No upcoming events.'
-    if (typeFiltered && !stateFiltered) return 'No events for this type.'
-    if (!typeFiltered && activeStates.size === 1 && activeStates.has('NOT_RESPONDED')) {
-        return 'Nothing needs your answer.'
+    if (narrowed === 0) return showPast ? 'No events yet.' : 'No upcoming events.'
+    if (narrowed === 1) {
+        if (typeFiltered) return 'No events for this type.'
+        if (stateFiltered && activeStates.size === 1 && activeStates.has('NOT_RESPONDED')) {
+            return 'Nothing needs your answer.'
+        }
+        if (turnoutFiltered && [...activeTurnouts].every((b) => SHORT_BUCKETS.includes(b))) {
+            return 'No events are short of players.'
+        }
     }
     return 'No events match these filters.'
 }

--- a/app/src/features/filter-event-types/model/filter-events.test.ts
+++ b/app/src/features/filter-event-types/model/filter-events.test.ts
@@ -1,47 +1,67 @@
 import {describe, expect, it} from 'vitest'
 import type {AttendanceState} from '@features/attendance-toggle/ui/AttendanceToggle'
-import {makeEvent} from '@shared/testing/event-fixtures'
+import type {RosterState} from '@shared/api/events'
+import {makeEvent, makeRoster} from '@shared/testing/event-fixtures'
 import {ALL_ATTENDANCE_STATES} from './attendance-states'
+import {ALL_TURNOUT_BUCKETS, type TurnoutBucket} from './turnout'
 import {filterEvents} from './filter-events'
 
 const TYPE_IDS = ['training', 'match']
 const ALL_TYPES = new Set(TYPE_IDS)
 const ALL_STATES = new Set<AttendanceState>(ALL_ATTENDANCE_STATES)
+const ALL_TURNOUTS = new Set<TurnoutBucket>(ALL_TURNOUT_BUCKETS)
 
-const event = (id: string, typeId: string, myState: AttendanceState) =>
-    makeEvent({id, myState, eventType: {id: typeId, name: typeId, color: '#000'}})
+const event = (id: string, typeId: string, myState: AttendanceState, state: RosterState = 'OFF') =>
+    makeEvent({
+        id,
+        myState,
+        eventType: {id: typeId, name: typeId, color: '#000'},
+        roster: makeRoster({state, positions: [], openSlots: 0}),
+    })
 
 const EVENTS = [
-    event('going-training', 'training', 'ATTENDING'),
-    event('blank-training', 'training', 'NOT_RESPONDED'),
-    event('maybe-match', 'match', 'MAYBE'),
-    event('absent-match', 'match', 'ABSENT'),
+    event('going-training', 'training', 'ATTENDING', 'CRITICAL'),
+    event('blank-training', 'training', 'NOT_RESPONDED', 'HEADCOUNT_SHORT'),
+    event('maybe-match', 'match', 'MAYBE', 'LINEUP_SET'),
+    event('absent-match', 'match', 'ABSENT', 'TALLY_ONLY'),
 ]
 
 const ids = (events: ReturnType<typeof event>[]) => events.map(e => e.id)
 
 describe('filterEvents', () => {
-    it('drops nothing when every chip in both groups is on', () => {
-        expect(ids(filterEvents(EVENTS, ALL_TYPES, ALL_STATES))).toEqual(ids(EVENTS))
+    it('drops nothing when every chip in all three groups is on', () => {
+        expect(ids(filterEvents(EVENTS, ALL_TYPES, ALL_STATES, ALL_TURNOUTS))).toEqual(ids(EVENTS))
     })
 
     it('ORs within the answer dimension', () => {
-        const result = filterEvents(EVENTS, ALL_TYPES, new Set<AttendanceState>(['MAYBE', 'ABSENT']))
+        const result = filterEvents(EVENTS, ALL_TYPES, new Set<AttendanceState>(['MAYBE', 'ABSENT']), ALL_TURNOUTS)
         expect(ids(result)).toEqual(['maybe-match', 'absent-match'])
     })
 
     it('ORs within the type dimension', () => {
-        const result = filterEvents(EVENTS, new Set(['training']), ALL_STATES)
+        const result = filterEvents(EVENTS, new Set(['training']), ALL_STATES, ALL_TURNOUTS)
+        expect(ids(result)).toEqual(['going-training', 'blank-training'])
+    })
+
+    it('ORs within the turnout dimension, over states that share a band', () => {
+        const result = filterEvents(EVENTS, ALL_TYPES, ALL_STATES,
+            new Set<TurnoutBucket>(['missing-position', 'spots-open']))
         expect(ids(result)).toEqual(['going-training', 'blank-training'])
     })
 
     it('ANDs across the two dimensions', () => {
-        const result = filterEvents(EVENTS, new Set(['training']), new Set<AttendanceState>(['NOT_RESPONDED']))
+        const result = filterEvents(EVENTS, new Set(['training']), new Set<AttendanceState>(['NOT_RESPONDED']), ALL_TURNOUTS)
         expect(ids(result)).toEqual(['blank-training'])
     })
 
-    it('yields nothing when the two dimensions have no event in common', () => {
-        const result = filterEvents(EVENTS, new Set(['match']), new Set<AttendanceState>(['ATTENDING']))
+    it('ANDs turnout with the other dimensions', () => {
+        const result = filterEvents(EVENTS, new Set(['training']), ALL_STATES,
+            new Set<TurnoutBucket>(['spots-open']))
+        expect(ids(result)).toEqual(['blank-training'])
+    })
+
+    it('yields nothing when the dimensions have no event in common', () => {
+        const result = filterEvents(EVENTS, new Set(['match']), new Set<AttendanceState>(['ATTENDING']), ALL_TURNOUTS)
         expect(result).toEqual([])
     })
 })

--- a/app/src/features/filter-event-types/model/filter-events.ts
+++ b/app/src/features/filter-event-types/model/filter-events.ts
@@ -1,19 +1,25 @@
 import type { Event } from '@shared/api/events'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
+import { turnoutBucket, type TurnoutBucket } from './turnout'
 
 /**
  * The events the filter lets through: OR within a dimension, AND across dimensions (ADR-0029 §2).
  *
- * Both arguments are membership sets over a total partition of the list — every event has exactly
- * one type and exactly one `myState` — so a fully-selected group contains every value an event can
- * have and drops nothing. That is why "all chips on" needs no special case here (ADR-0029 §1).
+ * Every argument is a membership set over a total partition of the list — every event has exactly
+ * one type, exactly one `myState` and exactly one Turnout band — so a fully-selected group contains
+ * every value an event can have and drops nothing. That is why "all chips on" needs no special case
+ * here (ADR-0029 §1), the Turnout group included even on the teams it is not rendered for.
  */
 export function filterEvents(
     events: Event[],
     activeTypeIds: Set<string>,
     activeStates: Set<AttendanceState>,
+    activeTurnouts: Set<TurnoutBucket>,
 ): Event[] {
     return events.filter(
-        (event) => activeTypeIds.has(event.eventType.id) && activeStates.has(event.myState),
+        (event) =>
+            activeTypeIds.has(event.eventType.id) &&
+            activeStates.has(event.myState) &&
+            activeTurnouts.has(turnoutBucket(event.roster.state)),
     )
 }

--- a/app/src/features/filter-event-types/model/turnout.test.ts
+++ b/app/src/features/filter-event-types/model/turnout.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest'
+import type {RosterState} from '@shared/api/events'
+import {makeEvent, makeRoster} from '@shared/testing/event-fixtures'
+import {
+    ALL_TURNOUT_BUCKETS,
+    TURNOUT_BY_STATE,
+    spansMultipleTurnoutBuckets,
+    turnoutBucket,
+} from './turnout'
+
+const eventInState = (state: RosterState) =>
+    makeEvent({id: state, roster: makeRoster({state, positions: [], openSlots: 0})})
+
+describe('turnoutBucket', () => {
+    // Exhaustive on purpose (#311): every one of the seven Roster States is pinned to its band, so a
+    // state added server-side lands here as a failure instead of falling through to no bucket.
+    const EXPECTED: Record<RosterState, (typeof ALL_TURNOUT_BUCKETS)[number]> = {
+        CRITICAL: 'missing-position',
+        SPOTS_OPEN: 'spots-open',
+        HEADCOUNT_SHORT: 'spots-open',
+        LINEUP_SET: 'covered',
+        HEADCOUNT_FULL: 'covered',
+        TALLY_ONLY: 'no-target',
+        OFF: 'no-target',
+    }
+
+    it('covers exactly the seven Roster States, so a new one fails rather than falls through', () => {
+        expect(Object.keys(TURNOUT_BY_STATE).sort()).toEqual(Object.keys(EXPECTED).sort())
+    })
+
+    it.each(Object.entries(EXPECTED))('puts %s in the %s band', (state, bucket) => {
+        expect(turnoutBucket(state as RosterState)).toBe(bucket)
+    })
+
+    it('is a total partition: every state lands in one of the four chips', () => {
+        for (const bucket of Object.values(TURNOUT_BY_STATE)) {
+            expect(ALL_TURNOUT_BUCKETS).toContain(bucket)
+        }
+    })
+})
+
+describe('spansMultipleTurnoutBuckets', () => {
+    it('is false for an empty list', () => {
+        expect(spansMultipleTurnoutBuckets([])).toBe(false)
+    })
+
+    it('is false for a team that sets no targets, where every event is a tally', () => {
+        expect(spansMultipleTurnoutBuckets([eventInState('TALLY_ONLY'), eventInState('TALLY_ONLY')]))
+            .toBe(false)
+    })
+
+    it('is false when two states share one band — the group would still filter nothing', () => {
+        expect(spansMultipleTurnoutBuckets([eventInState('SPOTS_OPEN'), eventInState('HEADCOUNT_SHORT')]))
+            .toBe(false)
+    })
+
+    it('is true once the list spans two bands', () => {
+        expect(spansMultipleTurnoutBuckets([eventInState('CRITICAL'), eventInState('LINEUP_SET')]))
+            .toBe(true)
+    })
+})

--- a/app/src/features/filter-event-types/model/turnout.ts
+++ b/app/src/features/filter-event-types/model/turnout.ts
@@ -1,0 +1,53 @@
+import type { Event, RosterState } from '@shared/api/events'
+
+/**
+ * Turnout — the member-facing banding of the seven Roster States into four legible chips
+ * (CONTEXT.md, ADR-0029 §4), in the order the filter offers them: most short of people first.
+ */
+export type TurnoutBucket = 'missing-position' | 'spots-open' | 'covered' | 'no-target'
+
+export const ALL_TURNOUT_BUCKETS: TurnoutBucket[] = [
+    'missing-position',
+    'spots-open',
+    'covered',
+    'no-target',
+]
+
+/**
+ * State name in, band out — and deliberately nothing more. The backend owns the verdict (#219) and
+ * `entities/event/lib/roster-view.ts` says why a second status implementation on the client is off
+ * limits: it would be free to drift from the tested one. This table only re-words what arrived.
+ *
+ * The first three bands follow the card's own `RosterTone` split, so the filter reads the states the
+ * way the card already does. `no-target` exists to complete the partition (ADR-0029 §1) rather than
+ * because anyone will filter on it: a tally has nothing to fall short of and a social has no roster,
+ * and neither may be dressed up as a verdict.
+ *
+ * Typed as a total `Record`, so a state added to the contract fails the typecheck here and the
+ * exhaustive unit test next door — never silently falls through to no band.
+ */
+export const TURNOUT_BY_STATE: Record<RosterState, TurnoutBucket> = {
+    CRITICAL: 'missing-position',
+    SPOTS_OPEN: 'spots-open',
+    HEADCOUNT_SHORT: 'spots-open',
+    LINEUP_SET: 'covered',
+    HEADCOUNT_FULL: 'covered',
+    TALLY_ONLY: 'no-target',
+    OFF: 'no-target',
+}
+
+export function turnoutBucket(state: RosterState): TurnoutBucket {
+    return TURNOUT_BY_STATE[state]
+}
+
+/**
+ * Whether the Turnout group is worth rendering at all (ADR-0029 §5).
+ *
+ * A team that sets no targets gets `TALLY_ONLY` on every event, so the group would be four chips
+ * that provably filter nothing. Read off the *unfiltered* list, so narrowing another dimension can
+ * never make the group vanish underneath a selection that is still in effect.
+ */
+export function spansMultipleTurnoutBuckets(events: Event[]): boolean {
+    const buckets = new Set(events.map((event) => turnoutBucket(event.roster.state)))
+    return buckets.size >= 2
+}

--- a/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.stories.tsx
@@ -4,13 +4,14 @@ import type { EventTypeItem } from '@shared/api/event-types'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { makeEventType } from '@shared/testing/event-fixtures'
 import { ALL_ATTENDANCE_STATES } from '../model/attendance-states'
+import { ALL_TURNOUT_BUCKETS, type TurnoutBucket } from '../model/turnout'
 import { EventFiltersView } from './EventFiltersView'
 
 // EventFiltersView is the events page's single filter control — the icon button plus the popover
-// holding the type chips, the answer chips and the "Show past events" switch. It replaces the old
-// Upcoming/Past tab bar. Prop-only apart from the popover's open/closed state; both selections and
-// the show-past flag live in the route, so every state here renders from props with no network
-// (ADR-0017).
+// holding the type chips, the answer chips, the Turnout chips and the "Show past events" switch. It
+// replaces the old Upcoming/Past tab bar. Prop-only apart from the popover's open/closed state; the
+// three selections and the show-past flag live in the route, so every state here renders from props
+// with no network (ADR-0017).
 const EVENT_TYPES: EventTypeItem[] = [
   makeEventType({ id: 'et-1', name: 'Training', color: '#249E6C' }),
   makeEventType({ id: 'et-2', name: 'Match', color: '#225C9C' }),
@@ -19,6 +20,7 @@ const EVENT_TYPES: EventTypeItem[] = [
 
 const ALL = new Set(EVENT_TYPES.map((t) => t.id))
 const ALL_STATES = new Set(ALL_ATTENDANCE_STATES)
+const ALL_TURNOUTS = new Set(ALL_TURNOUT_BUCKETS)
 
 const meta = {
   title: 'features/filter-event-types/EventFiltersView',
@@ -27,10 +29,13 @@ const meta = {
     eventTypes: EVENT_TYPES,
     activeTypeIds: ALL,
     activeStates: ALL_STATES,
+    activeTurnouts: ALL_TURNOUTS,
+    showTurnout: true,
     showPast: false,
     resultCount: 7,
     onToggleType: fn(),
     onToggleState: fn(),
+    onToggleTurnout: fn(),
     onToggleShowPast: fn(),
   },
 } satisfies Meta<typeof EventFiltersView>
@@ -53,17 +58,21 @@ export const Open: Story = {
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
     await expect(canvas.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument()
-    // All three parts of the popover: the type chips, the answer chips and the past-events switch.
+    // All four parts of the popover: the type chips, the answer chips, the Turnout chips and the
+    // past-events switch.
     await expect(canvas.getByRole('button', { name: 'Training' })).toBeInTheDocument()
     await expect(canvas.getByRole('group', { name: 'Your answer' })).toBeInTheDocument()
+    await expect(canvas.getByRole('group', { name: 'Turnout' })).toBeInTheDocument()
     await expect(canvas.getByRole('switch', { name: 'Show past events' })).toHaveAttribute(
       'aria-checked',
       'false',
     )
     await expect(canvas.getByText('Off — upcoming only')).toBeInTheDocument()
-    // The unfiltered default: every chip in both groups is on, so nothing is hidden
+    // The unfiltered default: every chip in every group is on, so nothing is hidden
     // (ADR-0029 §1), and the trigger carries no dot.
-    for (const label of ['Going', 'Maybe', "Can't", 'Not responded']) {
+    const allChips = ['Going', 'Maybe', "Can't", 'Not responded',
+      'Missing a position', 'Spots open', 'Covered', 'No target set']
+    for (const label of allChips) {
       await expect(canvas.getByRole('button', { name: label })).toHaveAttribute(
         'aria-pressed',
         'true',
@@ -216,5 +225,72 @@ export const AnnouncesResultCount: Story = {
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('1 event matches these filters')).toBeInTheDocument()
+  },
+}
+
+// Prop-contract spy: a Turnout chip reports its band up to the route, which runs it through the
+// same isolate-first toggler as the other two groups (ADR-0029 §3). One tap from the all-on default
+// isolates "Spots open" — the events a member can actually do something about by turning up.
+export const TogglesTurnout: Story = {
+  // Behavioural twin of Open — the open popover is the same picture; only onToggleTurnout fires
+  // (ADR-0027 §2).
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await userEvent.click(canvas.getByRole('button', { name: 'Spots open' }))
+    await expect(args.onToggleTurnout).toHaveBeenCalledWith('spots-open')
+  },
+}
+
+// The isolated result: only the events short a whole position. The dot shows even though every type
+// and every answer is still selected — turnout narrows the list just as invisibly.
+export const FilteredToMissingAPosition: Story = {
+  args: { activeTurnouts: new Set<TurnoutBucket>(['missing-position']), resultCount: 2 },
+  play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByTestId('active-filter-dot')).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.getByRole('button', { name: 'Missing a position' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    for (const label of ['Spots open', 'Covered', 'No target set']) {
+      await expect(canvas.getByRole('button', { name: label })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      )
+    }
+    // Every answer chip is still on — the dot is the Turnout group's doing.
+    await expect(canvas.getByRole('button', { name: 'Going' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  },
+}
+
+// The OR case (ADR-0029 §2): "missing a position or short of a few" — everything worth turning up
+// for. Tapping from a subset toggles rather than isolating.
+export const TogglesSecondTurnoutBackOn: Story = {
+  // Behavioural twin of FilteredToMissingAPosition — same picture, only onToggleTurnout fires
+  // (ADR-0027 §2).
+  args: { activeTurnouts: new Set<TurnoutBucket>(['missing-position']), resultCount: 2 },
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvas, userEvent, args }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await userEvent.click(canvas.getByRole('button', { name: 'Spots open' }))
+    await expect(args.onToggleTurnout).toHaveBeenCalledWith('spots-open')
+  },
+}
+
+// A team that sets no targets gets TALLY_ONLY on every event, so the list spans one band and the
+// group is four chips that provably filter nothing. It is not rendered at all (ADR-0029 §5) — the
+// other groups, and the past toggle, carry on as before.
+export const WithoutTurnout: Story = {
+  args: { showTurnout: false },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Filters' }))
+    await expect(canvas.queryByRole('group', { name: 'Turnout' })).not.toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Spots open' })).not.toBeInTheDocument()
+    await expect(canvas.getByRole('group', { name: 'Your answer' })).toBeInTheDocument()
+    await expect(canvas.getByRole('switch', { name: 'Show past events' })).toBeInTheDocument()
   },
 }

--- a/app/src/features/filter-event-types/ui/EventFiltersView.tsx
+++ b/app/src/features/filter-event-types/ui/EventFiltersView.tsx
@@ -3,6 +3,7 @@ import { SlidersHorizontal } from 'lucide-react'
 import type { EventTypeItem } from '@shared/api/event-types'
 import type { AttendanceState } from '@features/attendance-toggle/ui/AttendanceToggle'
 import { ALL_ATTENDANCE_STATES } from '../model/attendance-states'
+import { ALL_TURNOUT_BUCKETS, type TurnoutBucket } from '../model/turnout'
 
 interface EventFiltersViewProps {
   eventTypes: EventTypeItem[]
@@ -10,11 +11,19 @@ interface EventFiltersViewProps {
   activeTypeIds: Set<string>
   /** Attendance States currently shown. Every state active = no answer filter in effect. */
   activeStates: Set<AttendanceState>
+  /** Turnout bands currently shown. Every band active = no turnout filter in effect. */
+  activeTurnouts: Set<TurnoutBucket>
+  /**
+   * Whether the list spans two or more Turnout bands (ADR-0029 §5). False hides the whole group:
+   * for a team that sets no targets it would be four chips that provably filter nothing.
+   */
+  showTurnout: boolean
   showPast: boolean
   /** How many events survive the current filter — announced, never shown (ADR-0029). */
   resultCount: number
   onToggleType: (typeId: string) => void
   onToggleState: (state: AttendanceState) => void
+  onToggleTurnout: (bucket: TurnoutBucket) => void
   onToggleShowPast: (showPast: boolean) => void
 }
 
@@ -48,27 +57,64 @@ const STATE_CHIPS: { state: AttendanceState; label: string; active: string; inac
 ]
 
 /**
+ * The Turnout chips, in the order the bands run from most to least short of people. The first three
+ * carry the card's own roster tones — red / gold / green — so the filter and the card say the same
+ * thing about a state. `No target set` carries none: a tally and a social are not verdicts, and
+ * colouring them would invent the judgement the card deliberately withholds (ADR-0029 §4).
+ */
+const TURNOUT_CHIPS: { bucket: TurnoutBucket; label: string; active: string; inactive: string }[] = [
+  {
+    bucket: 'missing-position',
+    label: 'Missing a position',
+    active: 'bg-red border-red text-white',
+    inactive: 'border-red/40 text-red',
+  },
+  {
+    bucket: 'spots-open',
+    label: 'Spots open',
+    active: 'bg-gold border-gold text-white',
+    inactive: 'border-gold/40 text-gold',
+  },
+  {
+    bucket: 'covered',
+    label: 'Covered',
+    active: 'bg-green border-green text-white',
+    inactive: 'border-green/40 text-green',
+  },
+  {
+    bucket: 'no-target',
+    label: 'No target set',
+    active: 'bg-muted-foreground border-muted-foreground text-white',
+    inactive: 'border-muted-foreground/40 text-muted-foreground',
+  },
+]
+
+/**
  * The events page's single filter control: an icon button that opens a popover holding the
- * event-type chips, the answer chips and the "Show past events" switch. It replaces the old
- * Upcoming/Past segmented tab bar — past events are a filter, not a mode, and the page no longer
- * spends a band of chrome on a control that only flipped which way the same list grew.
+ * event-type chips, the answer chips, the Turnout chips and the "Show past events" switch. It
+ * replaces the old Upcoming/Past segmented tab bar — past events are a filter, not a mode, and the
+ * page no longer spends a band of chrome on a control that only flipped which way the same list grew.
  *
  * Each chip group is a total partition of the list, so "all chips on" is the unfiltered default and
  * can never hide anything (ADR-0029 §1). Selection is isolate-first and lives in the route, which
- * owns the one toggler both groups share.
+ * owns the one toggler every group shares. Groups come from the data: the type chips render only
+ * when the team has types, and the Turnout group only when the list spans two of its bands (§5).
  *
- * Prop-only apart from the popover's own open/closed state, which is local view state: the selected
- * types, the selected answers and the show-past flag live in the route so they can drive
- * `useEvents`, the hero and Bulk Attend.
+ * Prop-only apart from the popover's own open/closed state, which is local view state: the three
+ * selections and the show-past flag live in the route so they can drive `useEvents`, the hero and
+ * Bulk Attend.
  */
 export function EventFiltersView({
   eventTypes,
   activeTypeIds,
   activeStates,
+  activeTurnouts,
+  showTurnout,
   showPast,
   resultCount,
   onToggleType,
   onToggleState,
+  onToggleTurnout,
   onToggleShowPast,
 }: EventFiltersViewProps) {
   const [open, setOpen] = useState(false)
@@ -78,7 +124,8 @@ export function EventFiltersView({
   const hasActiveFilter =
     showPast ||
     activeTypeIds.size < eventTypes.length ||
-    activeStates.size < ALL_ATTENDANCE_STATES.length
+    activeStates.size < ALL_ATTENDANCE_STATES.length ||
+    activeTurnouts.size < ALL_TURNOUT_BUCKETS.length
 
   // Escape has to be caught on the document: focus stays on the trigger, which is a sibling of the
   // popover, so a handler on the panel itself would never see the key.
@@ -192,6 +239,39 @@ export function EventFiltersView({
                 })}
               </div>
             </div>
+
+            {showTurnout && (
+              <>
+                <div className="-mx-3.5 my-3.5 h-px bg-border/60" />
+
+                <div role="group" aria-labelledby="turnout-filter-heading">
+                  <h3
+                    id="turnout-filter-heading"
+                    className="mb-2.5 text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground"
+                  >
+                    Turnout
+                  </h3>
+                  <div className="flex flex-wrap gap-2">
+                    {TURNOUT_CHIPS.map(({ bucket, label, active, inactive }) => {
+                      const isActive = activeTurnouts.has(bucket)
+                      return (
+                        <button
+                          key={bucket}
+                          aria-pressed={isActive}
+                          onClick={() => onToggleTurnout(bucket)}
+                          className={[
+                            'shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition-all',
+                            isActive ? active : inactive,
+                          ].join(' ')}
+                        >
+                          {label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
 
             <div className="-mx-3.5 my-3.5 h-px bg-border/60" />
 

--- a/app/src/routes/t/$slug/index.tsx
+++ b/app/src/routes/t/$slug/index.tsx
@@ -12,6 +12,11 @@ import { CreateEventSheet } from '@widgets/create-event/ui/CreateEventSheet'
 import { EventFiltersView } from '@features/filter-event-types/ui/EventFiltersView'
 import { toggleTypeSelection } from '@features/filter-event-types/model/toggleTypeSelection'
 import { ALL_ATTENDANCE_STATES } from '@features/filter-event-types/model/attendance-states'
+import {
+    ALL_TURNOUT_BUCKETS,
+    spansMultipleTurnoutBuckets,
+    type TurnoutBucket,
+} from '@features/filter-event-types/model/turnout'
 import { filterEvents } from '@features/filter-event-types/model/filter-events'
 import { emptyEventsMessage } from '@features/filter-event-types/model/empty-message'
 import { BulkAttendBar } from '@features/bulk-attend/ui/BulkAttendBar'
@@ -38,6 +43,10 @@ function EventListPage() {
     // the states are known without a request.
     const [activeStates, setActiveStates] = useState<Set<Event['myState']>>(
         new Set(ALL_ATTENDANCE_STATES))
+    // Same for the Turnout bands: all four on is the unfiltered view, and it stays that way for a
+    // team whose list spans one band — the group is not rendered for them, so nothing can narrow it.
+    const [activeTurnouts, setActiveTurnouts] = useState<Set<TurnoutBucket>>(
+        new Set(ALL_TURNOUT_BUCKETS))
     const {data: events, isLoading, error} = useEvents(showPast)
     const {data: eventTypes} = useEventTypes()
     const isAdmin = useUserStore((s) => s.role) === 'ADMIN'
@@ -73,8 +82,8 @@ function EventListPage() {
 
     const filteredEvents = useMemo(() => {
         if (!events || !eventTypes) return events ?? []
-        return filterEvents(events, activeTypeIds, activeStates)
-    }, [events, activeTypeIds, activeStates, eventTypes])
+        return filterEvents(events, activeTypeIds, activeStates, activeTurnouts)
+    }, [events, activeTypeIds, activeStates, activeTurnouts, eventTypes])
 
     // The API returns upcoming ascending but "all" descending, so sort here: the list is flat now,
     // and flat only reads if it is chronological.
@@ -90,11 +99,17 @@ function EventListPage() {
     const hasActiveFilter =
         showPast ||
         activeTypeIds.size < allTypeIds.length ||
-        activeStates.size < ALL_ATTENDANCE_STATES.length
+        activeStates.size < ALL_ATTENDANCE_STATES.length ||
+        activeTurnouts.size < ALL_TURNOUT_BUCKETS.length
+
+    // Read off the *unfiltered* list (ADR-0029 §5): narrowing another dimension must not make the
+    // group vanish underneath a Turnout selection that is still in effect.
+    const showTurnout = useMemo(() => spansMultipleTurnoutBuckets(events ?? []), [events])
 
     const clearFilters = () => {
         setActiveTypeIds(new Set(allTypeIds))
         setActiveStates(new Set(ALL_ATTENDANCE_STATES))
+        setActiveTurnouts(new Set(ALL_TURNOUT_BUCKETS))
         setShowPast(false)
     }
 
@@ -125,6 +140,8 @@ function EventListPage() {
                         eventTypes={eventTypes ?? []}
                         activeTypeIds={activeTypeIds}
                         activeStates={activeStates}
+                        activeTurnouts={activeTurnouts}
+                        showTurnout={showTurnout}
                         showPast={showPast}
                         resultCount={sortedEvents.length}
                         onToggleType={(typeId) =>
@@ -135,6 +152,10 @@ function EventListPage() {
                         onToggleState={(state) =>
                             setActiveStates(prev =>
                                 toggleTypeSelection(prev, ALL_ATTENDANCE_STATES, state))
+                        }
+                        onToggleTurnout={(bucket) =>
+                            setActiveTurnouts(prev =>
+                                toggleTypeSelection(prev, ALL_TURNOUT_BUCKETS, bucket))
                         }
                         onToggleShowPast={setShowPast}
                     />
@@ -165,6 +186,7 @@ function EventListPage() {
                     activeTypeIds,
                     allTypeIds,
                     activeStates,
+                    activeTurnouts,
                 })}
                 onClearFilters={hasActiveFilter ? clearFilters : undefined}
             />


### PR DESCRIPTION
Closes #311. Extends #309's groundwork (shared empty state, `Clear filters`, the announced result count) rather than reinventing it.

## What

A fourth chip group, **Turnout**, in the events filter popover — *"which events are short of players?"*, framed from the member's side. Not admin-gated: a plain User can act on a short training by turning up. Client-side only; `roster.state` has been on the list payload since #219, so no contract change.

| Chip | `RosterState` |
|---|---|
| `Missing a position` | `CRITICAL` |
| `Spots open` | `SPOTS_OPEN`, `HEADCOUNT_SHORT` |
| `Covered` | `LINEUP_SET`, `HEADCOUNT_FULL` |
| `No target set` | `TALLY_ONLY`, `OFF` |

## How it holds the ADR-0029 line

- **Total partition (§1).** All seven Roster States are accounted for, so all-chips-on means "no constraint" and can never hide anything. `No target set` exists to complete the partition, not because anyone will filter on it.
- **State name → band, nothing more.** `TURNOUT_BY_STATE` is a lookup table; no roster state is re-derived client-side (`entities/event/lib/roster-view.ts` explains why a second status implementation is off limits). It is typed as a total `Record<RosterState, TurnoutBucket>`, so a state added to the contract **fails the typecheck and the exhaustive unit test** instead of falling through to no band.
- **The card's own reading (§4).** The first three bands follow the existing `RosterTone` split and carry its tones — red / gold / green. `No target set` carries none: a tally and a social are not verdicts, the same reasoning that gives them no chip on the card.
- **Conditional rendering (§5).** The group renders only when the list spans two or more bands, computed off the **unfiltered** list so narrowing another dimension cannot make the group vanish underneath a Turnout selection still in effect. A team that sets no targets sees no group.
- **Same behaviour as every other group (§1–3, §8).** All on by default, OR within / AND across, isolate-first via the shared `toggleTypeSelection`, nothing pre-applied, no persistence. `Clear filters` and the trigger's active-filter dot both cover it.
- **Everything follows the filter (§6).** The hero and Bulk Attend read the same filtered list, so they narrow with Turnout too.
- **Empty state.** `No events are short of players.` — but only when Turnout is the single narrowed dimension *and* the selection is within the two short bands. After isolating `Covered` that sentence would be a lie, so it falls back to the generic line, mirroring how the answer dimension already treats anything but `Not responded`.

## Interaction with #281

No rework needed there: #281 changes *which* `RosterState` an event gets, not the vocabulary, so the same events simply land in honest bands once it merges. The mapping is pinned by the exhaustive unit test so it cannot be silently perturbed.

Residual exposure, stated as a known trade-off: **before #281, a training short by one player can report `HEADCOUNT_FULL`**, land in `Covered`, and be hidden from a member filtered to `Spots open`. Worse in a filter than on a card, and accepted because the default is all-chips-on — it only bites someone who has actively narrowed.

## Testing

- **Vitest** `turnout.test.ts` — exhaustive: every one of the seven states pinned to its band, plus a key-set assertion so an eighth state fails rather than falls through; and the ≥2-bands render condition.
- **Vitest** `filter-events.test.ts` — OR within the turnout dimension (over two states sharing a band), AND with the other two.
- **Vitest** `empty-message.test.ts` — the short-of-players line for each short selection, the generic fallback for `Covered` and for a mixed selection, and for turnout narrowed alongside another dimension.
- **Vitest** `eligible-event-ids.test.ts` — Bulk Attend follows the turnout dimension too (§6).
- **Storybook** on `EventFiltersView` — the group open with all chips on, isolate-first (`TogglesTurnout`), the OR case (`TogglesSecondTurnoutBackOn`), the narrowed state with the dot (`FilteredToMissingAPosition`), and the **group absent** (`WithoutTurnout`).
- **No new e2e** — no new seam: no new auth path, no cross-tenant write, no external integration.
- No PWA screenshot regeneration: the change is inside the popover, not on the events overview or app shell.

`make test-app` (801 tests, 116 files) and `make lint` (eslint + detekt) pass.

## Manual verification

Ran the full stack locally (Postgres + backend on the `e2e` profile + Vite) and drove the real UI:

- Seeded single-band list (every event `OFF`) → **Turnout group not rendered**; the other groups and the past toggle unaffected.
- Seeded events spanning `CRITICAL` / `HEADCOUNT_SHORT` / `HEADCOUNT_FULL` / `OFF` → group renders, four chips on, no dot.
- Tapping `Missing a position` isolates it → only that event survives, the trigger dot appears, the hero and Bulk Attend ("Attend 1 training") narrow with it.
- With that band empty → `No events are short of players.` + `Clear filters`; narrowing a second dimension → `No events match these filters.`
- `Clear filters` restores all four Turnout chips and drops the dot; the live region announces the count on every tap.

Refs #290, #281, #219, #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGuNzifWGuRmToJHeLnJbj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGuNzifWGuRmToJHeLnJbj)_