### PR TITLE
fix(app): pin the roster bar high on the detail page + restore per-PR Storybook previews

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,11 +1,13 @@
 name: Storybook
 
 # Deploys the component catalog to GitHub Pages (branch-based, gh-pages):
-#   push to main -> gh-pages root -> https://storybook.teambalance.nl
+#   push to main             -> gh-pages root       -> https://storybook.teambalance.nl
+#   PR (own-repo, app diff)  -> gh-pages/pr-preview/pr-<n>/ + a comment on the PR
+#   PR closed                -> that preview dir is removed
 #
-# Main only, on purpose: per-PR review of the catalog happens in Chromatic
-# (chromatic.yml), which publishes a browsable Storybook per PR build alongside the
-# visual diff. A second per-PR copy on gh-pages was duplicate work with no extra signal.
+# Per-PR previews are back on purpose: Chromatic's per-build Storybook (chromatic.yml)
+# has been unreliable at publishing a browsable catalog, so the gh-pages PR preview is
+# the dependable way to open a PR's Storybook. Revisit if Chromatic's publish stabilises.
 #
 # Kept separate from ci.yml on purpose: this needs `contents: write` (to push the
 # gh-pages branch), whereas ci.yml is deliberately read-only.
@@ -16,14 +18,21 @@ on:
     paths:
       - 'app/**'
       - 'design-tokens/**'
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'app/**'
+      - 'design-tokens/**'
   workflow_dispatch:
 
 permissions:
   contents: write        # push the built Storybook to the gh-pages branch
+  pull-requests: write   # pr-preview-action comments the preview URL on the PR
 
 jobs:
   # Canonical Storybook for main -> served at storybook.teambalance.nl
   deploy-main:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     concurrency:
       group: storybook-main
@@ -57,20 +66,86 @@ jobs:
         working-directory: app
 
       # CNAME binds the custom domain on every publish (clean would drop it otherwise);
-      # robots.txt keeps the domain out of search engines.
+      # robots.txt at the gh-pages root keeps the whole domain (previews included) out
+      # of search engines.
       - name: Add CNAME + robots.txt
         working-directory: app/storybook-static
         run: |
           echo 'storybook.teambalance.nl' > CNAME
           printf 'User-agent: *\nDisallow: /\n' > robots.txt
 
-      # `clean: true` with no exclusions: the gh-pages branch now holds nothing but the
-      # main build, so the first run after this change also sweeps away the leftover
-      # pr-preview/ dirs from the retired PR-preview job.
       - name: Publish to gh-pages root
         uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         with:
           folder: app/storybook-static
           branch: gh-pages
           clean: true
+          clean-exclude: pr-preview/   # never wipe live PR previews
           commit-message: 'docs(storybook): deploy main ${{ github.sha }}'
+
+  # Per-PR preview. Own-repo branches only: fork PRs run without write access/secrets,
+  # so we skip them rather than reach for pull_request_target.
+  deploy-preview:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: storybook-preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.19.0'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Generate Wirespec TypeScript client
+        run: ./gradlew :api:wirespec-typescript
+
+      - name: Build Storybook
+        run: |
+          npm ci
+          npm run build-storybook
+        working-directory: app
+
+      # Deploys to gh-pages/pr-preview/pr-<n>/, comments the URL, preserves the root
+      # site + other previews. Storybook's Vite build already uses relative asset
+      # paths (base: './'), so it serves correctly from the subpath.
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: app/storybook-static
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+
+  # PR closed -> remove its preview dir (no build needed).
+  cleanup-preview:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: storybook-preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: app/storybook-static
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove

--- a/app/src/routes/t/$slug/events/$eventId.tsx
+++ b/app/src/routes/t/$slug/events/$eventId.tsx
@@ -138,6 +138,20 @@ function EventDetailPage() {
         </div>
       </div>
 
+      {/* Roster overview — pinned so completeness stays one glance away however far a big squad
+          scrolls. Sits high, right under the event identity, so on a tall desktop screen it is
+          visible and pinning from the start rather than buried below the response/info sections.
+          Where no position carries a target it renders nothing (the list keeps the headcount
+          breakdown as the fallback, ⑥). */}
+      {hasPositionTargets && (
+        <div
+          className="sticky z-20 -mx-4 mt-6"
+          style={{ top: `calc(var(--header-height) + ${subHeaderHeight}px)` }}
+        >
+          <RosterBar roster={event.roster} />
+        </div>
+      )}
+
       {/* Your Response */}
       {currentUserId && (
         <div className="mt-6">
@@ -172,18 +186,9 @@ function EventDetailPage() {
         </div>
       )}
 
-      {/* Attendance — one list by position, no tabs. The roster bar pins beneath the sub-header so
-          completeness stays visible however far a big squad scrolls; where no position carries a
-          target it has nothing to show and the headcount breakdown stays as the fallback. */}
-      {hasPositionTargets && (
-        <div
-          className="sticky z-20 -mx-4 mt-6"
-          style={{ top: `calc(var(--header-height) + ${subHeaderHeight}px)` }}
-        >
-          <RosterBar roster={event.roster} />
-        </div>
-      )}
-      <div className={`overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm ${hasPositionTargets ? 'mt-3' : 'mt-6'}`}>
+      {/* Attendance — one list by position, no tabs. Where no position carries a target the roster
+          bar (pinned above) shows nothing and the headcount breakdown stays as the fallback. */}
+      <div className="mt-6 overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm">
         {!hasPositionTargets && <RoleBreakdown breakdown={event.attendanceSummary.roleBreakdown} />}
         <AttendeeList
           attendees={event.attendances}


### PR DESCRIPTION
Two small follow-ups after #305 merged. They ride together only because they share this branch; they're independent and can be reviewed as two commits.

## 1. Roster bar pins high on the event detail page (`ae2139e`)

Follow-up to the detail-page redesign (#274 / #305). On desktop the roster overview sat after **Your response** and **Additional info** in the flow: on a tall screen much of the list is visible without scrolling, so the sticky pin rarely engaged and the completeness overview read as buried mid-page.

Move the roster bar up — directly under the event identity, above the response/info sections — so it's visible at rest and pins to the top as soon as you scroll. Pure reorder in `routes/t/$slug/events/$eventId.tsx`: same sticky offset (`--header-height` + measured sub-header height), same "no targets → renders nothing, headcount breakdown is the fallback" rule; the list drops its now-unneeded tight top margin. This also reorders the mobile layout (roster now above your own response) — single column, one order everywhere.

Container wiring (ADR-0017), covered by the existing detail-page e2e — no new seam, so per the PR gate no new e2e. Verified: `typecheck`, `lint`, and `test-app` (755) all green.

## 2. Restore per-PR Storybook previews on gh-pages (`54833d2`)

#238 dropped the per-PR gh-pages Storybook preview on the reasoning that Chromatic already publishes a browsable Storybook per PR build. That has proven unreliable — Chromatic often doesn't publish the catalog — leaving no dependable way to open a PR's Storybook.

Re-add it in `.github/workflows/storybook.yml`: the `pull_request` trigger, the `pull-requests: write` permission, the `deploy-preview` job (build → `gh-pages/pr-preview/pr-<n>/` + a comment with the URL) and `cleanup-preview` (removes the dir on close), plus the `clean-exclude: pr-preview/` guard so a main deploy never wipes a live preview. Own-repo PRs only, as before.

Not a raw revert: the new preview/cleanup jobs use the **current** action pins that main's `deploy-main` job already carries (checkout v7, setup-java v5, setup-node v7, setup-gradle v6), rather than resurrecting the pre-#238 pins. Interim — revisit if Chromatic's publish stabilises. This PR itself should exercise it: the `deploy-preview` job should publish a Storybook for this PR and comment the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AviQ3vmKsLSvQgf25jWGE

---
_Generated by [Claude Code](https://claude.ai/code/session_015AviQ3vmKsLSvQgf25jWGE)_