### PR TITLE
fix(api): cap the include-past events query in SQL, and warn when it is hit

### DIFF
--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/application/EventService.kt
@@ -24,6 +24,7 @@ import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -55,16 +56,45 @@ class EventService(
     private val authorizationService: AuthorizationService,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(EventService::class.java)
+
     companion object {
         val GRACE_PERIOD: Duration = Duration.ofHours(6)
 
         // A single occurrence can't run longer than a day — guards against a bogus/huge duration.
         const val MAX_DURATION_MINUTES: Long = 24 * 60
+
+        /**
+         * The most events `include-past=true` will ever return. Roughly four seasons of history at
+         * three events a week — well above any team we have, so it is a guardrail rather than a
+         * limit anyone should meet, and reaching it is itself the signal (the WARN below).
+         *
+         * Truncation drops the OLDEST events, since the ordering is newest-first. Future events are
+         * the newest of all, so Bulk Attend (future-only, ADR-0020) can never lose a row to it.
+         */
+        const val EVENT_HISTORY_CAP: Int = 500
     }
 
     fun getUpcomingEvents(): List<Event> = eventRepository.findUpcoming(clock.instant().minus(GRACE_PERIOD))
 
-    fun getAllEvents(): List<Event> = eventRepository.findAll()
+    /**
+     * Every event, newest first — capped at [EVENT_HISTORY_CAP].
+     *
+     * One row beyond the cap is asked for, which is what tells "exactly at the cap" from "over it"
+     * without a second `count()`. [teamId] is here for the warning and nothing else: the tenant is
+     * already bound by the time this runs, but a log line that cannot name the team is no signal.
+     */
+    fun getAllEvents(teamId: TeamId): List<Event> {
+        val events = eventRepository.findMostRecent(EVENT_HISTORY_CAP + 1)
+        if (events.size <= EVENT_HISTORY_CAP) return events
+        log.warn(
+            "Team {} has more than {} events; returning the {} most recent and dropping older history",
+            teamId,
+            EVENT_HISTORY_CAP,
+            EVENT_HISTORY_CAP,
+        )
+        return events.take(EVENT_HISTORY_CAP)
+    }
 
     fun getEvent(id: EventId): Event? = eventRepository.findById(id)
 

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/domain/port/EventRepository.kt
@@ -22,7 +22,13 @@ interface EventRepository {
      */
     fun findByIds(ids: List<EventId>): List<Event>
     fun findUpcoming(since: Instant): List<Event>
-    fun findAll(): List<Event>
+
+    /**
+     * The [limit] most recent events, newest first. The bound is part of the contract because it
+     * has to reach the query: the all-events read grows monotonically across seasons, and a caller
+     * that trimmed the result afterwards would already have paid for every row (#310).
+     */
+    fun findMostRecent(limit: Int): List<Event>
     fun findByRecurringGroup(group: UUID): List<Event>
     fun save(event: Event): Event
     fun saveAll(events: List<Event>): List<Event>

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/JpaEventRepositoryAdapter.kt
@@ -8,6 +8,7 @@ import com.github.zzave.teambalance.api.domain.model.PositionId
 import com.github.zzave.teambalance.api.domain.port.EventRepository
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.internalize
 import com.github.zzave.teambalance.api.infrastructure.persistence.mapper.externalize
+import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -54,8 +55,8 @@ class JpaEventRepositoryAdapter(
         jpaRepository.findByStartTimeGreaterThanOrderByStartTimeAsc(since).map { it.internalize() }
 
     @Transactional(readOnly = true)
-    override fun findAll(): List<Event> =
-        jpaRepository.findAllByOrderByStartTimeDesc().map { it.internalize() }
+    override fun findMostRecent(limit: Int): List<Event> =
+        jpaRepository.findAllByOrderByStartTimeDesc(Limit.of(limit)).map { it.internalize() }
 
     @Transactional(readOnly = true)
     override fun findByRecurringGroup(group: UUID): List<Event> =

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/infrastructure/persistence/SpringDataEventRepository.kt
@@ -1,6 +1,7 @@
 package com.github.zzave.teambalance.api.infrastructure.persistence
 
 import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
+import org.springframework.data.domain.Limit
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -12,7 +13,12 @@ interface SpringDataEventRepository : JpaRepository<EventJpaEntity, Long> {
     fun findByUuid(uuid: UUID): EventJpaEntity?
     fun findByUuidIn(uuids: List<UUID>): List<EventJpaEntity>
     fun findByStartTimeGreaterThanOrderByStartTimeAsc(since: Instant): List<EventJpaEntity>
-    fun findAllByOrderByStartTimeDesc(): List<EventJpaEntity>
+    /**
+     * Newest first, at most [limit] rows. A `Limit` parameter rather than a `findTopN` name so the
+     * cap stays where the policy is (`EventService.EVENT_HISTORY_CAP`) instead of being baked into a
+     * method name — and, unlike trimming the list afterwards, it becomes a SQL `LIMIT` (#310).
+     */
+    fun findAllByOrderByStartTimeDesc(limit: Limit): List<EventJpaEntity>
     fun findByRecurringGroupOrderByStartTimeAsc(recurringGroup: UUID): List<EventJpaEntity>
 
     fun countByEventTypeId(eventTypeId: Long): Int

--- a/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
+++ b/api/src/main/kotlin/com/github/zzave/teambalance/api/interfaces/EventController.kt
@@ -46,9 +46,11 @@ class EventController(
     DeleteEvent.Handler {
 
     override suspend fun listEvents(request: ListEvents.Request): ListEvents.Response<*> {
-        val members = attendanceService.teamMembers(currentTeamGateway.requireCurrentTeamId())
+        val teamId = currentTeamGateway.requireCurrentTeamId()
+        val members = attendanceService.teamMembers(teamId)
         val viewerId = currentUserGateway.requireCurrentUserId()
-        val events = if (request.queries.includepast) eventService.getAllEvents() else eventService.getUpcomingEvents()
+        val events =
+            if (request.queries.includepast) eventService.getAllEvents(teamId) else eventService.getUpcomingEvents()
         val attendance = attendanceService.attendanceForAll(events.map { it.id }, members)
         // The position vocabulary is fetched once for the whole listing, not per event: it is the
         // same list for every row, and it is both the label source and the row filter for the roster.

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/EventServiceTest.kt
@@ -25,8 +25,16 @@ import com.github.zzave.teambalance.api.domain.port.EventTypeRepository
 import com.github.zzave.teambalance.api.domain.port.PositionRepository
 import com.github.zzave.teambalance.api.domain.port.SeasonRepository
 import com.github.zzave.teambalance.api.domain.port.TeamMemberRepository
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.DayOfWeek
 import java.time.Instant
@@ -43,7 +51,7 @@ private class ExplodingEventRepo : EventRepository {
     override fun findById(id: EventId): Event? = error("repository must not be reached for an unauthorized caller")
     override fun findByIds(ids: List<EventId>): List<Event> = error("unused")
     override fun findUpcoming(since: Instant): List<Event> = error("unused")
-    override fun findAll(): List<Event> = error("unused")
+    override fun findMostRecent(limit: Int): List<Event> = error("unused")
     override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
     override fun save(event: Event): Event = error("unused")
     override fun saveAll(events: List<Event>): List<Event> = error("unused")
@@ -106,6 +114,45 @@ private class EventFakeMemberRepo(private val admins: Set<UserId>) : TeamMemberR
     override fun markOnboarded(teamId: TeamId, userId: UserId, at: Instant) = Unit
     override fun countAdmins(teamId: TeamId): Int = admins.size
     override fun countByPosition(teamId: TeamId, positionId: PositionId): Int = 0
+}
+
+/**
+ * Answers [findMostRecent] honestly — at most [limit] rows, newest first — and records the limit it
+ * was asked for. That is what lets these tests state the cap policy without a database: how many
+ * rows the service asks for, how many it hands back, and when it warns. Whether that limit actually
+ * reaches SQL is a different claim, proven against real Postgres in `EventHistoryCapIT`.
+ */
+private class RecordingEventRepo(private val available: Int) : EventRepository {
+    var requestedLimit: Int? = null
+
+    override fun findMostRecent(limit: Int): List<Event> {
+        requestedLimit = limit
+        return (0 until minOf(limit, available)).map { historyEvent(it) }
+    }
+
+    override fun findById(id: EventId): Event? = error("unused")
+    override fun findByIds(ids: List<EventId>): List<Event> = error("unused")
+    override fun findUpcoming(since: Instant): List<Event> = error("unused")
+    override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
+    override fun save(event: Event): Event = error("unused")
+    override fun saveAll(events: List<Event>): List<Event> = error("unused")
+    override fun deleteById(id: EventId) = error("unused")
+    override fun deleteAllById(ids: List<EventId>) = error("unused")
+    override fun countTargetsForPosition(positionId: PositionId): Int = error("unused")
+
+    // Index 0 is the newest, so "the oldest row is the one dropped" is observable by title.
+    private fun historyEvent(index: Int) = Event(
+        id = EventId(UUID.randomUUID()),
+        eventType = EventType(EventTypeId(UUID.randomUUID()), EventTypeName("Training"), null),
+        title = EventTitle("Event $index"),
+        description = null,
+        startTime = Instant.EPOCH.minusSeconds(index.toLong()),
+        endTime = Instant.EPOCH.minusSeconds(index.toLong()).plusSeconds(3600),
+        location = null,
+        recurringGroup = null,
+        createdBy = UserId.random(),
+        createdAt = Instant.EPOCH,
+    )
 }
 
 class EventServiceTest : FunSpec() {
@@ -179,5 +226,70 @@ class EventServiceTest : FunSpec() {
                 )
             }
         }
+
+        // --- the include-past cap (#310) -------------------------------------------------------
+
+        fun serviceOverHistoryOf(available: Int): Pair<EventService, RecordingEventRepo> {
+            val repo = RecordingEventRepo(available)
+            return EventService(
+                repo,
+                ExplodingEventTypeRepo(),
+                ExplodingSeasonRepo(),
+                ExplodingPositionRepo(),
+                AuthorizationService(EventFakeMemberRepo(admins = emptySet()), FakeActAsGateway()),
+                Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+            ) to repo
+        }
+
+        fun warningsWhile(block: () -> Unit): List<String> {
+            val logger = LoggerFactory.getLogger(EventService::class.java) as Logger
+            val appender = ListAppender<ILoggingEvent>().also { it.start() }
+            logger.addAppender(appender)
+            try {
+                block()
+            } finally {
+                logger.detachAppender(appender)
+                appender.stop()
+            }
+            return appender.list.filter { it.level == Level.WARN }.map { it.formattedMessage }
+        }
+
+        test("getAllEvents asks for one row beyond the cap, which is what separates 'at' from 'over'") {
+            val (service, repo) = serviceOverHistoryOf(EventService.EVENT_HISTORY_CAP + 1)
+
+            service.getAllEvents(teamId)
+
+            repo.requestedLimit shouldBe EventService.EVENT_HISTORY_CAP + 1
+        }
+
+        test("over the cap, exactly the cap comes back and the oldest row is the one dropped") {
+            val (service, _) = serviceOverHistoryOf(EventService.EVENT_HISTORY_CAP + 1)
+
+            val events = service.getAllEvents(teamId)
+
+            events.map { it.title.value } shouldContainExactly
+                (0 until EventService.EVENT_HISTORY_CAP).map { "Event $it" }
+        }
+
+        test("exactly at the cap, everything comes back and nothing is warned about") {
+            val (service, _) = serviceOverHistoryOf(EventService.EVENT_HISTORY_CAP)
+
+            var events: List<Event> = emptyList()
+            val warnings = warningsWhile { events = service.getAllEvents(teamId) }
+
+            events.size shouldBe EventService.EVENT_HISTORY_CAP
+            warnings shouldBe emptyList()
+        }
+
+        test("over the cap, one WARN names the team and the cap") {
+            val (service, _) = serviceOverHistoryOf(EventService.EVENT_HISTORY_CAP + 1)
+
+            val warnings = warningsWhile { service.getAllEvents(teamId) }
+
+            warnings.size shouldBe 1
+            warnings.single() shouldContain teamId.value.toString()
+            warnings.single() shouldContain EventService.EVENT_HISTORY_CAP.toString()
+        }
+
     }
 }

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/application/PositionServiceTest.kt
@@ -87,7 +87,7 @@ private class CountingEventRepo : EventRepository {
     override fun findById(id: EventId): Event? = error("unused")
     override fun findByIds(ids: List<EventId>): List<Event> = error("unused")
     override fun findUpcoming(since: Instant): List<Event> = error("unused")
-    override fun findAll(): List<Event> = error("unused")
+    override fun findMostRecent(limit: Int): List<Event> = error("unused")
     override fun findByRecurringGroup(group: UUID): List<Event> = error("unused")
     override fun save(event: Event): Event = error("unused")
     override fun saveAll(events: List<Event>): List<Event> = error("unused")

--- a/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventHistoryCapIT.kt
+++ b/api/src/test/kotlin/com/github/zzave/teambalance/api/interfaces/EventHistoryCapIT.kt
@@ -1,0 +1,140 @@
+package com.github.zzave.teambalance.api.interfaces
+
+import com.github.zzave.teambalance.api.TeamBalanceIT
+import com.github.zzave.teambalance.api.application.EventService
+import com.github.zzave.teambalance.api.infrastructure.multitenancy.TenantSchemaAdapter
+import com.github.zzave.teambalance.api.infrastructure.persistence.entity.EventJpaEntity
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManagerFactory
+import org.hibernate.SessionFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+// Spec-dedicated ids and, unusually, a spec-dedicated tenant schema: this spec asserts an EXACT row
+// count for the whole tenant, which no spec sharing `public` could ever do.
+private const val TEAM_ID = "a0000000-0000-0000-0000-0000000000ca"
+private const val USER_ID = "b0000000-0000-0000-0000-0000000000ca"
+private const val SCHEMA = "team_event_cap"
+
+private val CAP = EventService.EVENT_HISTORY_CAP
+
+// Comfortably past the cap, and past CAP + 1 as well. The margin is the point: with the limit in
+// SQL, Hibernate loads CAP + 1 rows however many are in the table; with a `.take(CAP)` applied after
+// `findAllByOrderByStartTimeDesc()` it would load all of them. Seeding only CAP + 1 would make both
+// implementations load the same number of rows and the assertion below would prove nothing.
+private const val SEEDED_EVENTS = 510
+
+/**
+ * The cap on `include-past=true` (#310), against real Postgres.
+ *
+ * Two claims, and the second is the one that is easy to fake: the endpoint returns the CAP most
+ * recent events, **and** the bound reached SQL. Nothing about a truncated response distinguishes a
+ * `LIMIT` from a Kotlin `.take()` after the fact — the latter has already paid the cost the cap
+ * exists to avoid — so the load count is asserted directly.
+ */
+@AutoConfigureMockMvc
+class EventHistoryCapIT : TeamBalanceIT() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var tenantSchemaAdapter: TenantSchemaAdapter
+
+    @Autowired
+    lateinit var entityManagerFactory: EntityManagerFactory
+
+    init {
+        test("include-past returns the cap's worth of events, newest first, dropping the oldest history") {
+            seedEvents()
+
+            listPastEvents()
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events.length()").value(CAP))
+                // Event 0 is the newest and Event ${SEEDED_EVENTS - 1} the oldest, so this pins both
+                // the ordering and which end of the history the cap cuts off.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].title").value("Event 0"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[${CAP - 1}].title").value("Event ${CAP - 1}"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.events[?(@.title == 'Event $CAP')]").doesNotExist())
+        }
+
+        test("the cap is applied in SQL: only CAP + 1 event rows are ever loaded") {
+            seedEvents()
+
+            val rowsLoaded = countingEventRowLoads { listPastEvents() }
+
+            // CAP + 1, not CAP: the extra row is what tells "exactly at the cap" from "over it"
+            // without a second count() query. And not $SEEDED_EVENTS, which is what a post-fetch
+            // `.take()` would have loaded.
+            rowsLoaded shouldBe (CAP + 1).toLong()
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private fun listPastEvents() =
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/events?include-past=true")
+                .header("X-Team-Id", SCHEMA)
+                .header("X-User-Id", USER_ID),
+        )
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn()
+            .let { mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(it)) }
+
+    /** Event rows Hibernate actually materialized while [block] ran — the whole point of the fix. */
+    private fun countingEventRowLoads(block: () -> Unit): Long {
+        val statistics = entityManagerFactory.unwrap(SessionFactory::class.java).statistics
+        val wasEnabled = statistics.isStatisticsEnabled
+        statistics.isStatisticsEnabled = true
+        statistics.clear()
+        try {
+            block()
+            return statistics.getEntityStatistics(EventJpaEntity::class.java.name).loadCount
+        } finally {
+            statistics.isStatisticsEnabled = wasEnabled
+        }
+    }
+
+    private fun seedEvents() {
+        tenantSchemaAdapter.provisionPlatformSchema()
+        tenantSchemaAdapter.provisionTenantSchema(SCHEMA)
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.teams (id, name, slug, schema_name)
+            VALUES ('$TEAM_ID'::uuid, 'Cap Team', 'cap-team', '$SCHEMA')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.execute(
+            """
+            INSERT INTO public.users (id, email, display_name)
+            VALUES ('$USER_ID'::uuid, 'cap-member@test.com', 'Cap Member')
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        jdbcTemplate.execute("SELECT public.tb_add_member('$TEAM_ID'::uuid, '$USER_ID'::uuid, 'ADMIN', 'Setter')")
+
+        // Rebuilt every test so the exact counts below hold whichever tests ran before.
+        jdbcTemplate.update("DELETE FROM $SCHEMA.events")
+        jdbcTemplate.update(
+            """
+            INSERT INTO $SCHEMA.events (uuid, event_type_id, title, start_time, end_time, created_by, created_at, updated_at)
+            SELECT gen_random_uuid(),
+                   (SELECT id FROM $SCHEMA.event_types WHERE name = 'Training'),
+                   'Event ' || i,
+                   TIMESTAMPTZ '2026-01-01 20:00:00+00' - (i || ' days')::interval,
+                   TIMESTAMPTZ '2026-01-01 22:00:00+00' - (i || ' days')::interval,
+                   '$USER_ID'::uuid, now(), now()
+            FROM generate_series(0, ${SEEDED_EVENTS - 1}) AS i
+            """,
+        )
+    }
+}


### PR DESCRIPTION
Closes #310.

## What changed

`ListEvents` with `include-past=true` read every event row a tenant had ever had — no date floor, no limit — and `EventController.listEvents` then did O(events × members) work over the result. The upcoming branch self-limits as time passes; this one grows monotonically across seasons, and nothing would have told us it was approaching trouble.

**The bound now reaches SQL.** `EventRepository.findAll()` becomes `findMostRecent(limit)`, implemented with a Spring Data `Limit` parameter so it compiles to a real `LIMIT`. A `Limit` argument rather than a `findTop500By…` name, so the cap stays where the policy is (`EventService.EVENT_HISTORY_CAP`) instead of being baked into a method name.

`EventService.getAllEvents(teamId)` asks for `CAP + 1` and returns `CAP`. That extra row is what separates "exactly at the cap" from "over it" without a second `count()` query, and it is the only case that WARNs. Truncation drops the **oldest** history, since the ordering is already `startTime DESC` — future events are the newest of all, so Bulk Attend (future-only, ADR-0020) can never lose a row to it.

Cap is **500**, per the issue's reasoning: roughly four seasons at ~3 events/week, well above any team we have, so it should not fire in practice — and if it does, that is the signal working.

`teamId` is now threaded into `getAllEvents` purely so the warning can name the tenant; the controller already had it in hand.

## Layers

`EVENT_HISTORY_CAP` and the truncate/warn decision live in `application`; the port states the bound as part of its contract; only the adapter and the Spring Data interface know how a limit becomes SQL. `detekt` (including the flock hexagonal rulesets, ADR-0018) is green.

## Testing

Per the PR gate, each claim sits at the lowest layer that proves it. No new e2e: this introduces no new seam — same endpoint, same auth path, same tenant write surface.

**`EventHistoryCapIT`** (Testcontainers, real Postgres, its own tenant schema so it can assert exact tenant-wide counts):
- with 510 events seeded, the endpoint returns exactly 500, `Event 0` first and `Event 499` last, and `Event 500` absent — pinning both the ordering and which end of the history the cap cuts off;
- **the cap is applied in SQL**: only `CAP + 1` `EventJpaEntity` rows are ever loaded, asserted through Hibernate's entity statistics.

That second test is the point of the change, so it was written to fail against the mistake it guards. Against a `findAllByOrderByStartTimeDesc().take(limit)` implementation it fails with `expected 501 but was 510` while the truncation test above still passes — which is exactly why the response size alone proves nothing. Seeding 510 rather than `CAP + 1` is deliberate: at `CAP + 1` both implementations would load the same number of rows and the assertion would be vacuous.

**`EventServiceTest`** (Kotest units, fake port that honours the limit) — the cap policy itself:
- it asks the port for `CAP + 1`;
- over the cap, exactly `CAP` comes back and the oldest row is the one dropped;
- exactly at the cap, everything comes back and **nothing is logged**;
- over the cap, one WARN naming the team and the cap (asserted via a Logback `ListAppender`).

`make test-api` — 657 tests, 0 failures. `make lint` — detekt green; the frontend half of that target fails in this container because `app/node_modules` isn't installed, which is pre-existing and untouched by this backend-only diff.

## Not in scope (per the issue)

No client-visible truncation signal, no metrics/monitors, no pagination, no contract change.

## One deviation worth flagging

The WARN names the team and the cap but **not the exact row count** — knowing it would require the `count()` query the `CAP + 1` trick exists to avoid. It reads: `Team {} has more than {} events; returning the {} most recent and dropping older history`. That is enough to act on; happy to add the `count()` behind the warn branch only if you'd rather have the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019T6z178KY7ob9rXU4rYPi5

---
_Generated by [Claude Code](https://claude.ai/code/session_019T6z178KY7ob9rXU4rYPi5)_