### PR TITLE
fix(app): the readiness chip says which state it is in, not just which colour

### DIFF
--- a/app/src/entities/event/lib/roster-view.test.ts
+++ b/app/src/entities/event/lib/roster-view.test.ts
@@ -52,22 +52,37 @@ describe('rosterChip', () => {
     })
   })
 
-  // Same words, different tone. The count is the news; the colour is what separates "chase later"
-  // from "chase now" — a position sitting at zero.
-  it('keeps the wording but turns critical when a position has nobody', () => {
-    // Libero at zero is what makes it critical; Setter's two missing bring the count to three.
+  // Critical is not "more of the same shortfall": a position has nobody, and that is what the chip
+  // says. The count of open slots is the wrong news here — Setter being two short is not why this
+  // event needs chasing now.
+  it('names the missing position rather than the open-slot count when a position has nobody', () => {
+    // Libero at zero is what makes it critical; Setter's two missing bring openSlots to three.
     const criticalBy3 = [pos('Setter', 3, 1), pos('Libero', 1, 0)]
     expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 3, positions: criticalBy3 }))).toEqual({
-      text: '3 spots open',
+      text: 'Missing a position',
       tone: 'critical',
     })
   })
 
-  it('says "spot" not "spots" for a single one', () => {
+  it('counts the empty positions once more than one has nobody', () => {
+    const criticalBy4 = [pos('Setter', 3, 0), pos('Libero', 1, 0)]
+    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 4, positions: criticalBy4 }))?.text).toBe(
+      'Missing 2 positions',
+    )
+  })
+
+  // WCAG 1.4.1 (#313). Before this, both states read "3 spots open" and only gold-vs-red told them
+  // apart — unavailable to anyone who cannot distinguish the two, and absent from the accessible
+  // name entirely. The words, not the tone, must carry the difference.
+  it('distinguishes critical from merely short by text, not only by tone', () => {
+    const short = rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 3, positions: [pos('Setter', 3, 0)] }))
+    const critical = rosterChip(roster({ state: 'CRITICAL', openSlots: 3, positions: [pos('Setter', 3, 0)] }))
+    expect(critical?.text).not.toBe(short?.text)
+  })
+
+  it('says "spot" not "spots" for a single open one', () => {
     const shortBy1 = [pos('Setter', 2, 1)]
-    const criticalBy1 = [pos('Setter', 1, 0)]
     expect(rosterChip(roster({ state: 'SPOTS_OPEN', openSlots: 1, positions: shortBy1 }))?.text).toBe('1 spot open')
-    expect(rosterChip(roster({ state: 'CRITICAL', openSlots: 1, positions: criticalBy1 }))?.text).toBe('1 spot open')
   })
 
   it('reads as a headcount when only a total is set', () => {

--- a/app/src/entities/event/lib/roster-view.ts
+++ b/app/src/entities/event/lib/roster-view.ts
@@ -32,12 +32,19 @@ export function rosterChip(roster: EventRoster): RosterChip | null {
       return null
     case 'LINEUP_SET':
       return { text: 'Lineup set', tone: 'covered' }
-    // Same words either way — the count is the news. The tone is what says whether somebody is
-    // merely short or missing entirely, which is the difference between "chase later" and "chase now".
     case 'SPOTS_OPEN':
       return { text: `${roster.openSlots} ${plural(roster.openSlots, 'spot', 'spots')} open`, tone: 'short' }
-    case 'CRITICAL':
-      return { text: `${roster.openSlots} ${plural(roster.openSlots, 'spot', 'spots')} open`, tone: 'critical' }
+    // Different words, not merely a different tone (#313). Both states used to read "3 spots open"
+    // and only gold-vs-red told them apart, which is unavailable to anyone who cannot distinguish
+    // the two and absent from the accessible name — WCAG 1.4.1. The open-slot count is also the
+    // wrong news here: what makes this "chase now" is a position sitting at nobody, not how far the
+    // rest of the lineup is off. The wording is the Turnout filter's own band (#311) rather than a
+    // third phrasing for the same distinction; the panel's `chaseNudge` names the positions, which
+    // is where there is room for them.
+    case 'CRITICAL': {
+      const empty = emptyPositions(roster).length
+      return { text: empty > 1 ? `Missing ${empty} positions` : 'Missing a position', tone: 'critical' }
+    }
     case 'HEADCOUNT_FULL':
       return { text: 'Full', tone: 'covered' }
     case 'HEADCOUNT_SHORT':
@@ -128,12 +135,21 @@ export interface ChaseNudge {
  * that singled out one position and implied every other was covered.
  */
 export function chaseNudge(roster: EventRoster): ChaseNudge | null {
-  const empty = rosterRows(roster).filter((row) => row.pips.length > 0 && row.pips.every((p) => p === 'missing'))
+  const empty = emptyPositions(roster)
 
   if (empty.length === 0) return null
   if (empty.length === 1) return { lead: empty[0].label, rest: 'still has no one — the one to chase.' }
   if (empty.length === 2) return { lead: `${empty[0].label} and ${empty[1].label}`, rest: 'still have no one.' }
   return { lead: `${empty.length} positions`, rest: 'still have no one.' }
+}
+
+/**
+ * The targeted positions with nobody at all — the fact that separates a critical roster from one
+ * that is merely short. Shared by the chip and the nudge so the two can never disagree about which
+ * positions are empty.
+ */
+function emptyPositions(roster: EventRoster): RosterRow[] {
+  return rosterRows(roster).filter((row) => row.pips.length > 0 && row.pips.every((p) => p === 'missing'))
 }
 
 /**

--- a/app/src/entities/event/ui/EventCard.stories.tsx
+++ b/app/src/entities/event/ui/EventCard.stories.tsx
@@ -135,7 +135,7 @@ export const WithRosterVerdict: Story = {
     }),
   },
   play: async ({ canvas, userEvent }) => {
-    await expect(canvas.getByText('2 spots open')).toBeInTheDocument()
+    await expect(canvas.getByText('Missing a position')).toBeInTheDocument()
     // Collapsed on a list card until asked.
     await expect(canvas.queryByText(/the one to chase/)).not.toBeInTheDocument()
 

--- a/app/src/entities/event/ui/ReadinessBadge.stories.tsx
+++ b/app/src/entities/event/ui/ReadinessBadge.stories.tsx
@@ -41,8 +41,10 @@ export const Critical: Story = {
   args: {
     roster: makeRoster({ state: 'CRITICAL', positions: [{ id: 'p', label: 'Libero', required: 1, attending: 0 }] }),
   },
+  // Not "1 spot open" — that is what Short says, and red-vs-gold was the only thing telling the two
+  // apart (#313).
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('1 spot open')).toBeInTheDocument()
+    await expect(canvas.getByText('Missing a position')).toBeInTheDocument()
   },
 }
 

--- a/app/src/entities/event/ui/RosterBar.stories.tsx
+++ b/app/src/entities/event/ui/RosterBar.stories.tsx
@@ -43,7 +43,7 @@ export const Critical: Story = {
     }),
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/2 spots open/)).toBeInTheDocument()
+    await expect(canvas.getByText(/Missing a position/)).toBeInTheDocument()
     await expect(canvas.getByText(/Middle 0\/2/)).toBeInTheDocument()
   },
 }

--- a/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
+++ b/app/src/widgets/next-event-hero/ui/NextEventHeroView.stories.tsx
@@ -271,7 +271,7 @@ export const ReadinessCritical: Story = {
     }),
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('3 spots open')).toBeInTheDocument()
+    await expect(canvas.getByText('Missing 2 positions')).toBeInTheDocument()
   },
 }
 


### PR DESCRIPTION
Fixes #313.

## The bug

`rosterChip` returned **the same words** for `SPOTS_OPEN` and `CRITICAL` — `3 spots open` either way — with gold-vs-red as the only thing separating them. That distinction is unavailable to anyone who cannot distinguish the two colours, and absent entirely from the accessible name a screen reader announces: **WCAG 1.4.1**. Two events that need very different action read identically.

## The fix

`CRITICAL` now reads **`Missing a position`** / **`Missing 2 positions`**.

- **Vocabulary comes from #311**, not a third phrasing for the same distinction — `Missing a position` is the Turnout filter's own band label for exactly this set of states.
- **`openSlots` was the wrong news here.** What makes a roster "chase now" is a position sitting at *nobody*, not how far the rest of the lineup is off. Which positions those are is `chaseNudge`'s existing derivation, extracted to a shared `emptyPositions` so the chip and the nudge can never disagree about which are empty.
- **Naming stays in the panel.** `chaseNudge` names the positions, which is where there is room for them; the collapsed chip is a `shrink-0` slot on a card row, so it takes the bounded form.
- **Tone is now reinforcement, not the sole carrier.**

`rowTone` / `RosterPips` checked as the issue asked, and **left alone**: the pips are `aria-hidden` decoration for the `0/2` count beside them, which carries the same fact as text, and the chase nudge names the empty positions below. Nothing there rests on colour alone.

## Testing

Per the PR gate — **lowest layer that proves it**. This is pure logic plus copy in existing stories, so no new e2e: the change introduces no new seam (no auth path, cross-tenant write, or external integration), and the attendance flow already covers the card.

**Vitest units** (`roster-view.test.ts`) — the WCAG assertion is the issue, and it was written first and failed first:

```
AssertionError: expected '3 spots open' not to be '3 spots open'
```

Three assertions now cover it: `CRITICAL` and `SPOTS_OPEN` must produce different `text`; the singular band; and the count once more than one position is empty.

**Stories** — the four existing `CRITICAL` stories assert the new copy. They cover both branches naturally: `ReadinessBadge`/`RosterBar`/`EventCard` land on `Missing a position` (one empty position), `NextEventHeroView` on `Missing 2 positions`.

⚠️ **These four stories need fresh Chromatic baselines** — the chip's words changed, so the pixel diff is expected on `ReadinessBadge.Critical`, `RosterBar.Critical`, `EventCard.WithRosterVerdict` and `NextEventHeroView.ReadinessCritical`.

No PWA screenshot regeneration: the events overview changes only chip copy inside an existing card, and the install-dialog previews show the shell.

- `make test-app` — **807 passed (116 files)**
- `make lint` — clean (detekt + ESLint)

## Manual verification

Ran the real stack (`docker compose up` + `make api` dev profile + dev server), logged in via magic link, and built one genuinely `SPOTS_OPEN` event (Middle 1/3 — short, but not empty) and `CRITICAL` events (nobody at two targeted positions), so both states sit on the same list:

| | before | after |
|---|---|---|
| Hero, one empty position | `1 spot open` | **`Missing a position`** |
| Card, `SPOTS_OPEN` | `2 spots open` | `2 spots open` (unchanged) |
| Card, `CRITICAL` | `2 spots open` | **`Missing 2 positions`** |

The two states now read differently in the running app with the colour ignored, and the longer chip fits the card row without wrapping.

Refs #311, #273, #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri1yeYrrS9wRr4rT6Tshc1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ri1yeYrrS9wRr4rT6Tshc1)_